### PR TITLE
[foundation]

### DIFF
--- a/code/addons/dynui/imguicontext.cc
+++ b/code/addons/dynui/imguicontext.cc
@@ -249,7 +249,7 @@ ImguiContext::Create()
 		CoreGraphics::GpuBufferTypes::AccessWrite,
 		CoreGraphics::GpuBufferTypes::UsageDynamic,
 		CoreGraphics::GpuBufferTypes::SyncingAutomatic,
-		IndexType::Index16,
+		IndexType::Index32,
 		100000 * 3,
 		nullptr,
 		0

--- a/code/foundation/io/filestream.cc
+++ b/code/foundation/io/filestream.cc
@@ -228,4 +228,27 @@ FileStream::Unmap()
     this->mappedContent = 0;
 }
 
+//------------------------------------------------------------------------------
+/**
+*/
+void* 
+FileStream::MemoryMap()
+{
+    n_assert(0 == this->mappedContent);
+    this->mappedContent = FSWrapper::Map(this->handle, this->accessMode, this->mapHandle);
+    Stream::Map();
+    return this->mappedContent;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
+FileStream::MemoryUnmap()
+{
+    n_assert(0 != this->mappedContent);
+    FSWrapper::Unmap(this->mapHandle, (char*)this->mappedContent);
+    Stream::Unmap();
+}
+
 } // namespace IO

--- a/code/foundation/io/filestream.h
+++ b/code/foundation/io/filestream.h
@@ -54,9 +54,14 @@ public:
     virtual void* Map();
     /// unmap stream
     virtual void Unmap();
+    /// memory map stream to memory
+    virtual void* MemoryMap() override;
+    /// unmap memory stream 
+    virtual void MemoryUnmap()override;
 
 protected:
     FSWrapper::Handle handle;
+    FSWrapper::Handle mapHandle;
     void* mappedContent;
 };
 

--- a/code/foundation/io/stream.cc
+++ b/code/foundation/io/stream.cc
@@ -329,6 +329,31 @@ Stream::Unmap()
 
 //------------------------------------------------------------------------------
 /**
+*/
+void* 
+Stream::MemoryMap()
+{
+    n_assert(this->IsOpen());
+    n_assert(this->CanBeMapped());
+    n_assert(!this->isMapped);
+    this->isMapped = true;
+    return 0;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
+Stream::MemoryUnmap()
+{
+    n_assert(this->IsOpen());
+    n_assert(this->CanBeMapped());
+    n_assert(this->isMapped);
+    this->isMapped = false;
+}
+
+//------------------------------------------------------------------------------
+/**
     Returns true if the stream is currently mapped.
 */
 bool

--- a/code/foundation/io/stream.h
+++ b/code/foundation/io/stream.h
@@ -109,6 +109,10 @@ public:
     virtual void* Map();
     /// unmap stream
     virtual void Unmap();
+    /// memory map stream to memory
+    virtual void* MemoryMap();
+    /// unmap memory stream 
+    virtual void MemoryUnmap();
     /// return true if stream is currently mapped to memory
     bool IsMapped() const;
         

--- a/code/foundation/io/win32/win32fswrapper.h
+++ b/code/foundation/io/win32/win32fswrapper.h
@@ -31,6 +31,10 @@ public:
     static void Write(Handle h, const void* buf, IO::Stream::Size numBytes);
     /// read from a file
     static IO::Stream::Size Read(Handle h, void* buf, IO::Stream::Size numBytes);
+    /// map file to virtual memory
+    static char* Map(Handle h, IO::Stream::AccessMode accessMode, Handle& mappedHandle);
+    /// unmap file
+    static void Unmap(Handle mapHandle, char* buf);
     /// seek in a file
     static void Seek(Handle h, IO::Stream::Offset offset, IO::Stream::SeekOrigin orig);
     /// get position in file

--- a/code/foundation/util/arrayallocatorsafe.h
+++ b/code/foundation/util/arrayallocatorsafe.h
@@ -325,7 +325,6 @@ ArrayAllocatorSafe<TYPES...>::UpdateSize()
 template<class ... TYPES> void
 ArrayAllocatorSafe<TYPES...>::EnterGet()
 {
-	n_assert(!this->inBeginGet);
 	this->sect.Enter();
 	this->inBeginGet = true;
 }
@@ -333,7 +332,6 @@ ArrayAllocatorSafe<TYPES...>::EnterGet()
 template<class ... TYPES> void
 ArrayAllocatorSafe<TYPES...>::LeaveGet()
 {
-	n_assert(this->inBeginGet);
 	this->sect.Leave();
 	this->inBeginGet = false;
 }

--- a/code/render/coregraphics/fence.h
+++ b/code/render/coregraphics/fence.h
@@ -30,5 +30,7 @@ bool FencePeek(const FenceId id);
 bool FenceReset(const FenceId id);
 /// wait for fence
 bool FenceWait(const FenceId id, const uint64 time);
+/// wait for fence and reset
+bool FenceWaitAndReset(const FenceId id, const uint64 time);
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -79,12 +79,17 @@ struct GraphicsDeviceState
 	CoreGraphics::CommandBufferPoolId submissionGraphicsCmdPool;
 	CoreGraphics::CommandBufferPoolId submissionComputeCmdPool;
 	CoreGraphics::CommandBufferPoolId submissionTransferCmdPool;
+	CoreGraphics::CommandBufferPoolId submissionTransferGraphicsHandoverCmdPool;
 
 	CoreGraphics::SubmissionContextId resourceSubmissionContext;
 	CoreGraphics::CommandBufferId resourceSubmissionCmdBuffer;
 	CoreGraphics::FenceId resourceSubmissionFence;
 	Threading::CriticalSection resourceSubmissionCriticalSection;
 	bool resourceSubmissionActive;
+
+	CoreGraphics::SubmissionContextId handoverSubmissionContext;
+	CoreGraphics::CommandBufferId handoverSubmissionCmdBuffer;
+	bool handoverSubmissionActive;
 
 	CoreGraphics::SubmissionContextId setupSubmissionContext;
 	CoreGraphics::CommandBufferId setupSubmissionCmdBuffer;
@@ -262,8 +267,14 @@ uint GetIndexBufferOffset(CoreGraphics::VertexBufferMemoryType type);
 /// get global index buffer
 CoreGraphics::IndexBufferId GetIndexBuffer(CoreGraphics::VertexBufferMemoryType type);
 
+/// lock resource updates, blocks if other thread is using it
+void LockResourceSubmission();
 /// return resource submission context
 CoreGraphics::SubmissionContextId GetResourceSubmissionContext();
+/// return the handover submission context
+CoreGraphics::SubmissionContextId GetHandoverSubmissionContext();
+/// unlocks resource updates
+void UnlockResourceSubmission();
 /// return setup submission context
 CoreGraphics::SubmissionContextId GetSetupSubmissionContext();
 /// return command buffer for current frame graphics submission

--- a/code/render/coregraphics/legacy/nvx2streamreader.cc
+++ b/code/render/coregraphics/legacy/nvx2streamreader.cc
@@ -69,7 +69,7 @@ Nvx2StreamReader::Open(const Resources::ResourceName& name)
     if (StreamReader::Open())
     {
         // map the stream to memory
-        this->mapPtr = this->stream->Map();
+        this->mapPtr = this->stream->MemoryMap();
         n_assert(0 != this->mapPtr);
 
         // read data
@@ -82,6 +82,7 @@ Nvx2StreamReader::Open(const Resources::ResourceName& name)
             this->SetupIndexBuffer(name);
             this->UpdateGroupBoundingBoxes();
         }
+        stream->MemoryUnmap();
         return true;
     }
     return false;
@@ -101,7 +102,6 @@ Nvx2StreamReader::Close()
 	this->vbo = VertexBufferId::Invalid();
     this->primGroups.Clear();
     this->vertexComponents.Clear();
-    stream->Unmap();
     StreamReader::Close();
 }
 
@@ -121,7 +121,6 @@ Nvx2StreamReader::ReadHeaderData()
     
     // endian-convert header
     struct Nvx2Header* header = (struct Nvx2Header*) this->mapPtr;
-    header->numIndices *= 3; // header holds number of tris, not indices
 
     // check magic number
     if (FourCC(header->magic) != FourCC('NVX2'))
@@ -132,7 +131,7 @@ Nvx2StreamReader::ReadHeaderData()
     this->numGroups = header->numGroups;
     this->numVertices = header->numVertices;
     this->vertexWidth = header->vertexWidth;
-    this->numIndices = header->numIndices;
+    this->numIndices = header->numIndices * 3;
     this->numEdges = header->numEdges;
     this->vertexComponentMask = header->vertexComponentMask;
     this->groupDataSize = 6 * sizeof(uint) * this->numGroups;

--- a/code/render/coregraphics/streammeshpool.cc
+++ b/code/render/coregraphics/streammeshpool.cc
@@ -22,7 +22,7 @@ __ImplementClass(CoreGraphics::StreamMeshPool, 'VKML', Resources::ResourceStream
 StreamMeshPool::StreamMeshPool() :
 	activeMesh(Ids::InvalidId24)
 {
-	// empty
+	this->async = true;
 }
 
 //------------------------------------------------------------------------------
@@ -31,6 +31,19 @@ StreamMeshPool::StreamMeshPool() :
 StreamMeshPool::~StreamMeshPool()
 {
 	// empty
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
+StreamMeshPool::Setup()
+{
+	this->placeholderResourceName = "msh:system/placeholder.nvx2";
+	this->failResourceName = "msh:system/error.nvx2";
+
+	// never forget to run this
+	ResourceStreamPool::Setup();
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/streammeshpool.h
+++ b/code/render/coregraphics/streammeshpool.h
@@ -21,6 +21,9 @@ public:
 	/// destructor
 	virtual ~StreamMeshPool();
 
+	/// setup resource loader, initiates the placeholder and error resources if valid
+	void Setup() override;
+
 	/// bind mesh
 	void MeshBind(const Resources::ResourceId id);
 	/// bind primitive group for currently bound mesh

--- a/code/render/coregraphics/vk/vkfence.cc
+++ b/code/render/coregraphics/vk/vkfence.cc
@@ -82,7 +82,6 @@ FencePeek(const FenceId id)
 //------------------------------------------------------------------------------
 /**
 */
-
 bool 
 FenceReset(const FenceId id)
 {
@@ -98,12 +97,24 @@ FenceWait(const FenceId id, const uint64 time)
 	VkFence fence = fenceAllocator.Get<1>(id.id24).fence;
 	VkDevice dev = fenceAllocator.Get<0>(id.id24);
 	VkResult res = vkWaitForFences(dev, 1, &fence, false, time);
+	return res == VK_SUCCESS || res == VK_TIMEOUT;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+bool 
+FenceWaitAndReset(const FenceId id, const uint64 time)
+{
+	VkFence fence = fenceAllocator.Get<1>(id.id24).fence;
+	VkDevice dev = fenceAllocator.Get<0>(id.id24);
+	VkResult res = vkWaitForFences(dev, 1, &fence, false, time);
 	if (res == VK_SUCCESS)
 	{
 		res = vkResetFences(dev, 1, &fence);
 		n_assert(res == VK_SUCCESS);
 	}
-	return res == VK_SUCCESS;
+	return res == VK_SUCCESS || res == VK_TIMEOUT;
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkloader.cc
+++ b/code/render/coregraphics/vk/vkloader.cc
@@ -135,6 +135,7 @@ InitInstance(VkInstance instance)
 	_IMP_VK(vkResetFences);
 	_IMP_VK(vkGetFenceStatus);
 	_IMP_VK(vkWaitForFences);
+	_IMP_VK(vkWaitSemaphores);
 
 	_IMP_VK(vkCreateRenderPass);
 	_IMP_VK(vkDestroyRenderPass);
@@ -287,6 +288,7 @@ _DEF_VK(vkDestroyFence);
 _DEF_VK(vkResetFences);
 _DEF_VK(vkGetFenceStatus);
 _DEF_VK(vkWaitForFences);
+_DEF_VK(vkWaitSemaphores);
 
 _DEF_VK(vkCreateRenderPass);
 _DEF_VK(vkDestroyRenderPass);

--- a/code/render/coregraphics/vk/vkloader.h
+++ b/code/render/coregraphics/vk/vkloader.h
@@ -122,6 +122,7 @@ _DEC_VK(vkDestroyFence);
 _DEC_VK(vkResetFences);
 _DEC_VK(vkGetFenceStatus);
 _DEC_VK(vkWaitForFences);
+_DEC_VK(vkWaitSemaphores);
 
 _DEC_VK(vkCreateRenderPass);
 _DEC_VK(vkDestroyRenderPass);

--- a/code/render/coregraphics/vk/vkmemorytexturepool.cc
+++ b/code/render/coregraphics/vk/vkmemorytexturepool.cc
@@ -673,68 +673,9 @@ VkMemoryTexturePool::Setup(const Resources::ResourceId id)
 
     if (!loadInfo.windowTexture)
     {
-        VkSampleCountFlagBits samples;
-        switch (loadInfo.samples)
-        {
-        case 1:
-            samples = VK_SAMPLE_COUNT_1_BIT;
-            break;
-        case 2:
-            samples = VK_SAMPLE_COUNT_2_BIT;
-            break;
-        case 4:
-            samples = VK_SAMPLE_COUNT_4_BIT;
-            break;
-        case 8:
-            samples = VK_SAMPLE_COUNT_8_BIT;
-            break;
-        case 16:
-            samples = VK_SAMPLE_COUNT_16_BIT;
-            break;
-        case 32:
-            samples = VK_SAMPLE_COUNT_32_BIT;
-            break;
-        case 64:
-            samples = VK_SAMPLE_COUNT_64_BIT;
-            break;
-        default:
-            n_error("Invalid number of samples '%d'", loadInfo.samples);
-            break;
-        }
-
-        VkImageViewType viewType;
-        VkImageType type;
-        switch (runtimeInfo.type)
-        {
-        case Texture1D:
-            type = VK_IMAGE_TYPE_1D;
-            viewType = VK_IMAGE_VIEW_TYPE_1D;
-            break;
-        case Texture1DArray:
-            type = VK_IMAGE_TYPE_1D;
-            viewType = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
-            break;
-        case Texture2D:
-            type = VK_IMAGE_TYPE_2D;
-            viewType = VK_IMAGE_VIEW_TYPE_2D;
-            break;
-        case Texture2DArray:
-            type = VK_IMAGE_TYPE_2D;
-            viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-            break;
-        case TextureCube:
-            type = VK_IMAGE_TYPE_2D;
-            viewType = VK_IMAGE_VIEW_TYPE_CUBE;
-            break;
-        case TextureCubeArray:
-            type = VK_IMAGE_TYPE_2D;
-            viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-            break;
-        case Texture3D:
-            type = VK_IMAGE_TYPE_3D;
-            viewType = VK_IMAGE_VIEW_TYPE_3D;
-            break;
-        }
+        VkSampleCountFlagBits samples = VkTypes::AsVkSampleFlags(loadInfo.samples);
+        VkImageViewType viewType = VkTypes::AsVkImageViewType(runtimeInfo.type);
+        VkImageType type = VkTypes::AsVkImageType(runtimeInfo.type);
 
         // if read-write, we will almost definitely use this texture on multiple queues
         VkSharingMode sharingMode = (loadInfo.texUsage & TextureUsage::ReadWriteUsage) ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE;
@@ -799,7 +740,6 @@ VkMemoryTexturePool::Setup(const Resources::ResourceId id)
             subres.layerCount = loadInfo.layers;
             subres.levelCount = loadInfo.mips;
 
-
             // insert barrier
             VkUtilities::ImageBarrier(CoreGraphics::SubmissionContextGetCmdBuffer(sub),
                 CoreGraphics::BarrierStage::Host,
@@ -810,7 +750,7 @@ VkMemoryTexturePool::Setup(const Resources::ResourceId id)
             VkBuffer outBuf;
             VkDeviceMemory outMem;
             uint32_t size = PixelFormat::ToSize(loadInfo.format);
-            VkUtilities::ImageUpdate(loadInfo.dev, CoreGraphics::SubmissionContextGetCmdBuffer(sub), TransferQueueType, loadInfo.img, imgInfo, 0, 0, VkDeviceSize(loadInfo.dims.width * loadInfo.dims.height * loadInfo.dims.depth * size), (uint32_t*)loadInfo.texBuffer, outBuf, outMem);
+            VkUtilities::ImageUpdate(loadInfo.dev, CoreGraphics::SubmissionContextGetCmdBuffer(sub), TransferQueueType, loadInfo.img, extents, 0, 0, VkDeviceSize(loadInfo.dims.width * loadInfo.dims.height * loadInfo.dims.depth * size), (uint32_t*)loadInfo.texBuffer, outBuf, outMem);
 
             // add host memory buffer, intermediate device memory, and intermediate device buffer to delete queue
             SubmissionContextFreeDeviceMemory(sub, loadInfo.dev, outMem);

--- a/code/render/coregraphics/vk/vkstreamtexturepool.cc
+++ b/code/render/coregraphics/vk/vkstreamtexturepool.cc
@@ -16,6 +16,7 @@
 #include "vkshaderserver.h"
 #include "coregraphics/memorytexturepool.h"
 #include "vksubmissioncontext.h"
+#include "profiling/profiling.h"
 namespace Vulkan
 {
 
@@ -47,6 +48,7 @@ void
 VkStreamTexturePool::Setup()
 {
 	ResourceStreamPool::Setup();
+	this->async = true;
 	this->placeholderResourceName = "tex:system/white.dds";
 	this->failResourceName = "tex:system/error.dds";
 }
@@ -75,17 +77,26 @@ VkStreamTexturePool::DeallocObject(const Resources::ResourceUnknownId id)
 ResourcePool::LoadStatus
 VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util::StringAtom& tag, const Ptr<IO::Stream>& stream, bool immediate)
 {
+	N_SCOPE(CreateAndLoad, TextureStream);
 	n_assert(stream.isvalid());
 	n_assert(stream->CanBeMapped());
 	n_assert(this->GetState(res) == Resources::Resource::Pending);
 
-	void* srcData = stream->Map();
+	void* srcData = stream->MemoryMap();
 	uint srcDataSize = stream->GetSize();
+
+	static const int NumBasicLods = 5;
 
 	// during the load-phase, we can safetly get the structs
 	texturePool->EnterGet();
-	VkTextureRuntimeInfo& runtimeInfo = texturePool->Get<0>(res.resourceId);
-	VkTextureLoadInfo& loadInfo = texturePool->Get<1>(res.resourceId);
+	VkTextureRuntimeInfo& runtimeInfo = texturePool->Get<Texture_RuntimeInfo>(res.resourceId);
+	VkTextureLoadInfo& loadInfo = texturePool->Get<Texture_LoadInfo>(res.resourceId);
+	VkTextureStreamInfo& streamInfo = texturePool->Get<Texture_StreamInfo>(res.resourceId);
+
+	streamInfo.mappedBuffer = srcData;
+	streamInfo.bufferSize = srcDataSize;
+	streamInfo.highestLod = NumBasicLods;
+	streamInfo.stream = stream;
 	loadInfo.dev = Vulkan::GetCurrentDevice();
 	texturePool->LeaveGet();
 
@@ -96,21 +107,29 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 	ILuint image = ilGenImage();
 	ilBindImage(image);
 	ilSetInteger(IL_DXTC_NO_DECOMPRESS, IL_TRUE);
+	ilSetInteger(IL_DDS_FIRST_MIP, -NumBasicLods);
+	ilSetInteger(IL_DDS_LAST_MIP, -1);
 	ilLoadL(IL_DDS, srcData, srcDataSize);
 
-	ILuint width = ilGetInteger(IL_IMAGE_WIDTH);
-	ILuint height = ilGetInteger(IL_IMAGE_HEIGHT);
-	ILuint depth = ilGetInteger(IL_IMAGE_DEPTH);
+	ILuint startWidth = ilGetInteger(IL_IMAGE_WIDTH);
+	ILuint startHeight = ilGetInteger(IL_IMAGE_HEIGHT);
+	ILuint startDepth = ilGetInteger(IL_IMAGE_DEPTH);
+	ILuint width = ilGetInteger(IL_DDS_WIDTH_HEADER);
+	ILuint height = ilGetInteger(IL_DDS_HEIGHT_HEADER);
+	ILuint depth = ilGetInteger(IL_DDS_DEPTH_HEADER);
 	ILuint bpp = ilGetInteger(IL_IMAGE_BYTES_PER_PIXEL);
 	ILuint numImages = ilGetInteger(IL_NUM_IMAGES);
 	ILuint numFaces = ilGetInteger(IL_NUM_FACES);
 	ILuint numLayers = ilGetInteger(IL_NUM_LAYERS);
 	ILuint mips = ilGetInteger(IL_NUM_MIPMAPS);
+	ILuint imageMips = ilGetInteger(IL_DDS_MIP_HEADER_COUNT); // get the mip count from the header, not from the data
 	ILenum cube = ilGetInteger(IL_IMAGE_CUBEFLAGS);
 	ILenum format = ilGetInteger(IL_PIXEL_FORMAT);	// only available when loading DDS, so this might need some work...
 
 	VkFormat vkformat = VkTypes::AsVkFormat(format);
 	VkTypes::VkBlockDimensions block = VkTypes::AsVkBlockSize(vkformat);
+
+	runtimeInfo.type = cube ? CoreGraphics::TextureCube : depth > 1 ? CoreGraphics::Texture3D : CoreGraphics::Texture2D;
 
 	// use linear if we really have to
 	VkFormatProperties formatProps;
@@ -126,16 +145,16 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 	extents.width = width;
 	extents.height = height;
 	extents.depth = depth;
-	//auto queues = Vulkan::GetQueueFamilies();
+	
 	VkImageCreateInfo info =
 	{
 		VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
 		NULL,
 		cube ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0,
-		depth > 1 ? VK_IMAGE_TYPE_3D : (height > 1 ? VK_IMAGE_TYPE_2D : VK_IMAGE_TYPE_1D),
+		VkTypes::AsVkImageType(runtimeInfo.type),
 		vkformat,
 		extents,
-		mips,
+		imageMips,
 		cube ? (uint32_t)numFaces : (uint32_t)numImages,
 		VK_SAMPLE_COUNT_1_BIT,
 		forceLinear ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL,
@@ -153,15 +172,29 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 	VkUtilities::AllocateImageMemory(loadInfo.dev, loadInfo.img, loadInfo.mem, VkMemoryPropertyFlagBits(0), alignedSize);
 	vkBindImageMemory(dev, loadInfo.img, loadInfo.mem, 0);
 
-	// transition into transfer mode
+	// create image view
 	VkImageSubresourceRange subres;
 	subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 	subres.baseArrayLayer = 0;
-	subres.baseMipLevel = 0;
+	subres.baseMipLevel = Math::n_max((ILint)imageMips - NumBasicLods, 0);
 	subres.layerCount = info.arrayLayers;
-	subres.levelCount = info.mipLevels;
+	subres.levelCount = Math::n_min((ILint)imageMips, NumBasicLods);
+	VkImageViewCreateInfo viewCreate =
+	{
+		VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+		nullptr,
+		0,
+		loadInfo.img,
+		VkTypes::AsVkImageViewType(runtimeInfo.type),
+		vkformat,
+		VkTypes::AsVkMapping(format),
+		subres
+	};
+	stat = vkCreateImageView(dev, &viewCreate, NULL, &runtimeInfo.view);
+	n_assert(stat == VK_SUCCESS);
 
 	// use resource submission
+	CoreGraphics::LockResourceSubmission();
 	CoreGraphics::SubmissionContextId sub = CoreGraphics::GetResourceSubmissionContext();
 
 	// transition to transfer
@@ -169,8 +202,6 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 		CoreGraphics::BarrierStage::Host,
 		CoreGraphics::BarrierStage::Transfer,
 		VkUtilities::ImageMemoryBarrier(loadInfo.img, subres, VK_ACCESS_HOST_WRITE_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL));
-	
-	uint32_t remainingBytes = alignedSize;
 
 	// now load texture by walking through all images and mips
 	ILuint i;
@@ -190,21 +221,36 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 				ilActiveMipmap(j);
 
 				ILuint size = ilGetInteger(IL_IMAGE_SIZE_OF_DATA);
-				remainingBytes -= size;
-				n_assert(remainingBytes >= 0);
 				ILubyte* buf = ilGetData();
 
-				int32_t mipWidth = (int32_t)Math::n_max(1.0f, Math::n_floor(width / Math::n_pow(2, (float)j)));
-				int32_t mipHeight = (int32_t)Math::n_max(1.0f, Math::n_floor(height / Math::n_pow(2, (float)j)));
-				int32_t mipDepth = (int32_t)Math::n_max(1.0f, Math::n_floor(depth / Math::n_pow(2, (float)j)));
+				int32_t mipWidth = Math::n_max(startWidth >> j, 1u);
+				int32_t mipHeight = Math::n_max(startHeight >> j, 1u);
+				int32_t mipDepth = Math::n_max(startDepth >> j, 1u);
 
-				info.extent.width = mipWidth;
-				info.extent.height = mipHeight;
-				info.extent.depth = mipDepth;
+				extents.width = mipWidth;
+				extents.height = mipHeight;
+				extents.depth = mipDepth;
+
+				VkImageSubresourceRange res = subres;
+				res.layerCount = 1;
+				res.levelCount = 1;
+				res.baseMipLevel = subres.baseMipLevel + j;
+				res.baseArrayLayer = subres.baseArrayLayer + i;
 
 				VkBuffer outBuf;
 				VkDeviceMemory outMem;
-				VkUtilities::ImageUpdate(dev, CoreGraphics::SubmissionContextGetCmdBuffer(sub), TransferQueueType, loadInfo.img, info, j, i, size, (uint32_t*)buf, outBuf, outMem);
+				VkUtilities::ImageUpdate(
+					dev, 
+					CoreGraphics::SubmissionContextGetCmdBuffer(sub), 
+					TransferQueueType, 
+					loadInfo.img, 
+					extents, 
+					res.baseMipLevel,
+					res.baseArrayLayer,
+					size, 
+					(uint32_t*)buf, 
+					outBuf, 
+					outMem);
 
 				// add host memory buffer, intermediate device memory, and intermediate device buffer to delete queue
 				SubmissionContextFreeDeviceMemory(sub, dev, outMem);
@@ -221,27 +267,43 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 			ilActiveMipmap(j);
 
 			ILuint size = ilGetInteger(IL_IMAGE_SIZE_OF_DATA);
-			remainingBytes -= size;
-			n_assert(remainingBytes >= 0);
 			ILubyte* buf = ilGetData();
 
-			int32_t mipWidth = (int32_t)Math::n_max(1.0f, Math::n_floor(width / Math::n_pow(2, (float)j)));
-			int32_t mipHeight = (int32_t)Math::n_max(1.0f, Math::n_floor(height / Math::n_pow(2, (float)j)));
-			int32_t mipDepth = (int32_t)Math::n_max(1.0f, Math::n_floor(depth / Math::n_pow(2, (float)j)));
+			int32_t mipWidth = Math::n_max(startWidth >> j, 1u);
+			int32_t mipHeight = Math::n_max(startHeight >> j, 1u);
+			int32_t mipDepth = Math::n_max(startDepth >> j, 1u);
 
-			info.extent.width = mipWidth;
-			info.extent.height = mipHeight;
-			info.extent.depth = mipDepth;
+			extents.width = mipWidth;
+			extents.height = mipHeight;
+			extents.depth = mipDepth;
+
+			VkImageSubresourceRange res = subres;
+			res.layerCount = 1;
+			res.levelCount = 1;
+			res.baseMipLevel = subres.baseMipLevel + j;
+			res.baseArrayLayer = 0;
 
 			VkBuffer outBuf;
 			VkDeviceMemory outMem;
-			VkUtilities::ImageUpdate(dev, CoreGraphics::SubmissionContextGetCmdBuffer(sub), TransferQueueType, loadInfo.img, info, j, 0, size, (uint32_t*)buf, outBuf, outMem);
+			VkUtilities::ImageUpdate(
+				dev, 
+				CoreGraphics::SubmissionContextGetCmdBuffer(sub), 
+				TransferQueueType, 
+				loadInfo.img, 
+				extents, 
+				res.baseMipLevel,
+				res.baseArrayLayer,
+				size, 
+				(uint32_t*)buf, 
+				outBuf, 
+				outMem);
 
 			// add host memory buffer, intermediate device memory, and intermediate device buffer to delete queue
 			SubmissionContextFreeDeviceMemory(sub, dev, outMem);
 			SubmissionContextFreeBuffer(sub, dev, outBuf);
 		}
 	}
+	ilDeleteImage(image);
 
 	// transition image to be used for rendering
 	VkUtilities::ImageBarrier(CoreGraphics::SubmissionContextGetCmdBuffer(sub),
@@ -250,60 +312,24 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 		VkUtilities::ImageMemoryBarrier(loadInfo.img, subres, TransferQueueType, GraphicsQueueType, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
 
 	// perform final transition on graphics queue
-	CoreGraphics::SubmissionContextId gfxSub = CoreGraphics::GetSetupSubmissionContext();
+	CoreGraphics::SubmissionContextId gfxSub = CoreGraphics::GetHandoverSubmissionContext();
 	VkUtilities::ImageBarrier(CoreGraphics::SubmissionContextGetCmdBuffer(gfxSub),
 		CoreGraphics::BarrierStage::Transfer,
 		CoreGraphics::BarrierStage::AllGraphicsShaders,
 		VkUtilities::ImageMemoryBarrier(loadInfo.img, subres, TransferQueueType, GraphicsQueueType, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
-		
-	ilDeleteImage(image);
+	CoreGraphics::UnlockResourceSubmission();
 
-	// create view
-	VkImageViewType viewType;
-	if (cube)
-	{
-		if (loadInfo.layers > 1) viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-		else					 viewType = VK_IMAGE_VIEW_TYPE_CUBE;
-	}
-	else
-	{
-		if (height > 1)
-		{
-			if (loadInfo.layers > 1) viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-			else if (depth > 1)		 viewType = VK_IMAGE_VIEW_TYPE_3D;
-			else					 viewType = VK_IMAGE_VIEW_TYPE_2D;
-		}
-		else
-		{
-			if (loadInfo.layers > 1) viewType = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
-			else					 viewType = VK_IMAGE_VIEW_TYPE_1D;
-		}
-	}
-
-	VkImageViewCreateInfo viewCreate =
-	{
-		VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-		nullptr,
-		0,
-		loadInfo.img,
-		viewType,
-		vkformat,
-		VkTypes::AsVkMapping(format),
-		subres
-	};
-	stat = vkCreateImageView(dev, &viewCreate, NULL, &runtimeInfo.view);
-	n_assert(stat == VK_SUCCESS);
 
 	loadInfo.dims.width = width;
 	loadInfo.dims.height = height;
 	loadInfo.dims.depth = depth;
-	loadInfo.mips = Math::n_max(mips, 1u);
+	loadInfo.layers = info.arrayLayers;
+	loadInfo.mips = Math::n_max(imageMips, 1u);
 	loadInfo.format = VkTypes::AsNebulaPixelFormat(vkformat);
 	loadInfo.dev = dev;
-	runtimeInfo.type = cube ? CoreGraphics::TextureCube : depth > 1 ? CoreGraphics::Texture3D : CoreGraphics::Texture2D;
 	runtimeInfo.bind = VkShaderServer::Instance()->RegisterTexture(TextureId(res), runtimeInfo.type);
 
-	stream->Unmap();
+	//stream->MemoryUnmap();
 
 #if NEBULA_GRAPHICS_DEBUG
 	ObjectSetName((TextureId)res, stream->GetURI().LocalPath().AsCharPtr());
@@ -318,7 +344,229 @@ VkStreamTexturePool::LoadFromStream(const Resources::ResourceId res, const Util:
 inline void
 VkStreamTexturePool::Unload(const Resources::ResourceId id)
 {
+	VkTextureStreamInfo& streamInfo = texturePool->Get<Texture_StreamInfo>(id.resourceId);
+	streamInfo.stream->MemoryUnmap();
 	texturePool->Unload(id);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
+VkStreamTexturePool::UpdateLOD(const Resources::ResourceId& id, const IndexT lod, bool immediate)
+{
+	N_SCOPE(UpdateLOD, TextureStream);
+	texturePool->EnterGet();
+	VkTextureStreamInfo& streamInfo = texturePool->Get<Texture_StreamInfo>(id.resourceId);
+	VkTextureLoadInfo& loadInfo = texturePool->Get<Texture_LoadInfo>(id.resourceId);
+	VkTextureRuntimeInfo& runtimeInfo = texturePool->Get<Texture_RuntimeInfo>(id.resourceId);
+	texturePool->LeaveGet();
+
+	// if the lod is undefined, just add 1 mip
+	IndexT adjustedLod = lod;
+	if (adjustedLod == -1)
+		adjustedLod = streamInfo.highestLod + 1;
+
+	// abort if the lod is already higher
+	if (streamInfo.highestLod > (uint32_t)adjustedLod)
+		return;
+
+	// bump lod
+	streamInfo.highestLod = adjustedLod;
+
+	// if we are already at the highest lod, return
+	if (streamInfo.highestLod > loadInfo.mips)
+		return;
+
+	VkDevice dev = Vulkan::GetCurrentDevice();
+
+	// load using IL
+	ILuint image = ilGenImage();
+	ilBindImage(image);
+	ilSetInteger(IL_DXTC_NO_DECOMPRESS, IL_TRUE);
+	ilSetInteger(IL_DDS_FIRST_MIP, -adjustedLod); // count lods backwards
+	ilSetInteger(IL_DDS_LAST_MIP, -adjustedLod);
+	ilLoadL(IL_DDS, streamInfo.mappedBuffer, streamInfo.bufferSize);
+
+	ILuint startWidth = ilGetInteger(IL_IMAGE_WIDTH);
+	ILuint startHeight = ilGetInteger(IL_IMAGE_HEIGHT);
+	ILuint startDepth = ilGetInteger(IL_IMAGE_DEPTH);
+	ILuint width = ilGetInteger(IL_DDS_WIDTH_HEADER);
+	ILuint height = ilGetInteger(IL_DDS_HEIGHT_HEADER);
+	ILuint depth = ilGetInteger(IL_DDS_DEPTH_HEADER);
+	ILuint bpp = ilGetInteger(IL_IMAGE_BYTES_PER_PIXEL);
+	ILuint numImages = ilGetInteger(IL_NUM_IMAGES);
+	ILuint numFaces = ilGetInteger(IL_NUM_FACES);
+	ILuint numLayers = ilGetInteger(IL_NUM_LAYERS);
+	ILuint mips = ilGetInteger(IL_NUM_MIPMAPS);
+	ILuint imageMips = ilGetInteger(IL_DDS_MIP_HEADER_COUNT); // get the mip count from the header, not from the data
+	ILenum cube = ilGetInteger(IL_IMAGE_CUBEFLAGS);
+	ILenum format = ilGetInteger(IL_PIXEL_FORMAT);	// only available when loading DDS, so this might need some work...
+
+	VkImageSubresourceRange subres;
+	subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	subres.baseArrayLayer = 0;
+	subres.baseMipLevel = Math::n_max((ILint)imageMips - adjustedLod, 0);
+	subres.layerCount = loadInfo.layers;
+	subres.levelCount = 1;
+
+	// create image
+	VkExtent3D extents;
+	extents.width = width;
+	extents.height = height;
+	extents.depth = depth;
+
+	// create image view
+	VkImageSubresourceRange viewSubres;
+	viewSubres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	viewSubres.baseArrayLayer = 0;
+	viewSubres.baseMipLevel = Math::n_max((ILint)imageMips - adjustedLod, 0);
+	viewSubres.layerCount = loadInfo.layers;
+	viewSubres.levelCount = imageMips - viewSubres.baseMipLevel;
+	VkImageViewCreateInfo viewCreate =
+	{
+		VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+		nullptr,
+		0,
+		loadInfo.img,
+		VkTypes::AsVkImageViewType(runtimeInfo.type),
+		VkTypes::AsVkFormat(loadInfo.format),
+		VkTypes::AsVkMapping(format),
+		viewSubres
+	};
+
+	// use resource submission
+	CoreGraphics::LockResourceSubmission();
+	CoreGraphics::SubmissionContextId sub = CoreGraphics::GetResourceSubmissionContext();
+	CoreGraphics::SubmissionContextId gfxSub = CoreGraphics::GetHandoverSubmissionContext();
+
+	// transition to transfer
+	VkUtilities::ImageBarrier(CoreGraphics::SubmissionContextGetCmdBuffer(gfxSub),
+		CoreGraphics::BarrierStage::AllGraphicsShaders,
+		CoreGraphics::BarrierStage::Transfer,
+		VkUtilities::ImageMemoryBarrier(loadInfo.img, viewSubres, GraphicsQueueType, TransferQueueType, VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL));
+
+	// now load texture by walking through all images and mips
+	ILuint i;
+	ILuint j;
+	if (cube)
+	{
+		for (i = 0; i < 6; i++)
+		{
+			ilBindImage(image);
+			ilActiveFace(i);
+			ilActiveMipmap(0);
+			for (j = 0; j < mips; j++)
+			{
+				// move to next mip
+				ilBindImage(image);
+				ilActiveFace(i);
+				ilActiveMipmap(j);
+
+				ILuint size = ilGetInteger(IL_IMAGE_SIZE_OF_DATA);
+				ILubyte* buf = ilGetData();
+
+				int32_t mipWidth = Math::n_max(startWidth >> j, 1u);
+				int32_t mipHeight = Math::n_max(startHeight >> j, 1u);
+				int32_t mipDepth = Math::n_max(startDepth >> j, 1u);
+
+				extents.width = mipWidth;
+				extents.height = mipHeight;
+				extents.depth = mipDepth;
+
+				VkImageSubresourceRange res = subres;
+				res.layerCount = 1;
+				res.levelCount = 1;
+				res.baseMipLevel = subres.baseMipLevel + j;
+				res.baseArrayLayer = subres.baseArrayLayer + i;
+
+				VkBuffer outBuf;
+				VkDeviceMemory outMem;
+				VkUtilities::ImageUpdate(
+					dev, 
+					CoreGraphics::SubmissionContextGetCmdBuffer(sub), 
+					TransferQueueType, 
+					loadInfo.img, 
+					extents, 
+					res.baseMipLevel,
+					res.baseArrayLayer,
+					size, 
+					(uint32_t*)buf, 
+					outBuf, 
+					outMem);
+
+				// add host memory buffer, intermediate device memory, and intermediate device buffer to delete queue
+				SubmissionContextFreeDeviceMemory(sub, dev, outMem);
+				SubmissionContextFreeBuffer(sub, dev, outBuf);
+			}
+		}
+	}
+	else
+	{
+		for (j = 0; j < mips; j++)
+		{
+			// move to next mip
+			ilBindImage(image);
+			ilActiveMipmap(j);
+
+			ILuint size = ilGetInteger(IL_IMAGE_SIZE_OF_DATA);
+			ILubyte* buf = ilGetData();
+
+			int32_t mipWidth = Math::n_max(startWidth >> j, 1u);
+			int32_t mipHeight = Math::n_max(startHeight >> j, 1u);
+			int32_t mipDepth = Math::n_max(startDepth >> j, 1u);
+
+			extents.width = mipWidth;
+			extents.height = mipHeight;
+			extents.depth = mipDepth;
+
+			VkImageSubresourceRange res = subres;
+			res.layerCount = 1;
+			res.levelCount = 1;
+			res.baseMipLevel = subres.baseMipLevel + j;
+			res.baseArrayLayer = 0;
+
+			VkBuffer outBuf;
+			VkDeviceMemory outMem;
+			VkUtilities::ImageUpdate(
+				dev, 
+				CoreGraphics::SubmissionContextGetCmdBuffer(sub), 
+				TransferQueueType, 
+				loadInfo.img, 
+				extents, 
+				subres.baseMipLevel + j,
+				0, 
+				size, 
+				(uint32_t*)buf, 
+				outBuf, 
+				outMem);
+
+			// add host memory buffer, intermediate device memory, and intermediate device buffer to delete queue
+			SubmissionContextFreeDeviceMemory(sub, dev, outMem);
+			SubmissionContextFreeBuffer(sub, dev, outBuf);
+		}
+	}
+	ilDeleteImage(image);
+
+	// transition image to be used for rendering
+	VkUtilities::ImageBarrier(CoreGraphics::SubmissionContextGetCmdBuffer(sub),
+		CoreGraphics::BarrierStage::Transfer,
+		CoreGraphics::BarrierStage::AllGraphicsShaders,
+		VkUtilities::ImageMemoryBarrier(loadInfo.img, viewSubres, TransferQueueType, GraphicsQueueType, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+
+	// perform final transition on graphics queue
+	VkUtilities::ImageBarrier(CoreGraphics::SubmissionContextGetCmdBuffer(gfxSub),
+		CoreGraphics::BarrierStage::Transfer,
+		CoreGraphics::BarrierStage::AllGraphicsShaders,
+		VkUtilities::ImageMemoryBarrier(loadInfo.img, viewSubres, TransferQueueType, GraphicsQueueType, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+
+	CoreGraphics::UnlockResourceSubmission();
+
+
+	VkShaderServer::Instance()->AddPendingImageView(viewCreate, TextureId(id));
+	// update binding
+	//if (loadInfo.bindless)
+	//VkShaderServer::Instance()->ReregisterTexture(TextureId(id), runtimeInfo.type, runtimeInfo.bind);
 }
 
 } // namespace Vulkan

--- a/code/render/coregraphics/vk/vkstreamtexturepool.h
+++ b/code/render/coregraphics/vk/vkstreamtexturepool.h
@@ -11,6 +11,7 @@
 #include "core/refcounted.h"
 #include "resources/resourcestreampool.h"
 #include "vktexture.h"
+
 namespace Vulkan
 {
 class VkStreamTexturePool : public Resources::ResourceStreamPool
@@ -30,6 +31,9 @@ private:
 	LoadStatus LoadFromStream(const Resources::ResourceId res, const Util::StringAtom& tag, const Ptr<IO::Stream>& stream, bool immediate = false) override;
 	/// unload shader
 	void Unload(const Resources::ResourceId id);
+
+	/// stream mips
+	void UpdateLOD(const Resources::ResourceId& id, const IndexT lod, bool immediate) override;
 
 	/// allocate object
 	Resources::ResourceUnknownId AllocObject() override;

--- a/code/render/coregraphics/vk/vksubcontexthandler.cc
+++ b/code/render/coregraphics/vk/vksubcontexthandler.cc
@@ -296,6 +296,24 @@ VkSubContextHandler::GetTimelineIndex(CoreGraphics::QueueType type)
 /**
 */
 void 
+VkSubContextHandler::Wait(CoreGraphics::QueueType type, uint64 index)
+{
+	VkSemaphoreWaitInfo waitInfo =
+	{
+		VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
+		nullptr,
+		0,
+		1,
+		&this->semaphores[type],
+		&index
+	};
+	vkWaitSemaphores(this->device, &waitInfo, UINT64_MAX);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
 VkSubContextHandler::AppendSubmission(CoreGraphics::QueueType type, VkCommandBuffer cmds, VkSemaphore waitSemaphore, VkPipelineStageFlags waitFlag, VkSemaphore signalSemaphore)
 {
 	Util::Array<Submission>& submissions = this->submissions[type];

--- a/code/render/coregraphics/vk/vksubcontexthandler.h
+++ b/code/render/coregraphics/vk/vksubcontexthandler.h
@@ -79,6 +79,8 @@ public:
 	uint64 FlushSubmissionsTimeline(CoreGraphics::QueueType type, VkFence fence);
 	/// get timeline index
 	uint64 GetTimelineIndex(CoreGraphics::QueueType type);
+	/// wait for timeline index
+	void Wait(CoreGraphics::QueueType type, uint64 index);
 
 	/// add submission to context, but don't really execute
 	void AppendSubmission(CoreGraphics::QueueType type, VkCommandBuffer cmds, VkSemaphore waitSemaphore, VkPipelineStageFlags waitFlag, VkSemaphore signalSemaphore);

--- a/code/render/coregraphics/vk/vksubmissioncontext.h
+++ b/code/render/coregraphics/vk/vksubmissioncontext.h
@@ -20,6 +20,7 @@ enum
 {
 	SubmissionContext_NumCycles,
 	SubmissionContext_CmdBuffer,
+	SubmissionContext_TimelineIndex,
 	SubmissionContext_RetiredCmdBuffer,
 	SubmissionContext_Fence,
 	SubmissionContext_FreeBuffers,
@@ -36,6 +37,7 @@ enum
 typedef Ids::IdAllocator<
 	SizeT,
 	Util::FixedArray<CoreGraphics::CommandBufferId>,
+	Util::FixedArray<uint64>,
 	Util::FixedArray<Util::Array<CoreGraphics::CommandBufferId>>,
 	Util::FixedArray<CoreGraphics::FenceId>,
 	Util::FixedArray<Util::Array<std::tuple<VkDevice, VkBuffer>>>,
@@ -50,9 +52,7 @@ typedef Ids::IdAllocator<
 > SubmissionContextAllocator;
 extern SubmissionContextAllocator submissionContextAllocator;
 
-
-/// FIXME, change these to be non-vulkan specific types and move them to generic submissioncontext
-
+/// TODO: make these generic
 /// add buffer for deletion
 void SubmissionContextFreeBuffer(const CoreGraphics::SubmissionContextId id, VkDevice dev, VkBuffer buf);
 /// add memory for deletion
@@ -63,5 +63,10 @@ void SubmissionContextFreeImage(const CoreGraphics::SubmissionContextId id, VkDe
 void SubmissionContextFreeCommandBuffer(const CoreGraphics::SubmissionContextId id, const CoreGraphics::CommandBufferId cmd);
 /// add command buffer for reset
 void SubmissionContextClearCommandBuffer(const CoreGraphics::SubmissionContextId id, const CoreGraphics::CommandBufferId cmd);
+
+/// set the submission timeline index for this cycle
+void SubmissionContextSetTimelineIndex(const CoreGraphics::SubmissionContextId id, uint64 index);
+/// get the submission timline index for the previous cycle
+uint64 SubmissionContextGetTimelineIndex(const CoreGraphics::SubmissionContextId id);
 
 } // namespace Vulkan

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -5,6 +5,7 @@
 #include "render/stdneb.h"
 #include "vktexture.h"
 #include "vkloader.h"
+#include "io/stream.h"
 
 namespace Vulkan
 {

--- a/code/render/coregraphics/vk/vktexture.h
+++ b/code/render/coregraphics/vk/vktexture.h
@@ -8,11 +8,16 @@
 	(C)2017-2020 Individual contributors, see AUTHORS file
 */
 //------------------------------------------------------------------------------
-#include "core/refcounted.h"
 #include "coregraphics/texture.h"
 #include "coregraphics/pixelformat.h"
 #include "resources/resourcepool.h"
 #include "ids/idallocator.h"
+
+namespace IO
+{
+class Stream;
+};
+
 namespace Vulkan
 {
 struct VkTextureLoadInfo
@@ -52,6 +57,15 @@ struct VkTextureMappingInfo
 	uint32_t mapCount;
 };
 
+struct VkTextureStreamInfo
+{
+	uint32_t highestLod;
+	void* mappedBuffer;
+	uint bufferSize;
+	uint32_t maxMips;
+	Ptr<IO::Stream> stream;
+};
+
 struct VkTextureWindowInfo
 {
 	CoreGraphics::WindowId window;
@@ -69,6 +83,7 @@ enum
 	Texture_LoadInfo,
 	Texture_MappingInfo,
 	Texture_WindowInfo,
+	Texture_StreamInfo
 };
 
 /// we need a thread-safe allocator since it will be used by both the memory and stream pool
@@ -76,7 +91,8 @@ typedef Ids::IdAllocatorSafe<
 	VkTextureRuntimeInfo,					// runtime info (for binding)
 	VkTextureLoadInfo,						// loading info (mostly used during the load/unload phase)
 	VkTextureMappingInfo,					// used when image is mapped to memory
-	VkTextureWindowInfo
+	VkTextureWindowInfo,
+	VkTextureStreamInfo
 > VkTextureAllocator;
 extern VkTextureAllocator textureAllocator;
 

--- a/code/render/coregraphics/vk/vktypes.cc
+++ b/code/render/coregraphics/vk/vktypes.cc
@@ -443,6 +443,60 @@ VkTypes::AsVkSampleFlags(const SizeT samples)
 //------------------------------------------------------------------------------
 /**
 */
+VkImageType 
+VkTypes::AsVkImageType(CoreGraphics::TextureType type)
+{
+	switch (type)
+	{
+		case Texture1D:
+			return VK_IMAGE_TYPE_1D;
+		case Texture2D:
+			return VK_IMAGE_TYPE_2D;
+		case Texture3D:
+			return VK_IMAGE_TYPE_3D;
+		case TextureCube:
+			return VK_IMAGE_TYPE_2D;
+		case Texture1DArray:
+			return VK_IMAGE_TYPE_1D;
+		case Texture2DArray:
+			return VK_IMAGE_TYPE_2D;
+		case TextureCubeArray:
+			return VK_IMAGE_TYPE_2D;
+	}
+	n_error("Should not happen");
+	return VK_IMAGE_TYPE_MAX_ENUM;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+VkImageViewType 
+VkTypes::AsVkImageViewType(CoreGraphics::TextureType type)
+{
+	switch (type)
+	{
+	case Texture1D:
+		return VK_IMAGE_VIEW_TYPE_1D;
+	case Texture2D:
+		return VK_IMAGE_VIEW_TYPE_2D;
+	case Texture3D:
+		return VK_IMAGE_VIEW_TYPE_3D;
+	case TextureCube:
+		return VK_IMAGE_VIEW_TYPE_CUBE;
+	case Texture1DArray:
+		return VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+	case Texture2DArray:
+		return VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+	case TextureCubeArray:
+		return VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+	}
+	n_error("Should not happen");
+	return VK_IMAGE_VIEW_TYPE_MAX_ENUM;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
 CoreGraphics::PixelFormat::Code
 VkTypes::AsNebulaPixelFormat(VkFormat f)
 {
@@ -454,6 +508,8 @@ VkTypes::AsNebulaPixelFormat(VkFormat f)
 	case VK_FORMAT_R8G8B8A8_UNORM:					return PixelFormat::R8G8B8A8;
 	case VK_FORMAT_B8G8R8A8_UNORM:					return PixelFormat::A8B8G8R8;
 	case VK_FORMAT_R8G8B8_UNORM:					return PixelFormat::R8G8B8;
+	case VK_FORMAT_B8G8R8_UNORM:					return PixelFormat::R8G8B8;
+	case VK_FORMAT_B8G8R8A8_UNORM:					return PixelFormat::R8G8B8A8;
 	case VK_FORMAT_R5G6B5_UNORM_PACK16:				return PixelFormat::R5G6B5;
 	case VK_FORMAT_R8G8B8A8_SRGB:					return PixelFormat::SRGBA8;
 	case VK_FORMAT_B8G8R8A8_SRGB:					return PixelFormat::SRGBA8;

--- a/code/render/coregraphics/vk/vktypes.h
+++ b/code/render/coregraphics/vk/vktypes.h
@@ -55,6 +55,10 @@ public:
 	static VkFormat AsVkDataFormat(CoreGraphics::PixelFormat::Code p);
 	/// convert uint to vulkan sample count
 	static VkSampleCountFlagBits AsVkSampleFlags(const SizeT samples);
+	/// convert texture type to vk image type
+	static VkImageType AsVkImageType(CoreGraphics::TextureType type);
+	/// convert texture type to vk view type
+	static VkImageViewType AsVkImageViewType(CoreGraphics::TextureType type);
 	/// convert DevIL pixel format to Vulkan component mapping
 	static VkComponentMapping AsVkMapping(ILenum p);
 	/// convert vulkan format back to nebula format

--- a/code/render/coregraphics/vk/vkutilities.cc
+++ b/code/render/coregraphics/vk/vkutilities.cc
@@ -65,7 +65,7 @@ VkUtilities::BufferUpdate(CoreGraphics::CommandBufferId cmd, VkBuffer buf, VkDev
 /**
 */
 void 
-VkUtilities::ImageUpdate(VkDevice dev, CoreGraphics::CommandBufferId cmd, CoreGraphics::QueueType queue, VkImage img, const VkImageCreateInfo& info, uint32_t mip, uint32_t face, VkDeviceSize size, uint32_t* data, VkBuffer& outIntermediateBuffer, VkDeviceMemory& outIntermediateMemory)
+VkUtilities::ImageUpdate(VkDevice dev, CoreGraphics::CommandBufferId cmd, CoreGraphics::QueueType queue, VkImage img, const VkExtent3D& extent, uint32_t mip, uint32_t layer, VkDeviceSize size, uint32_t* data, VkBuffer& outIntermediateBuffer, VkDeviceMemory& outIntermediateMemory)
 {
 	// create transfer buffer
 	const uint32_t qfamily = Vulkan::GetQueueFamily(queue);
@@ -101,9 +101,9 @@ VkUtilities::ImageUpdate(VkDevice dev, CoreGraphics::CommandBufferId cmd, CoreGr
 	copy.bufferOffset = 0;
 	copy.bufferImageHeight = 0;
 	copy.bufferRowLength = 0;
-	copy.imageExtent = info.extent;
+	copy.imageExtent = extent;
 	copy.imageOffset = { 0, 0, 0 };
-	copy.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, mip, face, 1 };
+	copy.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, mip, layer, 1 };
 	vkCmdCopyBufferToImage(CommandBufferGetVk(cmd), buf, img, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
 
 	outIntermediateBuffer = buf;

--- a/code/render/coregraphics/vk/vkutilities.h
+++ b/code/render/coregraphics/vk/vkutilities.h
@@ -28,7 +28,7 @@ public:
 	/// update buffer memory from CPU
 	static void BufferUpdate(CoreGraphics::CommandBufferId cmd, VkBuffer buf, VkDeviceSize offset, VkDeviceSize size, const void* data);
 	/// update image memory from CPU
-	static void ImageUpdate(VkDevice dev, CoreGraphics::CommandBufferId cmd, CoreGraphics::QueueType queue, VkImage img, const VkImageCreateInfo& info, uint32_t mip, uint32_t face, VkDeviceSize size, uint32_t* data, VkBuffer& outIntermediateBuffer, VkDeviceMemory& outIntermediateMemory);
+	static void ImageUpdate(VkDevice dev, CoreGraphics::CommandBufferId cmd, CoreGraphics::QueueType queue, VkImage img, const VkExtent3D& extent, uint32_t mip, uint32_t layer, VkDeviceSize size, uint32_t* data, VkBuffer& outIntermediateBuffer, VkDeviceMemory& outIntermediateMemory);
 	/// perform image color clear
 	static void ImageColorClear(CoreGraphics::CommandBufferId cmd, const VkImage& image, VkImageLayout layout, VkClearColorValue clearValue, VkImageSubresourceRange subres);
 	/// perform image depth stencil clear

--- a/code/render/graphics/environmentcontext.cc
+++ b/code/render/graphics/environmentcontext.cc
@@ -53,8 +53,10 @@ EnvironmentContext::Create(const Graphics::GraphicsEntityId sun)
 	Graphics::RegisterEntity<Models::ModelContext, Visibility::ObservableContext>(envState.skyBoxEntity);
 
 	// setup both model and visibility
-	Models::ModelContext::Setup(envState.skyBoxEntity, "mdl:system/skybox.n3", "system");
-	Visibility::ObservableContext::Setup(envState.skyBoxEntity, Visibility::VisibilityEntityType::Model);
+	Models::ModelContext::Setup(envState.skyBoxEntity, "mdl:system/skybox.n3", "system", []()
+		{
+			Visibility::ObservableContext::Setup(envState.skyBoxEntity, Visibility::VisibilityEntityType::Model);
+		});
 
 	envState.bloomColor = Math::vec4(1.0f);
 	envState.bloomThreshold = 25.0f;

--- a/code/render/materials/materialserver.cc
+++ b/code/render/materials/materialserver.cc
@@ -15,7 +15,7 @@
 namespace Materials
 {
 __ImplementClass(Materials::MaterialServer, 'MASV', Core::RefCounted)
-__ImplementSingleton(Materials::MaterialServer)
+__ImplementInterfaceSingleton(Materials::MaterialServer)
 //------------------------------------------------------------------------------
 /**
 */

--- a/code/render/materials/materialserver.h
+++ b/code/render/materials/materialserver.h
@@ -19,7 +19,7 @@ namespace Materials
 class MaterialServer : public Core::RefCounted
 {
 	__DeclareClass(MaterialServer);
-	__DeclareSingleton(MaterialServer);
+	__DeclareInterfaceSingleton(MaterialServer);
 public:
 
 	/// constructor

--- a/code/render/materials/surfacepool.cc
+++ b/code/render/materials/surfacepool.cc
@@ -105,6 +105,9 @@ SurfacePool::LoadFromStream(const Resources::ResourceId id, const Util::StringAt
 							[type, sid, binding](Resources::ResourceId rid)
 							{
 								type->SetSurfaceConstant(sid, binding, CoreGraphics::TextureGetBindlessHandle(rid));
+
+								// lol test
+								Resources::StreamLOD(rid, -1, false);
 							}, 
 							[type, sid, binding](Resources::ResourceId rid)
 							{
@@ -117,6 +120,9 @@ SurfacePool::LoadFromStream(const Resources::ResourceId id, const Util::StringAt
 					
 					defaultVal.SetUInt64(tex.HashCode64());
 					type->SetSurfaceConstant(sid, binding, CoreGraphics::TextureGetBindlessHandle(tex));
+
+
+
 					break;
 				}
 				}
@@ -155,6 +161,14 @@ SurfacePool::Unload(const Resources::ResourceId id)
 	type->DestroySurface(mid);
 
 	this->states[id.poolId] = Resources::Resource::State::Unloaded;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+inline void
+SurfacePool::UpdateLOD(const SurfaceResourceId id, const IndexT lod)
+{
 }
 
 } // namespace Materials

--- a/code/render/materials/surfacepool.h
+++ b/code/render/materials/surfacepool.h
@@ -42,6 +42,8 @@ public:
 	const SurfaceId GetId(const SurfaceResourceId id);
 	/// get material type
 	MaterialType* const GetType(const SurfaceResourceId id);
+	/// update lod for textures in surface 
+	void UpdateLOD(const SurfaceResourceId id, const IndexT lod);
 private:
 
 	/// unload resource (overload to implement resource deallocation)
@@ -74,5 +76,6 @@ SurfacePool::GetType(const SurfaceResourceId id)
 	allocator.LeaveGet();
 	return ret;
 }
+
 
 } // namespace Materials

--- a/code/render/models/modelcontext.cc
+++ b/code/render/models/modelcontext.cc
@@ -62,7 +62,7 @@ ModelContext::Create()
 /**
 */
 void
-ModelContext::Setup(const Graphics::GraphicsEntityId gfxId, const Resources::ResourceName& name, const Util::StringAtom& tag)
+ModelContext::Setup(const Graphics::GraphicsEntityId gfxId, const Resources::ResourceName& name, const Util::StringAtom& tag, std::function<void()> finishedCallback)
 {
 	const ContextEntityId cid = GetContextId(gfxId);
     modelContextAllocator.Get<Model_InstanceId>(cid.id) = ModelInstanceId::Invalid();
@@ -70,23 +70,27 @@ ModelContext::Setup(const Graphics::GraphicsEntityId gfxId, const Resources::Res
 	ResourceCreateInfo info;
 	info.resource = name;
 	info.tag = tag;
-	info.async = false;
-	info.failCallback = nullptr;
+	info.async = true;
+	info.successCallback = [cid, gfxId, finishedCallback](Resources::ResourceId mid)
+	{
+		modelContextAllocator.Get<Model_Id>(cid.id) = mid;
+		ModelInstanceId& mdl = modelContextAllocator.Get<Model_InstanceId>(cid.id);
+		mdl = Models::CreateModelInstance(mid);
+		const Math::mat4& pending = modelContextAllocator.Get<Model_Transform>(cid.id);
+		Models::modelPool->modelInstanceAllocator.Get<StreamModelPool::InstanceTransform>(mdl.instance) = pending;
+		Models::modelPool->modelInstanceAllocator.Get<StreamModelPool::ObjectId>(mdl.instance) = gfxId.id;
+		finishedCallback();
+	};
+	info.failCallback = info.successCallback;
 
 	ModelId mid = Models::CreateModel(info);
-	modelContextAllocator.Get<Model_Id>(cid.id) = mid;
-	ModelInstanceId& mdl = modelContextAllocator.Get<Model_InstanceId>(cid.id);
-	mdl = Models::CreateModelInstance(mid);
-	const Math::mat4& pending = modelContextAllocator.Get<Model_Transform>(cid.id);
-	Models::modelPool->modelInstanceAllocator.Get<StreamModelPool::InstanceTransform>(mdl.instance) = pending;
-	Models::modelPool->modelInstanceAllocator.Get<StreamModelPool::ObjectId>(mdl.instance) = gfxId.id;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 void
-ModelContext::ChangeModel(const Graphics::GraphicsEntityId gfxId, const Resources::ResourceName& name, const Util::StringAtom& tag)
+ModelContext::ChangeModel(const Graphics::GraphicsEntityId gfxId, const Resources::ResourceName& name, const Util::StringAtom& tag, std::function<void()> finishedCallback)
 {
 	const ContextEntityId cid = GetContextId(gfxId);
 
@@ -104,14 +108,16 @@ ModelContext::ChangeModel(const Graphics::GraphicsEntityId gfxId, const Resource
 	info.resource = name;
 	info.tag = tag;
 	info.async = false;
-	info.failCallback = nullptr;
-	info.successCallback = [&mdl, rid, cid, gfxId](Resources::ResourceId id)
+	info.successCallback = [&mdl, cid, gfxId, finishedCallback](Resources::ResourceId mid)
 	{
-		mdl = Models::CreateModelInstance(id);
+		modelContextAllocator.Get<Model_Id>(cid.id) = mid;
+		ModelInstanceId& mdl = modelContextAllocator.Get<Model_InstanceId>(cid.id);
 		const Math::mat4& pending = modelContextAllocator.Get<Model_Transform>(cid.id);
 		Models::modelPool->modelInstanceAllocator.Get<StreamModelPool::InstanceTransform>(mdl.instance) = pending;
 		Models::modelPool->modelInstanceAllocator.Get<StreamModelPool::ObjectId>(mdl.instance) = gfxId.id;
+		finishedCallback();
 	};
+	info.failCallback = info.successCallback;
 
 	rid = Models::CreateModel(info);
 }
@@ -161,7 +167,6 @@ void
 ModelContext::SetTransform(const Graphics::GraphicsEntityId id, const Math::mat4& transform)
 {
 	const ContextEntityId cid = GetContextId(id);
-	ModelInstanceId& inst = modelContextAllocator.Get<Model_InstanceId>(cid.id);
 	Math::mat4& pending = modelContextAllocator.Get<Model_Transform>(cid.id);
 	bool& hasPending = modelContextAllocator.Get<Model_Dirty>(cid.id);
 	pending = transform;
@@ -175,7 +180,6 @@ Math::mat4
 ModelContext::GetTransform(const Graphics::GraphicsEntityId id)
 {
 	const ContextEntityId cid = GetContextId(id);
-	ModelInstanceId& inst = modelContextAllocator.Get<Model_InstanceId>(cid.id);
 	return modelContextAllocator.Get<Model_Transform>(cid.id);
 }
 

--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -38,10 +38,10 @@ public:
 	static void Create();
 
 	/// setup
-	static void Setup(const Graphics::GraphicsEntityId id, const Resources::ResourceName& name, const Util::StringAtom& tag);
+	static void Setup(const Graphics::GraphicsEntityId id, const Resources::ResourceName& name, const Util::StringAtom& tag, std::function<void()> finishedCallback);
 
 	/// change model for existing entity
-	static void ChangeModel(const Graphics::GraphicsEntityId id, const Resources::ResourceName& name, const Util::StringAtom& tag);
+	static void ChangeModel(const Graphics::GraphicsEntityId id, const Resources::ResourceName& name, const Util::StringAtom& tag, std::function<void()> finishedCallback);
 	/// get model
 	static const Models::ModelId GetModel(const Graphics::GraphicsEntityId id);
 	/// get model instance

--- a/code/render/models/nodes/primitivenode.cc
+++ b/code/render/models/nodes/primitivenode.cc
@@ -43,12 +43,17 @@ PrimitiveNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag, con
 		Resources::ResourceName meshName = reader->ReadString();
 
 		// add as pending resource in loader
-		this->res = Resources::CreateResource(meshName, tag, nullptr, nullptr, immediate);
+		this->primitiveGroupIndex = 0;
+		this->res = Resources::CreateResource(meshName, tag, [this](Resources::ResourceId id)
+			{
+				this->res = id;
+				this->primitiveGroupIndex = this->primitiveGroupIndexLoaded;
+			}, nullptr, immediate);
 	}
 	else if (FourCC('PGRI') == fourcc)
 	{
 		// primitive group index
-		this->primitiveGroupIndex = reader->ReadUInt();
+		this->primitiveGroupIndexLoaded = reader->ReadUInt();
 	}
 	else
 	{

--- a/code/render/models/nodes/primitivenode.h
+++ b/code/render/models/nodes/primitivenode.h
@@ -50,6 +50,7 @@ protected:
 
 	CoreGraphics::MeshId res;
 	uint32_t primitiveGroupIndex;
+	uint32_t primitiveGroupIndexLoaded;
 };
 
 ModelNodeInstanceCreator(PrimitiveNode)

--- a/code/render/models/nodes/shaderstatenode.cc
+++ b/code/render/models/nodes/shaderstatenode.cc
@@ -130,6 +130,8 @@ void
 ShaderStateNode::OnFinishedLoading()
 {
 	TransformNode::OnFinishedLoading();
+
+	// load surface immediately, however it will load textures async
 	this->surRes = Resources::CreateResource(this->materialName, this->tag, nullptr, nullptr, true);
 	this->materialType = Materials::surfacePool->GetType(this->surRes);
 	this->surface = Materials::surfacePool->GetId(this->surRes);

--- a/code/render/models/streammodelpool.h
+++ b/code/render/models/streammodelpool.h
@@ -39,7 +39,7 @@ public:
 	virtual ~StreamModelPool();
 
 	/// setup resource loader, initiates the placeholder and error resources if valid
-	void Setup();
+	void Setup() override;
 
 	/// create an instance of a model
 	ModelInstanceId CreateModelInstance(const ModelId id);

--- a/code/resource/resources/resourceloaderthread.cc
+++ b/code/resource/resources/resourceloaderthread.cc
@@ -3,7 +3,9 @@
 // (C)2017-2020 Individual contributors, see AUTHORS file
 //------------------------------------------------------------------------------
 #include "foundation/stdneb.h"
+#include "io/ioserver.h"
 #include "resourceloaderthread.h"
+#include "profiling/profiling.h"
 
 namespace Resources
 {
@@ -32,8 +34,10 @@ ResourceLoaderThread::~ResourceLoaderThread()
 void
 ResourceLoaderThread::DoWork()
 {
+	Profiling::ProfilingRegisterThread();
 	Util::Array<std::function<void()>> arr;
 	arr.Reserve(1000);
+	this->ioServer = IO::IoServer::Create();
 	while (!this->ThreadStopRequested())
 	{
 		this->completeEvent.Reset();

--- a/code/resource/resources/resourceloaderthread.h
+++ b/code/resource/resources/resourceloaderthread.h
@@ -10,6 +10,11 @@
 #include "threading/safequeue.h"
 #include <functional>
 #include "resourceid.h"
+
+namespace IO
+{
+	class IoServer;
+};
 namespace Resources
 {
 class ResourceLoaderThread : public Threading::Thread
@@ -34,5 +39,6 @@ private:
 
 	Threading::SafeQueue<std::function<void()>> jobs;
 	Threading::Event completeEvent;
+	Ptr<IO::IoServer> ioServer;
 };
 } // namespace Resources

--- a/code/resource/resources/resourceserver.cc
+++ b/code/resource/resources/resourceserver.cc
@@ -13,7 +13,7 @@ namespace Resources
 {
 
 __ImplementClass(Resources::ResourceServer, 'RMGR', Core::RefCounted);
-__ImplementSingleton(Resources::ResourceServer);
+__ImplementInterfaceSingleton(Resources::ResourceServer);
 
 int32_t ResourceServer::UniquePoolCounter = 0;
 //------------------------------------------------------------------------------

--- a/tests/testviewer/scenes/benchmark.cpp
+++ b/tests/testviewer/scenes/benchmark.cpp
@@ -35,13 +35,14 @@ void OpenScene()
 {
     ground = Graphics::CreateEntity();
     Graphics::RegisterEntity<ModelContext, ObservableContext>(ground);
-    ModelContext::Setup(ground, "mdl:environment/plcholder_world.n3", "Viewer");
+    ModelContext::Setup(ground, "mdl:environment/plcholder_world.n3", "Viewer", []()
+        {
+            // setup visibility
+            ObservableContext::Setup(ground, VisibilityEntityType::Model);
+        });
     ModelContext::SetTransform(ground, Math::scaling(1000, 1, 1000) * Math::translation(0,0,0));
     entities.Append(ground);
     entityNames.Append("Ground");
-
-    // setup visibility
-    ObservableContext::Setup(ground, VisibilityEntityType::Model);
 
     const Util::StringAtom modelRes[] = { "mdl:Units/Unit_Archer.n3",  "mdl:Units/Unit_Footman.n3",  "mdl:Units/Unit_Spearman.n3" };
     //const Util::StringAtom modelRes[] = { "mdl:system/placeholder.n3",  "mdl:system/placeholder.n3",  "mdl:system/placeholder.n3" };
@@ -66,9 +67,11 @@ void OpenScene()
             const float timeOffset = Math::n_rand();// (((i + NumModels)* NumModels + (j + NumModels)) % 4) / 3.0f;
 
             // create model and move it to the front
-            ModelContext::Setup(ent, modelRes[resourceIndex], "NotA");
+            ModelContext::Setup(ent, modelRes[resourceIndex], "NotA", [ent]()
+                {
+                    ObservableContext::Setup(ent, VisibilityEntityType::Model);
+                });
             ModelContext::SetTransform(ent, Math::translation(i * 16, 0, j * 16));
-            ObservableContext::Setup(ent, VisibilityEntityType::Model);
 
             //Characters::CharacterContext::Setup(ent, skeletonRes[resourceIndex], animationRes[resourceIndex], "Viewer");
             //Characters::CharacterContext::PlayClip(ent, nullptr, 0, 0, Characters::Append, 1.0f, 1, Math::n_rand() * 100.0f, 0.0f, 0.0f, Math::n_rand() * 100.0f);

--- a/tests/testviewer/scenes/bistro.cpp
+++ b/tests/testviewer/scenes/bistro.cpp
@@ -19,7 +19,10 @@ void OpenScene()
 {
     entity = Graphics::CreateEntity();
     Graphics::RegisterEntity<Models::ModelContext, Visibility::ObservableContext>(entity);
-    Models::ModelContext::Setup(entity, "mdl:bistro/Bistro_Exterior.n3", "BistroScene");
+    Models::ModelContext::Setup(entity, "mdl:bistro/Bistro_Exterior.n3", "BistroScene", []()
+        {
+            Visibility::ObservableContext::Setup(entity, Visibility::VisibilityEntityType::Model);
+        });
     
     Math::mat4 t = Math::translation(Math::vec3(0, 0, 0));
     Math::mat4 r = Math::rotationx(Math::n_deg2rad(0.0f));
@@ -29,7 +32,6 @@ void OpenScene()
     trs = trs * t;
     
     Models::ModelContext::SetTransform(entity, trs);
-    Visibility::ObservableContext::Setup(entity, Visibility::VisibilityEntityType::Model);
 };
 
 //------------------------------------------------------------------------------

--- a/tests/testviewer/scenes/clusteredlighting.cpp
+++ b/tests/testviewer/scenes/clusteredlighting.cpp
@@ -94,10 +94,7 @@ void OpenScene()
 
             // load textures
             CoreGraphics::TextureId albedo = Resources::CreateResource("tex:system/white.dds", "decal"_atm, nullptr, nullptr, true);
-            CoreGraphics::TextureId normal = Resources::CreateResource("tex:test/normalbox_normal.dds", "decal"_atm, [id](Resources::ResourceId rid)
-                {
-                    Decals::DecalContext::SetNormalTexture(id, rid);
-                });
+            CoreGraphics::TextureId normal = Resources::CreateResource("tex:test/normalbox_normal.dds", "decal"_atm, nullptr, nullptr, true);
             CoreGraphics::TextureId material = Resources::CreateResource("tex:system/default_material.dds", "decal"_atm, nullptr, nullptr, true);
 
             // setup decal
@@ -139,7 +136,10 @@ void OpenScene()
 
     tower = Graphics::CreateEntity();
     Graphics::RegisterEntity<ModelContext, ObservableContext>(tower);
-    ModelContext::Setup(tower, "mdl:test/test.n3", "Viewer");
+    ModelContext::Setup(tower, "mdl:test/test.n3", "Viewer", []()
+        {
+            ObservableContext::Setup(tower, VisibilityEntityType::Model);
+        });
     ModelContext::SetTransform(tower, Math::translation(4, 0, -7));
     entities.Append(tower);
     entityNames.Append("Tower");
@@ -150,19 +150,22 @@ void OpenScene()
     ModelContext::SetTransform(ground, Math::scaling(4) * Math::translation(0,0,0));
     entities.Append(ground);
     entityNames.Append("Ground");
+    */
+
 
 	particle = Graphics::CreateEntity();
 	Graphics::RegisterEntity<ModelContext, ObservableContext, Particles::ParticleContext>(particle);
-	ModelContext::Setup(particle, "mdl:Particles/Build_dust.n3", "Viewer");
-	Particles::ParticleContext::Setup(particle);
-	Particles::ParticleContext::Play(particle, Particles::ParticleContext::RestartIfPlaying);
+    ModelContext::Setup(particle, "mdl:Particles/Build_dust.n3", "Viewer", []()
+        {
+            ObservableContext::Setup(particle, VisibilityEntityType::Particle);
+            Particles::ParticleContext::Setup(particle);
+            Particles::ParticleContext::Play(particle, Particles::ParticleContext::RestartIfPlaying);
+        });	
 	entities.Append(particle);
 	entityNames.Append("Particle");
 
     // setup visibility
-    ObservableContext::Setup(tower, VisibilityEntityType::Model);
-    ObservableContext::Setup(ground, VisibilityEntityType::Model);
-	ObservableContext::Setup(particle, VisibilityEntityType::Particle);
+    //ObservableContext::Setup(ground, VisibilityEntityType::Model);
 
     const Util::StringAtom modelRes[] = { "mdl:Units/Unit_Archer.n3",  "mdl:Units/Unit_Footman.n3",  "mdl:Units/Unit_Spearman.n3", "mdl:Units/Unit_Rifleman.n3" };
     //const Util::StringAtom modelRes[] = { "mdl:system/placeholder.n3",  "mdl:system/placeholder.n3",  "mdl:system/placeholder.n3" };
@@ -187,16 +190,17 @@ void OpenScene()
             const float timeOffset = Math::n_rand();// (((i + NumModels)* NumModels + (j + NumModels)) % 4) / 3.0f;
 
             // create model and move it to the front
-            ModelContext::Setup(ent, modelRes[modelIndex], "NotA");
-            ModelContext::SetTransform(ent, Math::translation(i * 16, 0, j * 16));
-            ObservableContext::Setup(ent, VisibilityEntityType::Model);
-
-            Characters::CharacterContext::Setup(ent, skeletonRes[modelIndex], animationRes[modelIndex], "Viewer");
-            Characters::CharacterContext::PlayClip(ent, nullptr, 1, 0, Characters::Append, 1.0f, 1, Math::n_rand() * 100.0f, 0.0f, 0.0f, Math::n_rand() * 100.0f);
+            ModelContext::Setup(ent, modelRes[modelIndex], "NotA", [ent, modelIndex, i, j, skeletonRes, animationRes]()
+                {
+                    ModelContext::SetTransform(ent, Math::translation(i * 16, 0, j * 16));
+                    ObservableContext::Setup(ent, VisibilityEntityType::Model);
+                    Characters::CharacterContext::Setup(ent, skeletonRes[modelIndex], animationRes[modelIndex], "Viewer");
+                    Characters::CharacterContext::PlayClip(ent, nullptr, 1, 0, Characters::Append, 1.0f, 1, Math::n_rand() * 100.0f, 0.0f, 0.0f, Math::n_rand() * 100.0f);
+                });
+            
             modelIndex = (modelIndex + 1) % 4;
         }
     }
-
 
     ModelContext::EndBulkRegister();
     ObservableContext::EndBulkRegister();

--- a/tests/testviewer/scenes/example.cpp
+++ b/tests/testviewer/scenes/example.cpp
@@ -30,15 +30,19 @@ void OpenScene()
 {
     entity = Graphics::CreateEntity();
     Graphics::RegisterEntity<Models::ModelContext, Visibility::ObservableContext>(entity);
-    Models::ModelContext::Setup(entity, "mdl:system/placeholder.n3", "ExampleScene");
+    Models::ModelContext::Setup(entity, "mdl:system/placeholder.n3", "ExampleScene", []()
+        {
+            Visibility::ObservableContext::Setup(entity, Visibility::VisibilityEntityType::Model);
+        });
     Models::ModelContext::SetTransform(entity, Math::translation(Math::vec3(0, 0, 0)));
-    Visibility::ObservableContext::Setup(entity, Visibility::VisibilityEntityType::Model);
     
     otherEntity = Graphics::CreateEntity();
     Graphics::RegisterEntity<Models::ModelContext, Visibility::ObservableContext>(otherEntity);
-    Models::ModelContext::Setup(otherEntity, "mdl:system/placeholder.n3", "ExampleScene");
+    Models::ModelContext::Setup(otherEntity, "mdl:system/placeholder.n3", "ExampleScene", []()
+        {
+            Visibility::ObservableContext::Setup(otherEntity, Visibility::VisibilityEntityType::Model);
+        });
     Models::ModelContext::SetTransform(otherEntity, Math::translation(Math::vec3(2, 0, 0)));
-    Visibility::ObservableContext::Setup(otherEntity, Visibility::VisibilityEntityType::Model);
 
     v = 0.0f;
 };

--- a/tests/testviewer/scenes/scenes.h
+++ b/tests/testviewer/scenes/scenes.h
@@ -69,4 +69,4 @@ enum
 
 // Which is the currently active scene?
 // This is used to determine which scenes callbacks to call and is normally changed via imgui
-static int currentScene = BenchmarkSceneId;
+static int currentScene = SponzaSceneId;

--- a/tests/testviewer/scenes/sponza.cpp
+++ b/tests/testviewer/scenes/sponza.cpp
@@ -25,7 +25,10 @@ void OpenScene()
 {
     entity = Graphics::CreateEntity();
     Graphics::RegisterEntity<Models::ModelContext, Visibility::ObservableContext>(entity);
-    Models::ModelContext::Setup(entity, "mdl:sponza/sponza.n3", "SponzaScene");
+    Models::ModelContext::Setup(entity, "mdl:sponza/sponza.n3", "SponzaScene", []()
+        {
+            Visibility::ObservableContext::Setup(entity, Visibility::VisibilityEntityType::Model);
+        });
     
     Math::mat4 t = Math::translation(Math::vec3(0, 0, 0));
     Math::mat4 r = Math::rotationx(Math::n_deg2rad(0.0f));
@@ -35,7 +38,6 @@ void OpenScene()
     trs = trs * t;
     
     Models::ModelContext::SetTransform(entity, trs);
-    Visibility::ObservableContext::Setup(entity, Visibility::VisibilityEntityType::Model);
     
     light = Graphics::CreateEntity();
     Graphics::RegisterEntity<Lighting::LightContext>(light);

--- a/work/shaders/vk/combine.fx
+++ b/work/shaders/vk/combine.fx
@@ -29,10 +29,10 @@ void csCombine()
 	vec4 light = imageLoad(Lighting, fullscaleCoord);
 
 	//vec4 res = vec4(mix(light.rgb, fog.rgb, fog.a), 1);
-	vec3 res = 
-		light.rgb * fog.a 
+	vec3 res =
+		light.rgb;// *fog.a
 		//+ reflections.rgb * fog.a 
-		+ fog.rgb;
+		//+ fog.rgb;
 	imageStore(Lighting, fullscaleCoord, vec4(res, 1));
 }
 

--- a/work/shaders/vk/terrain/terrain.fx
+++ b/work/shaders/vk/terrain/terrain.fx
@@ -1,0 +1,293 @@
+//------------------------------------------------------------------------------
+//  terrain.fx
+//  (C) 2020 Gustav Sterbrant
+//------------------------------------------------------------------------------
+#include "lib/std.fxh"
+#include "lib/util.fxh"
+#include "lib/shared.fxh"
+#include "lib/techniques.fxh"
+
+// this is used to keep track of how many lights we have active
+group(BATCH_GROUP) constant TerrainUniforms [ string Visibility = "VS|HS|DS"; ]
+{
+	mat4 Transform;
+	vec2 TerrainDimensions;
+	float MinLODDistance;
+	float MaxLODDistance;
+	float MinTessellation;
+	float MaxTessellation;
+	float MinHeight;
+	float MaxHeight;
+	textureHandle HeightMap;
+	textureHandle NormalMap;
+	textureHandle DecisionMap;
+};
+
+sampler_state TextureSampler
+{
+	//Samplers = { Texture };
+};
+
+sampler_state DecisionSampler
+{
+	Filter = Point;
+	//Samplers = { Texture };
+};
+
+//------------------------------------------------------------------------------
+/**
+	Tessellation terrain vertex shader
+*/
+shader
+void
+vsTerrain(
+	[slot=0] in vec3 position,
+	[slot=2] in vec2 uv,
+	out vec4 Position,
+	out vec2 UV,
+	out float Tessellation) 
+{
+	vec4 modelSpace = Transform * vec4(position, 1);
+	Position = modelSpace;
+
+	float vertexDistance = distance( Position.xyz, EyePos.xyz );
+	float factor = 1.0f - saturate((MinLODDistance - vertexDistance) / (MinLODDistance - MaxLODDistance));
+	float decision = 1.0f - sample2DLod(DecisionMap, DecisionSampler, uv, 0).r;
+
+	Tessellation = MinTessellation + factor * (MaxTessellation - MinTessellation) * decision;
+
+	gl_Position = modelSpace;
+	UV = uv;
+}
+
+//------------------------------------------------------------------------------
+/**
+	Tessellation terrain hull shader
+*/
+[inputvertices] = 3
+[outputvertices] = 3
+shader
+void
+hsTerrain(
+	in vec4 position[],
+	in vec2 uv[],
+	in float tessellation[],
+	out vec2 UV[],
+	out vec4 Position[]) 
+{
+	Position[gl_InvocationID]	= position[gl_InvocationID];
+	UV[gl_InvocationID]			= uv[gl_InvocationID];
+
+	// provoking vertex gets to decide tessellation factors
+	if (gl_InvocationID == 0)
+	{
+		vec4 EdgeTessFactors;
+		EdgeTessFactors.x = 0.5 * (tessellation[1] + tessellation[2]);
+		EdgeTessFactors.y = 0.5 * (tessellation[2] + tessellation[0]);
+		EdgeTessFactors.z = 0.5 * (tessellation[0] + tessellation[1]);
+
+		gl_TessLevelOuter[0] = EdgeTessFactors.x;
+		gl_TessLevelOuter[1] = EdgeTessFactors.y;
+		gl_TessLevelOuter[2] = EdgeTessFactors.z;
+		gl_TessLevelInner[0] = gl_TessLevelOuter[0];
+	}
+}
+
+//------------------------------------------------------------------------------
+/**
+	Tessellation terrain shader
+*/
+[inputvertices] = 3
+[winding] = cw
+[topology] = triangle
+[partition] = odd
+shader
+void
+dsTerrain(
+	in vec2 uv[],
+	in vec4 position[],
+	out vec3 Normal,
+	out vec2 UV) 
+{
+	vec3 Position = 
+		gl_TessCoord.x * position[0].xyz + 
+		gl_TessCoord.y * position[1].xyz + 
+		gl_TessCoord.z * position[2].xyz;
+
+	UV = 
+		gl_TessCoord.x * uv[0] + 
+		gl_TessCoord.y * uv[1] + 
+		gl_TessCoord.z * uv[2];
+
+	// sample height map
+	float heightValue = sample2D(HeightMap, TextureSampler, UV).r;
+	float height = MinHeight + heightValue * (MaxHeight - MinHeight);
+	Position.y += height;
+	vec2 normalSample = sample2D(NormalMap, TextureSampler, UV).ag;
+	Normal.xy = (normalSample.xy * 2.0f) - 1.0f;
+	Normal.z = saturate(sqrt(1.0f - dot(Normal.xy, Normal.xy)));
+	Normal = Normal.xzy;
+
+	gl_Position = ViewProjection * vec4(Position, 1);
+}
+
+//------------------------------------------------------------------------------
+/**
+	Simple terrain vertex shader
+*/
+shader
+void
+vsTerrainZ(
+	[slot=0] in vec3 position,
+	[slot=2] in vec2 uv,
+	out vec2 UV) 
+{
+	vec4 modelSpace = Transform * vec4(position, 1);
+	gl_Position = ViewProjection * modelSpace;
+	UV = uv;
+}
+
+//------------------------------------------------------------------------------
+/**
+	Tessellation terrain hull shader
+*/
+[inputvertices] = 3
+[outputvertices] = 3
+shader
+void
+hsTerrainZ(
+	in vec4 position[],
+	in vec2 uv[],
+	in float tessellation[],
+	out vec2 UV[],
+	out vec4 Position[]) 
+{
+	Position[gl_InvocationID]	= position[gl_InvocationID];
+	UV[gl_InvocationID]			= uv[gl_InvocationID];
+
+	// provoking vertex gets to decide tessellation factors
+	if (gl_InvocationID == 0)
+	{
+		vec4 EdgeTessFactors;
+		EdgeTessFactors.x = 0.5 * (tessellation[1] + tessellation[2]);
+		EdgeTessFactors.y = 0.5 * (tessellation[2] + tessellation[0]);
+		EdgeTessFactors.z = 0.5 * (tessellation[0] + tessellation[1]);
+
+		gl_TessLevelOuter[0] = EdgeTessFactors.x;
+		gl_TessLevelOuter[1] = EdgeTessFactors.y;
+		gl_TessLevelOuter[2] = EdgeTessFactors.z;
+		gl_TessLevelInner[0] = gl_TessLevelOuter[0];
+	}
+}
+
+//------------------------------------------------------------------------------
+/**
+	Tessellation terrain shader
+*/
+[inputvertices] = 3
+[winding] = cw
+[topology] = triangle
+[partition] = odd
+shader
+void
+dsTerrainZ(
+	in vec2 uv[],
+	in vec4 position[],
+	out vec2 UV) 
+{
+	vec3 Position = 
+		gl_TessCoord.x * position[0].xyz + 
+		gl_TessCoord.y * position[1].xyz + 
+		gl_TessCoord.z * position[2].xyz;
+
+	UV = 
+		gl_TessCoord.x * uv[0] + 
+		gl_TessCoord.y * uv[1] + 
+		gl_TessCoord.z * uv[2];
+
+	// sample height map
+	float heightValue = sample2D(HeightMap, TextureSampler, UV).r;
+	float height = MinHeight + heightValue * (MaxHeight - MinHeight);
+	Position.y += height;
+
+	gl_Position = ViewProjection * vec4(Position, 1);
+}
+
+
+//------------------------------------------------------------------------------
+/**
+	Pixel shader for multilayered painting
+*/
+[early_depth]
+shader
+void
+psTerrain(
+	in vec3 Normal,
+	in vec2 UV,
+	[color0] out vec4 Albedo,
+	[color1] out vec3 Normals,
+	[color2] out vec4 Material) 
+{	
+	Material = vec4(0.0f, 1.0f, 0.5f, 0.0f);
+	Albedo = vec4(1, 1, 1, 1);
+	Normals = Normal;
+}
+
+//------------------------------------------------------------------------------
+/**
+	Pixel shader for Z pass
+*/
+[early_depth]
+shader
+void
+psTerrainZ(in vec2 UV) 
+{	
+	// do nothing, we use the built-in depth generated for this pass
+}
+
+//------------------------------------------------------------------------------
+/**
+	Pixel shader for multilayered painting
+*/
+shader
+void
+psTerrainShadow(
+	in vec3 Normal,
+	in vec2 UV,
+	[color0] out vec2 Shadow) 
+{	
+	float depth = gl_FragCoord.z / gl_FragCoord.w;
+	float moment1 = depth;
+	float moment2 = depth * depth;
+
+	// Adjusting moments (this is sort of bias per pixel) using derivative
+	float dx = dFdx(depth);
+	float dy = dFdy(depth);
+	moment2 += 0.25f*(dx*dx+dy*dy);
+
+	Shadow = vec2(moment1, moment2);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+render_state TerrainState
+{
+	CullMode = Back;
+	//FillMode = Line;
+};
+
+render_state TerrainShadowState
+{
+	CullMode = Back;
+	DepthClamp = false;
+	DepthEnabled = false;
+	DepthWrite = false;
+	BlendEnabled[0] = true;
+	SrcBlend[0] = One;
+	DstBlend[0] = One;
+	BlendOp[0] = Min;
+};
+
+TessellationTechnique(Terrain, "Terrain", vsTerrain(), psTerrain(), hsTerrain(), dsTerrain(), TerrainState);
+TessellationTechnique(TerrainZ, "TerrainZ", vsTerrainZ(), psTerrainZ(), hsTerrainZ(), dsTerrainZ(), TerrainState);


### PR DESCRIPTION
Added memory mapping interface for Windows (ONLY, BEWARE!).
Removed the asserts in ArrayAllocatorSafe, the reason why we have a critical section is to allow us to enter it on several threads...

[render]
Changed the FenceWait to FenceWaitAndReset, which is more clear. Also added an ordinary fence wait which doesn't reset.
Added a handover submission context, which is meant to handover resources from transfer to graphics, which can be triggered from another thread.
Using the new memory mapping in both texture and mesh streaming.
Increased the index type in imgui to 32 bit, maybe stupid, we'll see... but I need it for the profiler.
Enabled async loading for textures and meshes, wohoo!
The graphics device now uses a lock for the resource (and handover) submissions, the only reason why there are two contexts is because you need a submission context to act on a single queue.
Added the API for waiting for a semaphore, as supported by the new timeline semaphores. This is used for the handover to not have to wait for the graphics fence, but can instead just wait for the semaphore. Actually, we should use this everywhere where we have fences, as they are no longer required.
Submission contexts can now save which timeline submission index they have for a certain frame index, allowing us to wait for that specific submission on the next frame index.
We now stream in new LODs asynchronously.
Added an API for queuing up new image views to be created in the shader server. This is because we might stream-load new LODs, which require a new image view so that we can see these new LODs.
All model loads now send a callback for when the model is loaded, such that observers and such can actually register their stuff when the model actually loads (which they have to).
Started working on allowing a surface to update the LODs.
Simplified observable setup procedure, it is really stupid that there is an ad-hoc way to setup entities. Instead, when an entity is registered as an Observable, all Observers should react to it on their next update, which is the case now.