### PR TITLE
Feature/global vertex cache

### DIFF
--- a/code/foundation/memory/rangeallocator.h
+++ b/code/foundation/memory/rangeallocator.h
@@ -38,7 +38,7 @@ private:
         IndexT start;
         SizeT length;
     };
-    Util::Array<Range> ranges;
+    Util::Dictionary<IndexT, Range> ranges;
     SizeT size;
 };
 
@@ -79,7 +79,7 @@ RangeAllocator::Alloc(SizeT numElements, SizeT alignment, IndexT& outIndex)
     IndexT i;
     for (i = 0; i < this->ranges.Size(); i++)
     {
-        const Range& range = this->ranges[i];
+        const Range& range = this->ranges.ValueAtIndex(i);
 
         if (currentOffset > range.start)
             goto next;
@@ -99,7 +99,7 @@ RangeAllocator::Alloc(SizeT numElements, SizeT alignment, IndexT& outIndex)
         ret = true;
         outIndex = currentOffset;
 
-        this->ranges.Insert(i, Range{ currentOffset, numElements });
+        this->ranges.Add(currentOffset, Range{ currentOffset, numElements });
     }
 
     return ret;
@@ -111,13 +111,11 @@ RangeAllocator::Alloc(SizeT numElements, SizeT alignment, IndexT& outIndex)
 inline void 
 RangeAllocator::Dealloc(IndexT startIndex)
 {
-    for (IndexT i = 0; i < this->ranges.Size(); i++)
+    IndexT index = this->ranges.FindIndex(startIndex);
+    if (index != InvalidIndex)
     {
-        if (this->ranges[i].start == startIndex)
-        {
-            this->ranges.EraseIndex(i);
-            return;
-        }
+        this->ranges.EraseAtIndex(index);
+        return;
     }
     n_error("Tried to dealloc non-existant range");
 }

--- a/code/foundation/memory/rangeallocator.h
+++ b/code/foundation/memory/rangeallocator.h
@@ -38,7 +38,7 @@ private:
         IndexT start;
         SizeT length;
     };
-    Util::Dictionary<IndexT, Range> ranges;
+    Util::Array<Range> ranges;
     SizeT size;
 };
 
@@ -79,7 +79,7 @@ RangeAllocator::Alloc(SizeT numElements, SizeT alignment, IndexT& outIndex)
     IndexT i;
     for (i = 0; i < this->ranges.Size(); i++)
     {
-        const Range& range = this->ranges.ValueAtIndex(i);
+        const Range& range = this->ranges[i];
 
         if (currentOffset > range.start)
             goto next;
@@ -99,7 +99,7 @@ RangeAllocator::Alloc(SizeT numElements, SizeT alignment, IndexT& outIndex)
         ret = true;
         outIndex = currentOffset;
 
-        this->ranges.Add(currentOffset, Range{ currentOffset, numElements });
+        this->ranges.Insert(i, Range{ currentOffset, numElements });
     }
 
     return ret;
@@ -111,11 +111,13 @@ RangeAllocator::Alloc(SizeT numElements, SizeT alignment, IndexT& outIndex)
 inline void 
 RangeAllocator::Dealloc(IndexT startIndex)
 {
-    IndexT index = this->ranges.FindIndex(startIndex);
-    if (index != InvalidIndex)
+    for (IndexT i = 0; i < this->ranges.Size(); i++)
     {
-        this->ranges.EraseAtIndex(index);
-        return;
+        if (this->ranges[i].start == startIndex)
+        {
+            this->ranges.EraseIndex(i);
+            return;
+        }
     }
     n_error("Tried to dealloc non-existant range");
 }

--- a/code/foundation/util/arrayallocatorsafe.h
+++ b/code/foundation/util/arrayallocatorsafe.h
@@ -274,9 +274,8 @@ template<class ...TYPES>
 inline const uint32_t
 ArrayAllocatorSafe<TYPES...>::Size() const
 {
-    this->lock.LockRead();
+    n_assert2(this->numReaders > 0, "Size requires a read lock");
     return this->size;
-    this->lock.UnlockRead();
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/characters/charactercontext.cc
+++ b/code/render/characters/charactercontext.cc
@@ -79,6 +79,7 @@ CharacterContext::Setup(const Graphics::GraphicsEntityId id, const Resources::Re
     characterContextAllocator.Set<Loaded>(cid.id, NoneLoaded);
     characterContextAllocator.Set<EntityId>(cid.id, id);
 
+
     // check to make sure we registered this entity for observation, then get the visibility context
     const ContextEntityId visId = Visibility::ObservableContext::GetContextId(id);
     n_assert_fmt(visId != InvalidContextEntityId, "Entity %d needs to be setup as observerable before character!", id.HashCode());
@@ -100,9 +101,9 @@ CharacterContext::Setup(const Graphics::GraphicsEntityId id, const Resources::Re
         }
     }
 
-    characterContextAllocator.Get<SkeletonId>(cid.id) = Resources::CreateResource(skeleton, tag, [cid, id](Resources::ResourceId rid)
+    characterContextAllocator.Get<SkeletonId>(cid.id) = Resources::CreateResource(skeleton, tag, [cid, id, skeleton](Resources::ResourceId rid)
         {
-            characterContextAllocator.Get<SkeletonId>(cid.id) = rid.As<Characters::SkeletonId>();
+            characterContextAllocator.Set<SkeletonId>(cid.id, rid.As<Characters::SkeletonId>());
             characterContextAllocator.Get<Loaded>(cid.id) |= SkeletonLoaded;
 
             const Util::FixedArray<CharacterJoint>& joints = Characters::SkeletonGetJoints(rid.As<Characters::SkeletonId>());
@@ -121,6 +122,7 @@ CharacterContext::Setup(const Graphics::GraphicsEntityId id, const Resources::Re
                 SkeletonJobJoint& jobJoint = characterContextAllocator.Get<JobJoints>(cid.id)[i];
                 jobJoint.parentJointIndex = joint.parentJointIndex;
             }
+
         }, nullptr, true);
 
     characterContextAllocator.Get<AnimationId>(cid.id) = Resources::CreateResource(animation, tag, [cid, id, supportBlending](Resources::ResourceId rid)
@@ -845,6 +847,7 @@ CharacterContext::WaitForCharacterJobs(const Graphics::FrameContext& ctx)
         const Util::Array<IndexT>& usedIndices = sparent->skinFragments[0].jointPalette;
         Util::FixedArray<Math::mat4> usedMatrices(usedIndices.Size());
 
+
         // update joints, which is stored in character context
         if (!jointPalette.IsEmpty())
         {
@@ -864,7 +867,6 @@ CharacterContext::WaitForCharacterJobs(const Graphics::FrameContext& ctx)
                 usedMatrices[j] = Math::mat4();
             }
         }
-
         // update skinning palette
         uint offset = CoreGraphics::SetGraphicsConstants(usedMatrices.Begin(), usedMatrices.Size());
         renderables.nodeStates[node].resourceTableOffsets[renderables.nodeStates[node].skinningConstantsIndex] = offset;

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -152,11 +152,11 @@ void CmdEndRecord(const CmdBufferId id);
 void CmdReset(const CmdBufferId id, const CmdBufferClearInfo& info);
 
 /// Set vertex buffer
-void CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, SizeT bufferOffset);
+void CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, IndexT offsetVertexIndex);
 /// Set vertex layout
 void CmdSetVertexLayout(const CmdBufferId id, const CoreGraphics::VertexLayoutId& vl);
 /// Set index buffer
-void CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, SizeT bufferOffset);
+void CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, IndexT offsetIndex);
 /// Set the type of topology used
 void CmdSetPrimitiveTopology(const CmdBufferId id, const CoreGraphics::PrimitiveTopology::Code topo);
 

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -152,11 +152,11 @@ void CmdEndRecord(const CmdBufferId id);
 void CmdReset(const CmdBufferId id, const CmdBufferClearInfo& info);
 
 /// Set vertex buffer
-void CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, IndexT offsetVertexIndex);
+void CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, SizeT bufferOffset);
 /// Set vertex layout
 void CmdSetVertexLayout(const CmdBufferId id, const CoreGraphics::VertexLayoutId& vl);
 /// Set index buffer
-void CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, IndexT offsetIndex);
+void CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, SizeT bufferOffset);
 /// Set the type of topology used
 void CmdSetPrimitiveTopology(const CmdBufferId id, const CoreGraphics::PrimitiveTopology::Code topo);
 

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -20,6 +20,7 @@
 #include "debug/debugcounter.h"
 #include "coregraphics/rendereventhandler.h"
 #include "coregraphics/resourcetable.h"
+#include "memory/rangeallocator.h"
 #include "timing/timer.h"
 #include "util/stack.h"
 #include "memory.h"
@@ -31,6 +32,7 @@ struct GraphicsDeviceCreateInfo
 {
     uint64 globalGraphicsConstantBufferMemorySize;
     uint64 globalComputeConstantBufferMemorySize;
+    uint64 globalVertexBufferMemorySize;
     uint64 memoryHeaps[NumMemoryPoolTypes];
     uint64 maxOcclusionQueries, maxTimestampQueries, maxStatisticsQueries;
     byte numBufferedFrames : 3;
@@ -93,6 +95,9 @@ struct GraphicsDeviceState
     CoreGraphics::ResourceTableId frameResourceTable;
 
     Util::Array<Ptr<CoreGraphics::RenderEventHandler> > eventHandlers;
+
+    Memory::RangeAllocator vertexAllocator;
+    CoreGraphics::BufferId vertexBuffer;
 
     bool isOpen : 1;
     bool inNotifyEventHandlers : 1;
@@ -228,6 +233,13 @@ void DelayedDeleteDescriptorSet(const CoreGraphics::ResourceTableId id);
 uint AllocateQueries(const CoreGraphics::QueryType type, uint numQueries);
 /// Copy query results to buffer
 void FinishQueries(const CoreGraphics::CmdBufferId cmdBuf, const CoreGraphics::QueryType type, IndexT start, SizeT count);
+
+/// Allocate vertices from the global vertex pool
+uint AllocateVertices(const SizeT numVertices, const SizeT vertexSize);
+/// Deallocate vertices
+void DeallocateVertices(uint offset);
+/// Get vertex buffer 
+const CoreGraphics::BufferId GetVertexBuffer();
 
 /// Swap
 void Swap(IndexT i);

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -20,7 +20,6 @@
 #include "debug/debugcounter.h"
 #include "coregraphics/rendereventhandler.h"
 #include "coregraphics/resourcetable.h"
-#include "memory/rangeallocator.h"
 #include "timing/timer.h"
 #include "util/stack.h"
 #include "memory.h"
@@ -32,7 +31,6 @@ struct GraphicsDeviceCreateInfo
 {
     uint64 globalGraphicsConstantBufferMemorySize;
     uint64 globalComputeConstantBufferMemorySize;
-    uint64 globalVertexBufferMemorySize;
     uint64 memoryHeaps[NumMemoryPoolTypes];
     uint64 maxOcclusionQueries, maxTimestampQueries, maxStatisticsQueries;
     byte numBufferedFrames : 3;
@@ -95,9 +93,6 @@ struct GraphicsDeviceState
     CoreGraphics::ResourceTableId frameResourceTable;
 
     Util::Array<Ptr<CoreGraphics::RenderEventHandler> > eventHandlers;
-
-    Memory::RangeAllocator vertexAllocator;
-    CoreGraphics::BufferId vertexBuffer;
 
     bool isOpen : 1;
     bool inNotifyEventHandlers : 1;
@@ -233,13 +228,6 @@ void DelayedDeleteDescriptorSet(const CoreGraphics::ResourceTableId id);
 uint AllocateQueries(const CoreGraphics::QueryType type, uint numQueries);
 /// Copy query results to buffer
 void FinishQueries(const CoreGraphics::CmdBufferId cmdBuf, const CoreGraphics::QueryType type, IndexT start, SizeT count);
-
-/// Allocate vertices from the global vertex pool
-uint AllocateVertices(const SizeT numVertices, const SizeT vertexSize);
-/// Deallocate vertices
-void DeallocateVertices(uint offset);
-/// Get vertex buffer 
-const CoreGraphics::BufferId GetVertexBuffer();
 
 /// Swap
 void Swap(IndexT i);

--- a/code/render/coregraphics/legacy/nvx2streamreader.cc
+++ b/code/render/coregraphics/legacy/nvx2streamreader.cc
@@ -9,7 +9,6 @@
 #include "resources/resourceserver.h"
 #include "coregraphics/config.h"
 #include "coregraphics/indextype.h"
-#include "coregraphics/graphicsdevice.h"
 
 #if NEBULA_LEGACY_SUPPORT
 namespace Legacy
@@ -29,10 +28,10 @@ Nvx2StreamReader::Nvx2StreamReader() :
     access(CoreGraphics::GpuBufferTypes::AccessNone),
     rawMode(false),
     mapPtr(0),
-    ibo(InvalidBufferId),
-    vbo(InvalidBufferId),
-    layout(InvalidVertexLayoutId),
-    copySourceFlag(false),
+	ibo(InvalidBufferId),
+	vbo(InvalidBufferId),
+	layout(InvalidVertexLayoutId),
+	copySourceFlag(false),
     groupDataPtr(nullptr),
     vertexDataPtr(nullptr),
     indexDataPtr(nullptr),
@@ -93,8 +92,8 @@ Nvx2StreamReader::Open(const Resources::ResourceName& name)
             this->SetupVertexBuffer(name);
             this->SetupIndexBuffer(name);
             this->UpdateGroupBoundingBoxes();
-            stream->MemoryUnmap();
         }
+        if (!this->rawMode) stream->MemoryUnmap();
         return true;
     }
     return false;
@@ -173,7 +172,7 @@ Nvx2StreamReader::ReadPrimitiveGroups()
     {
         // setup a primitive group object
         PrimitiveGroup primGroup;
-        primGroup.SetBaseVertex(group->firstVertex);
+        //primGroup.SetBaseVertex(group->firstVertex);
         primGroup.SetNumVertices(group->numVertices);
         primGroup.SetBaseIndex(group->firstTriangle * 3);
         primGroup.SetNumIndices(group->numTriangles * 3);
@@ -198,7 +197,7 @@ Nvx2StreamReader::SetupVertexComponents()
         VertexComponent::SemanticName sem;
         VertexComponent::Format fmt;
         IndexT index = 0;
-        if (this->vertexComponentMask & (1<<i))
+        if (vertexComponentMask & (1<<i))
         {
             switch (1<<i)
             {
@@ -224,7 +223,7 @@ Nvx2StreamReader::SetupVertexComponents()
                 case N2JIndices:     sem = VertexComponent::SkinJIndices; fmt = VertexComponent::Float4; break;
                 case N2JIndicesUB4:  sem = VertexComponent::SkinJIndices; fmt = VertexComponent::UByte4; break;
                 default:
-                    n_error("Invalid Nebula VertexComponent in Nvx2StreamReader::SetupVertexComponents");
+                    n_error("Invalid Nebula2 VertexComponent in Nvx2StreamReader::SetupVertexComponents");
                     sem = VertexComponent::Position;
                     fmt = VertexComponent::Float3;
                     break;
@@ -283,33 +282,16 @@ Nvx2StreamReader::SetupVertexBuffer(const Resources::ResourceName& name)
     n_assert(this->numVertices > 0);    
     n_assert(this->vertexComponents.Size() > 0);
 
-    // Create temporary host-to-device buffer to copy from Host memory to GPU
-    BufferCreateInfo tempBufInfo;
-    tempBufInfo.size = this->numVertices;
-    tempBufInfo.elementSize = VertexLayoutGetSize(this->layout);
-    tempBufInfo.usageFlags = CoreGraphics::TransferBufferSource;
-    tempBufInfo.mode = CoreGraphics::HostToDevice;
-    CoreGraphics::BufferId tempBuf = CoreGraphics::CreateBuffer(tempBufInfo);
-    this->vbo = CoreGraphics::GetVertexBuffer();
-
-    // Do the actual copy
-    void* mem = CoreGraphics::BufferMap(tempBuf);
-    memcpy(mem, this->vertexDataPtr, this->vertexDataSize);
-
-    // Allocate vertices from global repository 
-    this->baseOffset = CoreGraphics::AllocateVertices(this->numVertices, tempBufInfo.elementSize);
-    CoreGraphics::BufferFlush(tempBuf, 0, this->vertexDataSize);
-
-    // Copy from host mappable buffer to device local buffer
-    CoreGraphics::BufferCopy from, to;
-    from.offset = 0;
-    to.offset = this->baseOffset;
-    CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockGraphicsSetupCommandBuffer();
-    CoreGraphics::CmdCopy(cmdBuf, tempBuf, { from }, this->vbo, { to }, this->vertexDataSize);
-    CoreGraphics::UnlockGraphicsSetupCommandBuffer();
-
-    // Delete temporary buffer
-    CoreGraphics::DelayedDeleteBuffer(tempBuf);
+    // create vertex buffer
+    BufferCreateInfo vboInfo;
+    vboInfo.name = name;
+    vboInfo.size = this->numVertices;
+    vboInfo.elementSize = VertexLayoutGetSize(this->layout); 
+    vboInfo.mode = CoreGraphics::DeviceLocal;
+    vboInfo.usageFlags = CoreGraphics::VertexBuffer | (this->copySourceFlag ? CoreGraphics::TransferBufferSource : 0);
+	vboInfo.data = this->vertexDataPtr;
+	vboInfo.dataSize = this->vertexDataSize;
+	this->vbo = CreateBuffer(vboInfo);
 }
 
 //------------------------------------------------------------------------------
@@ -331,9 +313,9 @@ Nvx2StreamReader::SetupIndexBuffer(const Resources::ResourceName& name)
     iboInfo.elementSize = CoreGraphics::IndexType::SizeOf(CoreGraphics::IndexType::Index32);
     iboInfo.mode = CoreGraphics::DeviceLocal;
     iboInfo.usageFlags = CoreGraphics::IndexBuffer | (this->copySourceFlag ? CoreGraphics::TransferBufferSource : 0);
-    iboInfo.data = this->indexDataPtr;
-    iboInfo.dataSize = this->indexDataSize;
-    this->ibo = CreateBuffer(iboInfo);
+	iboInfo.data = this->indexDataPtr;
+	iboInfo.dataSize = this->indexDataSize;
+	this->ibo = CreateBuffer(iboInfo);
 }
 
 } // namespace Legacy

--- a/code/render/coregraphics/legacy/nvx2streamreader.h
+++ b/code/render/coregraphics/legacy/nvx2streamreader.h
@@ -66,8 +66,6 @@ public:
     SizeT GetVertexWidth() const;
     /// get number of edges
     SizeT GetNumEdges() const;
-    /// Get base offset
-    SizeT GetBaseOffset() const;
     /// get vertex components
     const Util::Array<CoreGraphics::VertexComponent>& GetVertexComponents() const;
 
@@ -144,7 +142,6 @@ private:
     uint numIndices;
     uint numEdges;
     uint vertexComponentMask;
-    uint baseOffset;
     Util::Array<CoreGraphics::VertexComponent> vertexComponents;   
 };
 
@@ -245,15 +242,6 @@ inline SizeT
 Nvx2StreamReader::GetNumEdges() const
 {
     return this->numEdges;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-inline SizeT 
-Nvx2StreamReader::GetBaseOffset() const
-{
-    return this->baseOffset;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/legacy/nvx2streamreader.h
+++ b/code/render/coregraphics/legacy/nvx2streamreader.h
@@ -66,6 +66,8 @@ public:
     SizeT GetVertexWidth() const;
     /// get number of edges
     SizeT GetNumEdges() const;
+    /// Get base offset
+    SizeT GetBaseOffset() const;
     /// get vertex components
     const Util::Array<CoreGraphics::VertexComponent>& GetVertexComponents() const;
 
@@ -142,6 +144,7 @@ private:
     uint numIndices;
     uint numEdges;
     uint vertexComponentMask;
+    uint baseOffset;
     Util::Array<CoreGraphics::VertexComponent> vertexComponents;   
 };
 
@@ -242,6 +245,15 @@ inline SizeT
 Nvx2StreamReader::GetNumEdges() const
 {
     return this->numEdges;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+inline SizeT 
+Nvx2StreamReader::GetBaseOffset() const
+{
+    return this->baseOffset;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/memorymeshcache.cc
+++ b/code/render/coregraphics/memorymeshcache.cc
@@ -59,31 +59,6 @@ MemoryMeshCache::Unload(const Resources::ResourceId id)
 //------------------------------------------------------------------------------
 /**
 */
-void
-MemoryMeshCache::BindMesh(const MeshId id, IndexT prim, const CoreGraphics::CmdBufferId cmdBuf)
-{
-#if _DEBUG
-    n_assert(id.resourceType == MeshIdType);
-#endif
-    __LockName(this->Allocator(), lock, Util::ArrayAllocatorAccess::Read);
-    MeshCreateInfo& inf = this->allocator.Get<0>(id.resourceId);
-
-    // setup pipeline (a bit ugly)
-    CoreGraphics::CmdSetPrimitiveTopology(cmdBuf, inf.topology);
-    CoreGraphics::CmdSetVertexLayout(cmdBuf, inf.primitiveGroups[prim].GetVertexLayout());
-
-    // bind vertex buffers
-    IndexT i;
-    for (i = 0; i < inf.streams.Size(); i++)
-        CoreGraphics::CmdSetVertexBuffer(cmdBuf, inf.streams[i].index, inf.streams[i].vertexBuffer, 0);
-
-    if (inf.indexBuffer != CoreGraphics::InvalidBufferId)
-        CoreGraphics::CmdSetIndexBuffer(cmdBuf, inf.indexBuffer, 0);
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
 const Util::Array<CoreGraphics::PrimitiveGroup>&
 MemoryMeshCache::GetPrimitiveGroups(const MeshId id)
 {
@@ -101,6 +76,17 @@ MemoryMeshCache::GetVertexBuffer(const MeshId id, const IndexT stream)
     __LockName(this->Allocator(), lock, Util::ArrayAllocatorAccess::Read);
     const MeshCreateInfo& inf = this->allocator.Get<0>(id.resourceId);
     return inf.streams[stream].vertexBuffer;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+const uint
+MemoryMeshCache::GetVertexOffset(const MeshId id, const IndexT stream)
+{
+    __LockName(this->Allocator(), lock, Util::ArrayAllocatorAccess::Read);
+    const MeshCreateInfo& inf = this->allocator.Get<0>(id.resourceId);
+    return inf.streams[stream].offset;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/memorymeshcache.h
+++ b/code/render/coregraphics/memorymeshcache.h
@@ -30,12 +30,12 @@ public:
     /// unload resource
     void Unload(const Resources::ResourceId id);
 
-    /// bind mesh
-    void BindMesh(const MeshId id, IndexT prim, const CoreGraphics::CmdBufferId cmdBuf);
     /// get primitive groups from mesh
     const Util::Array<CoreGraphics::PrimitiveGroup>& GetPrimitiveGroups(const MeshId id);
     /// get vertex buffer
     const BufferId GetVertexBuffer(const MeshId id, const IndexT stream);
+    /// Get vertex offset
+    const uint GetVertexOffset(const MeshId id, const IndexT stream);
     /// get index buffer
     const BufferId GetIndexBuffer(const MeshId id);
     /// get topology

--- a/code/render/coregraphics/mesh.cc
+++ b/code/render/coregraphics/mesh.cc
@@ -64,6 +64,15 @@ MeshGetVertexBuffer(const MeshId id, const IndexT stream)
 //------------------------------------------------------------------------------
 /**
 */
+const uint
+MeshGetVertexOffset(const MeshId id, const IndexT stream)
+{
+    return meshCache->GetVertexOffset(id, stream);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
 const BufferId
 MeshGetIndexBuffer(const MeshId id)
 {

--- a/code/render/coregraphics/mesh.cc
+++ b/code/render/coregraphics/mesh.cc
@@ -37,15 +37,6 @@ DestroyMesh(const MeshId id)
 //------------------------------------------------------------------------------
 /**
 */
-void
-MeshBind(const CoreGraphics::CmdBufferId cmdBuf, IndexT prim, const MeshId id)
-{
-    meshCache->BindMesh(id, prim, cmdBuf);
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
 const Util::Array<CoreGraphics::PrimitiveGroup>&
 MeshGetPrimitiveGroups(const MeshId id)
 {

--- a/code/render/coregraphics/mesh.h
+++ b/code/render/coregraphics/mesh.h
@@ -28,6 +28,7 @@ struct MeshCreateInfo
     struct Stream
     {
         BufferId vertexBuffer;
+        SizeT offset;
         IndexT index;
     };
 
@@ -51,6 +52,8 @@ void MeshBind(const CoreGraphics::CmdBufferId cmdBuf, IndexT prim, const MeshId 
 const Util::Array<CoreGraphics::PrimitiveGroup>& MeshGetPrimitiveGroups(const MeshId id);
 /// get vertex buffer
 const BufferId MeshGetVertexBuffer(const MeshId id, const IndexT stream);
+/// Get mesh vertex offset
+const uint MeshGetVertexOffset(const MeshId id, const IndexT stream);
 /// get index buffer
 const BufferId MeshGetIndexBuffer(const MeshId id);
 /// get topology

--- a/code/render/coregraphics/mesh.h
+++ b/code/render/coregraphics/mesh.h
@@ -46,8 +46,6 @@ const MeshId CreateMesh(const MeshCreateInfo& info);
 /// destroy mesh
 void DestroyMesh(const MeshId id);
 
-/// Bind mesh
-void MeshBind(const CoreGraphics::CmdBufferId cmdBuf, IndexT prim, const MeshId id);
 /// get number of primitive groups
 const Util::Array<CoreGraphics::PrimitiveGroup>& MeshGetPrimitiveGroups(const MeshId id);
 /// get vertex buffer

--- a/code/render/coregraphics/streammeshcache.cc
+++ b/code/render/coregraphics/streammeshcache.cc
@@ -140,7 +140,7 @@ StreamMeshCache::SetupMeshFromNvx2(const Ptr<Stream>& stream, const Resources::R
         MeshCreateInfo& msh = meshCache->Get<0>(res);
         n_assert(this->GetState(res) == Resources::Resource::Pending);
         auto vertexLayout = CreateVertexLayout({ nvx2Reader->GetVertexComponents() });
-        msh.streams.Append({ nvx2Reader->GetVertexBuffer(), 0 });
+        msh.streams.Append({ nvx2Reader->GetVertexBuffer(), nvx2Reader->GetBaseOffset(), 0 });
         msh.indexBuffer = nvx2Reader->GetIndexBuffer();
         msh.topology = PrimitiveTopology::TriangleList;
         msh.primitiveGroups = nvx2Reader->GetPrimitiveGroups();

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -301,7 +301,7 @@ CmdReset(const CmdBufferId id, const CmdBufferClearInfo& info)
 /**
 */
 void
-CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, SizeT bufferOffset)
+CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, IndexT offsetVertexIndex)
 {
 #if _DEBUG
     CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
@@ -309,7 +309,7 @@ CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics:
 #endif
     VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
-    VkDeviceSize offset = bufferOffset;
+    VkDeviceSize offset = offsetVertexIndex;
     vkCmdBindVertexBuffers(cmdBuf, streamIndex, 1, &buf, &offset);
 }   
 
@@ -336,7 +336,7 @@ CmdSetVertexLayout(const CmdBufferId id, const CoreGraphics::VertexLayoutId& vl)
 /**
 */
 void
-CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, SizeT bufferOffset)
+CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, IndexT offsetIndex)
 {
 #if _DEBUG
     CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
@@ -344,7 +344,7 @@ CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, Si
 #endif
     VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
-    VkDeviceSize offset = bufferOffset;
+    VkDeviceSize offset = offsetIndex;
     IndexType::Code idxType = IndexType::ToIndexType(BufferGetElementSize(buffer));
     VkIndexType vkIdxType = idxType == IndexType::Index16 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
     vkCmdBindIndexBuffer(cmdBuf, buf, offset, vkIdxType);

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -301,7 +301,7 @@ CmdReset(const CmdBufferId id, const CmdBufferClearInfo& info)
 /**
 */
 void
-CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, IndexT offsetVertexIndex)
+CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, SizeT bufferOffset)
 {
 #if _DEBUG
     CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
@@ -309,7 +309,7 @@ CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics:
 #endif
     VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
-    VkDeviceSize offset = offsetVertexIndex;
+    VkDeviceSize offset = bufferOffset;
     vkCmdBindVertexBuffers(cmdBuf, streamIndex, 1, &buf, &offset);
 }   
 
@@ -336,7 +336,7 @@ CmdSetVertexLayout(const CmdBufferId id, const CoreGraphics::VertexLayoutId& vl)
 /**
 */
 void
-CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, IndexT offsetIndex)
+CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, SizeT bufferOffset)
 {
 #if _DEBUG
     CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
@@ -344,7 +344,7 @@ CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, In
 #endif
     VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
-    VkDeviceSize offset = offsetIndex;
+    VkDeviceSize offset = bufferOffset;
     IndexType::Code idxType = IndexType::ToIndexType(BufferGetElementSize(buffer));
     VkIndexType vkIdxType = idxType == IndexType::Index16 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
     vkCmdBindIndexBuffer(cmdBuf, buf, offset, vkIdxType);

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -1030,18 +1030,6 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
 
     state.waitForPresentSemaphore = VK_NULL_HANDLE;
 
-    CoreGraphics::BufferCreateInfo vboInfo;
-    vboInfo.name = "Global Vertex Cache";
-    vboInfo.byteSize = info.globalVertexBufferMemorySize;
-    vboInfo.mode = CoreGraphics::BufferAccessMode::DeviceLocal;
-    vboInfo.queueSupport = CoreGraphics::BufferQueueSupport::GraphicsQueueSupport | CoreGraphics::BufferQueueSupport::ComputeQueueSupport;
-    vboInfo.usageFlags =
-        CoreGraphics::BufferUsageFlag::VertexBuffer
-        | CoreGraphics::BufferUsageFlag::TransferBufferDestination
-        | CoreGraphics::BufferUsageFlag::ReadWriteBuffer;
-    state.vertexBuffer = CoreGraphics::CreateBuffer(vboInfo);
-    state.vertexAllocator.Resize(info.globalVertexBufferMemorySize);
-
     _setup_grouped_timer(state.DebugTimer, "GraphicsDevice");
     _setup_grouped_counter(state.NumImageBytesAllocated, "GraphicsDevice");
     _begin_counter(state.NumImageBytesAllocated);
@@ -1813,35 +1801,6 @@ FinishQueries(const CoreGraphics::CmdBufferId cmdBuf, const CoreGraphics::QueryT
 
     // Finally reset the query pool
     vkCmdResetQueryPool(vkCmd, state.queries[state.currentBufferedFrameIndex].queryPools[type], start, count);
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-uint
-AllocateVertices(const SizeT numVertices, const SizeT vertexSize)
-{
-    IndexT ret;
-    state.vertexAllocator.Alloc(numVertices * vertexSize, 1, ret);
-    return ret;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-void
-DeallocateVertices(uint offset)
-{
-    state.vertexAllocator.Dealloc(offset);
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-const CoreGraphics::BufferId
-GetVertexBuffer()
-{
-    return state.vertexBuffer;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -1030,6 +1030,18 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
 
     state.waitForPresentSemaphore = VK_NULL_HANDLE;
 
+    CoreGraphics::BufferCreateInfo vboInfo;
+    vboInfo.name = "Global Vertex Cache";
+    vboInfo.byteSize = info.globalVertexBufferMemorySize;
+    vboInfo.mode = CoreGraphics::BufferAccessMode::DeviceLocal;
+    vboInfo.queueSupport = CoreGraphics::BufferQueueSupport::GraphicsQueueSupport | CoreGraphics::BufferQueueSupport::ComputeQueueSupport;
+    vboInfo.usageFlags =
+        CoreGraphics::BufferUsageFlag::VertexBuffer
+        | CoreGraphics::BufferUsageFlag::TransferBufferDestination
+        | CoreGraphics::BufferUsageFlag::ReadWriteBuffer;
+    state.vertexBuffer = CoreGraphics::CreateBuffer(vboInfo);
+    state.vertexAllocator.Resize(info.globalVertexBufferMemorySize);
+
     _setup_grouped_timer(state.DebugTimer, "GraphicsDevice");
     _setup_grouped_counter(state.NumImageBytesAllocated, "GraphicsDevice");
     _begin_counter(state.NumImageBytesAllocated);
@@ -1801,6 +1813,35 @@ FinishQueries(const CoreGraphics::CmdBufferId cmdBuf, const CoreGraphics::QueryT
 
     // Finally reset the query pool
     vkCmdResetQueryPool(vkCmd, state.queries[state.currentBufferedFrameIndex].queryPools[type], start, count);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+uint
+AllocateVertices(const SizeT numVertices, const SizeT vertexSize)
+{
+    IndexT ret;
+    state.vertexAllocator.Alloc(numVertices * vertexSize, 1, ret);
+    return ret;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+DeallocateVertices(uint offset)
+{
+    state.vertexAllocator.Dealloc(offset);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+const CoreGraphics::BufferId
+GetVertexBuffer()
+{
+    return state.vertexBuffer;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vk/vkshadercache.cc
+++ b/code/render/coregraphics/vk/vkshadercache.cc
@@ -374,7 +374,9 @@ VkShaderCache::GetConstantBindingsCount(const CoreGraphics::ShaderId id) const
 CoreGraphics::ResourceTableLayoutId
 VkShaderCache::GetResourceTableLayout(const CoreGraphics::ShaderId id, const IndexT group)
 {
-    return Util::Get<1>(this->shaderAlloc.Get<Shader_SetupInfo>(id.resourceId).descriptorSetLayouts[group]);
+    const VkShaderSetupInfo& setupInfo = this->shaderAlloc.Get<Shader_SetupInfo>(id.resourceId);
+    uint layout = setupInfo.descriptorSetLayoutMap[group];
+    return Util::Get<1>(setupInfo.descriptorSetLayouts[layout]);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vk/vkshadercache.cc
+++ b/code/render/coregraphics/vk/vkshadercache.cc
@@ -374,9 +374,7 @@ VkShaderCache::GetConstantBindingsCount(const CoreGraphics::ShaderId id) const
 CoreGraphics::ResourceTableLayoutId
 VkShaderCache::GetResourceTableLayout(const CoreGraphics::ShaderId id, const IndexT group)
 {
-    const VkShaderSetupInfo& setupInfo = this->shaderAlloc.Get<Shader_SetupInfo>(id.resourceId);
-    uint layout = setupInfo.descriptorSetLayoutMap[group];
-    return Util::Get<1>(setupInfo.descriptorSetLayouts[layout]);
+    return Util::Get<1>(this->shaderAlloc.Get<Shader_SetupInfo>(id.resourceId).descriptorSetLayouts[group]);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/graphics/graphicsserver.cc
+++ b/code/render/graphics/graphicsserver.cc
@@ -56,8 +56,9 @@ GraphicsServer::Open()
     this->displayDevice->Open();
 
     CoreGraphics::GraphicsDeviceCreateInfo gfxInfo { 
-        30_MB,                      // Graphics queue constant memory size
+        32_MB,                      // Graphics queue constant memory size
         1_MB,                       // Compute queue constant memory size
+        32_MB,                      // Vertex memory size
         {
             128_MB,                 // Device local memory block size, textures and vertex/index buffers
             32_MB,                  // Memory to use for temporary host buffers which are copied to the GPU

--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -71,9 +71,7 @@ public:
 
     /// get model
     static const Models::ModelId GetModel(const Graphics::ContextEntityId id);
-    /// get model node instances
-    static const Util::Array<Models::NodeType>& GetModelNodeTypes(const Graphics::ContextEntityId id);
-
+     
     struct NodeInstanceState
     {
         CoreGraphics::ResourceTableId resourceTable;

--- a/code/render/models/nodes/characterskinnode.cc
+++ b/code/render/models/nodes/characterskinnode.cc
@@ -48,7 +48,7 @@ CharacterSkinNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag,
     else if (FourCC('SFRG') == fourcc)
     {
         // SkinFragment
-        this->primitiveGroupIndexLoaded = reader->ReadInt();
+        this->primitiveGroupIndex = reader->ReadInt();
         Array<IndexT> jointPalette;
         SizeT numJoints = reader->ReadInt();
         jointPalette.Reserve(numJoints);
@@ -57,7 +57,7 @@ CharacterSkinNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag,
         {
             jointPalette.Append(reader->ReadInt());
         }
-        this->AddFragment(this->primitiveGroupIndexLoaded, jointPalette);
+        this->AddFragment(this->primitiveGroupIndex, jointPalette);
     }
     else
     {

--- a/code/render/models/nodes/characterskinnode.cc
+++ b/code/render/models/nodes/characterskinnode.cc
@@ -48,7 +48,7 @@ CharacterSkinNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag,
     else if (FourCC('SFRG') == fourcc)
     {
         // SkinFragment
-        IndexT primGroupIndex = reader->ReadInt();
+        this->primitiveGroupIndexLoaded = reader->ReadInt();
         Array<IndexT> jointPalette;
         SizeT numJoints = reader->ReadInt();
         jointPalette.Reserve(numJoints);
@@ -57,7 +57,7 @@ CharacterSkinNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag,
         {
             jointPalette.Append(reader->ReadInt());
         }
-        this->AddFragment(primGroupIndex, jointPalette);
+        this->AddFragment(this->primitiveGroupIndexLoaded, jointPalette);
     }
     else
     {
@@ -83,24 +83,12 @@ CharacterSkinNode::OnFinishedLoading()
 //------------------------------------------------------------------------------
 /**
 */
-std::function<void(const CoreGraphics::CmdBufferId)>
-CharacterSkinNode::GetApplyFunction()
-{
-    return [this](const CoreGraphics::CmdBufferId id)
-    {
-        CoreGraphics::MeshBind(id, this->skinFragments[0].primGroupIndex, this->res);
-    };
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
 std::function<const CoreGraphics::PrimitiveGroup()>
 CharacterSkinNode::GetPrimitiveGroupFunction()
 {
     return [this]()
     {
-        return CoreGraphics::MeshGetPrimitiveGroups(this->res)[this->skinFragments[0].primGroupIndex];
+        return this->primGroup;
     };
 }
 

--- a/code/render/models/nodes/characterskinnode.h
+++ b/code/render/models/nodes/characterskinnode.h
@@ -34,8 +34,6 @@ public:
     /// get joint palette of a fragment
     const Util::Array<IndexT>& GetFragmentJointPalette(IndexT fragmentIndex) const;
 
-        /// Get function to apply node 
-    std::function<void(const CoreGraphics::CmdBufferId)> GetApplyFunction() override;
     /// Get function to fetch primitive group
     std::function<const CoreGraphics::PrimitiveGroup()> GetPrimitiveGroupFunction() override;
 

--- a/code/render/models/nodes/primitivenode.cc
+++ b/code/render/models/nodes/primitivenode.cc
@@ -72,10 +72,10 @@ PrimitiveNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag, con
     bool retval = true;
     if (FourCC('MESH') == fourcc)
     {
-        // get mesh resource
+        // Get mesh resource
         Resources::ResourceName meshName = reader->ReadString();
 
-        // add as pending resource in loader
+        // Load directly, since the model is already loaded on a thread, this is fine
         this->primitiveGroupIndex = 0;
         this->res = Resources::CreateResource(meshName, tag, nullptr, nullptr, true);
 

--- a/code/render/models/nodes/primitivenode.cc
+++ b/code/render/models/nodes/primitivenode.cc
@@ -17,8 +17,7 @@ namespace Models
 /**
 */
 PrimitiveNode::PrimitiveNode() :
-    primitiveGroupIndex(InvalidIndex),
-    primitiveGroupIndexLoaded(0)
+    primitiveGroupIndex(InvalidIndex)
 {
     this->type = PrimitiveNodeType;
     this->bits = HasTransformBit | HasStateBit;
@@ -40,7 +39,15 @@ PrimitiveNode::GetApplyFunction()
 {
     return [this](const CoreGraphics::CmdBufferId id)
     {
-        CoreGraphics::MeshBind(id, this->primitiveGroupIndex, this->res);
+        // setup pipeline (a bit ugly)
+        CoreGraphics::CmdSetPrimitiveTopology(id, this->topology);
+        CoreGraphics::CmdSetVertexLayout(id, this->vertexLayout);
+
+        // bind vertex buffers
+        CoreGraphics::CmdSetVertexBuffer(id, 0, this->vbo, this->vboOffset);
+
+        if (this->ibo != CoreGraphics::InvalidBufferId)
+            CoreGraphics::CmdSetIndexBuffer(id, this->ibo, this->iboOffset);
     };
 }
 
@@ -61,7 +68,7 @@ PrimitiveNode::GetPrimitiveGroupFunction()
 */
 bool
 PrimitiveNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag, const Ptr<IO::BinaryReader>& reader, bool immediate)
-{
+{         
     bool retval = true;
     if (FourCC('MESH') == fourcc)
     {
@@ -70,16 +77,20 @@ PrimitiveNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag, con
 
         // add as pending resource in loader
         this->primitiveGroupIndex = 0;
-        this->res = Resources::CreateResource(meshName, tag, [this](Resources::ResourceId id)
-            {
-                this->res = id;
-                this->primitiveGroupIndex = this->primitiveGroupIndexLoaded;
-            }, nullptr, immediate);
+        this->res = Resources::CreateResource(meshName, tag, nullptr, nullptr, true);
+
+        this->vbo = CoreGraphics::MeshGetVertexBuffer(this->res, 0);
+        this->ibo = CoreGraphics::MeshGetIndexBuffer(this->res);
+        this->topology = CoreGraphics::MeshGetTopology(this->res);
+        this->primGroup = CoreGraphics::MeshGetPrimitiveGroups(this->res)[this->primitiveGroupIndex];
+        this->vertexLayout = this->primGroup.GetVertexLayout();
+        this->vboOffset = CoreGraphics::MeshGetVertexOffset(this->res, 0);
+        this->iboOffset = 0;
     }
     else if (FourCC('PGRI') == fourcc)
     {
         // primitive group index
-        this->primitiveGroupIndexLoaded = reader->ReadUInt();
+        this->primitiveGroupIndex = reader->ReadUInt();
     }
     else
     {

--- a/code/render/models/nodes/primitivenode.cc
+++ b/code/render/models/nodes/primitivenode.cc
@@ -59,7 +59,7 @@ PrimitiveNode::GetPrimitiveGroupFunction()
 {
     return [this]()
     {
-        return CoreGraphics::MeshGetPrimitiveGroups(this->res)[this->primitiveGroupIndex];
+        return this->primGroup;
     };
 }
 

--- a/code/render/models/nodes/primitivenode.h
+++ b/code/render/models/nodes/primitivenode.h
@@ -43,7 +43,12 @@ protected:
 
     CoreGraphics::MeshId res;
     uint16_t primitiveGroupIndex;
-    uint16_t primitiveGroupIndexLoaded;
+
+    CoreGraphics::BufferId vbo, ibo;
+    IndexT vboOffset, iboOffset;
+    CoreGraphics::PrimitiveTopology::Code topology;
+    CoreGraphics::PrimitiveGroup primGroup;
+    CoreGraphics::VertexLayoutId vertexLayout;
 };
 
 } // namespace Models

--- a/code/resource/resources/resourcestreamcache.cc
+++ b/code/resource/resources/resourcestreamcache.cc
@@ -433,10 +433,12 @@ Resources::ResourceStreamCache::CreateResource(const ResourceName& res, const vo
             // if loaded, run callback, otherwise just return id
             success(ret);
         }
-        else if (state == Resource::Failed && failed != nullptr)
+        else if (state == Resource::Failed)
         {
             // if failed, run callback, otherwise just return id
-            failed(ret);
+            if (failed != nullptr)
+                failed(ret);
+            ret.resourceId = this->failResourceId.resourceId;
         }
         else if (state == Resource::Pending)
         {


### PR DESCRIPTION
This PR changes the way we deal with vertex data (not index data yet, but that will come soon too), in order to allow for a single buffer used for all vertices. As well as this prevents any device allocations per mesh being loaded, it also provides a way to bind all vertex data as single a read-write buffer, opening up for ID buffer rendering.

API changes:
CreateGraphicsDeviceInfo has a new member for setting up the vertex cache size. 
MeshBind is gone. Instead, a mesh is a resource and should have it's resources fetched where necessary, and applied after.

Fixes:
Resource loading on a previously failed resource without async has been fixed.
In some scenarios, resource table layouts were incorrectly fetched.
Meshes are loaded together with models in sequence. This doesn't mean they are loaded on the main thread, but rather they are loaded with the same job that loads the model itself, which is async. 
