### PR TITLE
[input]

### DIFF
--- a/code/render/coregraphics/glfw/glfwwindow.cc
+++ b/code/render/coregraphics/glfw/glfwwindow.cc
@@ -605,8 +605,16 @@ WindowPresent(const WindowId id, const IndexT frameIndex)
 		glfwSwapBuffers(wnd);
 #endif
 		frame = frameIndex;
-		glfwPollEvents();
 	}
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+WindowPollEvents()
+{
+	glfwPollEvents();
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/glfw/glfwwindow.h
+++ b/code/render/coregraphics/glfw/glfwwindow.h
@@ -51,7 +51,6 @@ void RecreateVulkanSwapchain(const CoreGraphics::WindowId& id, const CoreGraphic
 /// perform a present
 void Present(const CoreGraphics::WindowId& id);
 
-
 } // namespace Vulkan
 #endif
 

--- a/code/render/coregraphics/window.h
+++ b/code/render/coregraphics/window.h
@@ -50,6 +50,8 @@ void WindowSetTitle(const WindowId id, const Util::String& title);
 void WindowMakeCurrent(const WindowId id);
 /// present window
 void WindowPresent(const WindowId id, const IndexT frameIndex);
+/// poll events for window
+void WindowPollEvents();
 /// toggle fullscreen
 void WindowApplyFullscreen(const WindowId id, Adapter::Code monitor, bool b);
 /// set if the cursor should be visible

--- a/tests/testviewer/viewerapp.cc
+++ b/tests/testviewer/viewerapp.cc
@@ -256,6 +256,7 @@ SimpleViewerApplication::Run()
 #endif NEBULA_ENABLE_PROFILING
 
 		this->gfxServer->BeginFrame();
+        CoreGraphics::WindowPollEvents();
         this->RenderUI();
 
         if (this->renderDebug)


### PR DESCRIPTION
Extracted event polling from present to separate call since this meant we sometimes reset the input handlers before being able to handle the input.

Poll events should be called at beginning of frame, after inputserver begin frame, but before rendering and presenting.

This fixes some issues with single key presses and mouse wheel being registered undeterministically.