### PR TITLE
Bug/per instance constants

### DIFF
--- a/code/foundation/io/cache/streamcache.cc
+++ b/code/foundation/io/cache/streamcache.cc
@@ -66,7 +66,7 @@ StreamCache::OpenStream(IO::URI const& uri, Core::Rtti const& rtti)
     stream->SetAccessMode(Stream::ReadAccess);
     if (stream->Open())
     {
-        CacheEntry & entry = this->streams.AddUnique(uriString);
+        CacheEntry & entry = this->streams.Emplace(uriString);
         entry.stream = stream;
         entry.useCount = 0;
         entry.buffer = stream->Map();

--- a/code/foundation/util/array.h
+++ b/code/foundation/util/array.h
@@ -713,7 +713,7 @@ Array<TYPE>::AppendArray(const Array<TYPE>& rhs)
     IndexT i;
     for (i = 0; i < rhs.count; i++)
     {
-        this->elements[this->count + i] = std::forward<TYPE>(rhs.elements[i]);
+        this->elements[this->count + i] = rhs.elements[i];
     }
     this->count += rhs.count;
 }
@@ -735,7 +735,7 @@ Array<TYPE>::AppendArray(const TYPE* arr, const SizeT count)
     IndexT i;
     for (i = 0; i < count; i++)
     {
-        this->elements[this->count + i] = std::forward<const TYPE>(arr[i]);
+        this->elements[this->count + i] = arr[i];
     }
     this->count += count;
 }

--- a/code/foundation/util/array.h
+++ b/code/foundation/util/array.h
@@ -693,7 +693,7 @@ Array<TYPE>::Append(TYPE&& elm)
 #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements);
 #endif
-    this->elements[this->count++] = std::forward<TYPE>(elm);
+    this->elements[this->count++] = std::move(elm);
 }
 
 //------------------------------------------------------------------------------

--- a/code/foundation/util/dictionary.h
+++ b/code/foundation/util/dictionary.h
@@ -61,8 +61,8 @@ public:
     IndexT Add(const KeyValuePair<KEYTYPE, VALUETYPE>& kvp);
     /// add a key and associated value
     IndexT Add(const KEYTYPE& key, const VALUETYPE& value);
-    /// creates a new entry of VALUETYPE if key does not exist, 
-    VALUETYPE& AddUnique(const KEYTYPE& key);
+    /// creates a new entry of VALUETYPE if key does not exist, or returns the existing element
+    VALUETYPE& Emplace(const KEYTYPE& key);
     /// end a bulk insert (this will sort the internal array)
     void EndBulkAdd();
     /// merge two dictionaries
@@ -302,7 +302,7 @@ Dictionary<KEYTYPE, VALUETYPE>::Add(const KEYTYPE& key, const VALUETYPE& value)
 */
 template<class KEYTYPE, class VALUETYPE>
 inline VALUETYPE&
-Dictionary<KEYTYPE, VALUETYPE>::AddUnique(const KEYTYPE& key)
+Dictionary<KEYTYPE, VALUETYPE>::Emplace(const KEYTYPE& key)
 {
     IndexT i = this->FindIndex(key);
     if (i == InvalidIndex)

--- a/code/foundation/util/hashtable.h
+++ b/code/foundation/util/hashtable.h
@@ -72,7 +72,7 @@ public:
     /// add a key and associated value
     IndexT Add(const KEYTYPE& key, const VALUETYPE& value);
     /// adds element only if it doesn't exist, and return reference to it
-    VALUETYPE& AddUnique(const KEYTYPE& key);
+    VALUETYPE& Emplace(const KEYTYPE& key);
     /// end bulk adding, which sorts all affected tables
     void EndBulkAdd();
     /// merge two dictionaries
@@ -441,7 +441,7 @@ HashTable<KEYTYPE, VALUETYPE, TABLE_SIZE, STACK_SIZE>::Add(const KEYTYPE& key, c
 */
 template<class KEYTYPE, class VALUETYPE, int TABLE_SIZE, int STACK_SIZE>
 VALUETYPE&
-HashTable<KEYTYPE, VALUETYPE, TABLE_SIZE, STACK_SIZE>::AddUnique(const KEYTYPE& key)
+HashTable<KEYTYPE, VALUETYPE, TABLE_SIZE, STACK_SIZE>::Emplace(const KEYTYPE& key)
 {
     // get hash code from key, trim to capacity
     uint32_t hashIndex = GetHashCode<KEYTYPE>(key);

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -172,6 +172,8 @@ void SetFrameResourceTable(const CoreGraphics::ResourceTableId table);
 /// Get frame resoure table
 CoreGraphics::ResourceTableId GetFrameResourceTable();
 
+typedef uint ConstantBufferOffset;
+
 /// Unlock constants
 void UnlockConstantUpdates();
 /// Allocate range of graphics memory and set data, return offset (thread safe)
@@ -179,30 +181,34 @@ template<class TYPE> uint SetGraphicsConstants(const TYPE& data);
 /// Allocate range of graphics memory and set data as an array of elements, return offset  (thread safe)
 template<class TYPE> uint SetGraphicsConstants(const TYPE* data, SizeT elements);
 /// Set graphics constants based on pre-allocated memory  (thread safe)
-template<class TYPE> void SetGraphicsConstants(uint offset, const TYPE& data);
+template<class TYPE> void SetGraphicsConstants(ConstantBufferOffset offset, const TYPE& data);
+/// Set graphics constants based on pre-allocated memory  (thread safe)
+void SetGraphicsConstants(uint offset, const void* data, SizeT bytes);
 /// Allocate range of compute memory and set data, return offset  (thread safe)
 template<class TYPE> uint SetComputeConstants(const TYPE& data);
 /// Allocate range of graphics memory and set data as an array of elements, return offset (thread safe)
 template<class TYPE> uint SetComputeConstants(const TYPE* data, SizeT elements);
 /// Set graphics constants based on pre-allocated memory (thread safe)
-template<class TYPE> void SetComputeConstants(uint offset, const TYPE& data);
+template<class TYPE> void SetComputeConstants(ConstantBufferOffset offset, const TYPE& data);
+/// Set graphics constants based on pre-allocated memory  (thread safe)
+void SetComputeConstants(uint offset, const void* data, SizeT bytes);
 /// Lock constant updates
 void LockConstantUpdates();
 
 /// allocate range of graphics memory and set data, return offset
 int SetGraphicsConstantsInternal(const void* data, SizeT size);
 /// use pre-allocated range of memory to update graphics constants
-void SetGraphicsConstantsInternal(uint offset, const void* data, SizeT size);
+void SetGraphicsConstantsInternal(ConstantBufferOffset offset, const void* data, SizeT size);
 /// allocate range of compute memory and set data, return offset
 int SetComputeConstantsInternal(const void* data, SizeT size);
 /// use pre-allocated range of memory to update compute constants
-void SetComputeConstantsInternal(uint offset, const void* data, SizeT size);
+void SetComputeConstantsInternal(ConstantBufferOffset offset, const void* data, SizeT size);
 /// reserve range of graphics constant buffer memory and return offset
-uint AllocateGraphicsConstantBufferMemory(uint size);
+ConstantBufferOffset AllocateGraphicsConstantBufferMemory(uint size);
 /// return id to global graphics constant buffer
 CoreGraphics::BufferId GetGraphicsConstantBuffer();
 /// reserve range of compute constant buffer memory and return offset
-uint AllocateComputeConstantBufferMemory(uint size);
+ConstantBufferOffset AllocateComputeConstantBufferMemory(uint size);
 /// return id to global compute constant buffer
 CoreGraphics::BufferId GetComputeConstantBuffer();
 /// Flush constants for queue type, do this before recording any commands doing draw or dispatch
@@ -290,7 +296,7 @@ void QueueInsertMarker(const CoreGraphics::QueueType queue, const Math::vec4& co
 /**
 */
 template<class TYPE>
-inline uint
+inline ConstantBufferOffset
 SetGraphicsConstants(const TYPE& data)
 {
     return SetGraphicsConstantsInternal(&data, sizeof(TYPE));
@@ -300,7 +306,7 @@ SetGraphicsConstants(const TYPE& data)
 /**
 */
 template<class TYPE>
-inline uint
+inline ConstantBufferOffset
 SetGraphicsConstants(const TYPE* data, SizeT elements)
 {
     return SetGraphicsConstantsInternal(data, sizeof(TYPE) * elements);
@@ -311,16 +317,25 @@ SetGraphicsConstants(const TYPE* data, SizeT elements)
 */
 template<class TYPE>
 inline void
-SetGraphicsConstants(uint offset, const TYPE& data)
+SetGraphicsConstants(ConstantBufferOffset offset, const TYPE& data)
 {
-    return SetGraphicsConstantsInternal(offset, &data, sizeof(TYPE));
+    SetGraphicsConstantsInternal(offset, &data, sizeof(TYPE));
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+inline void
+SetGraphicsConstants(ConstantBufferOffset offset, const void* data, SizeT bytes)
+{
+    SetGraphicsConstantsInternal(offset, data, bytes);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 template<class TYPE>
-inline uint
+inline ConstantBufferOffset
 SetComputeConstants(const TYPE& data)
 {
     return SetComputeConstantsInternal(&data, sizeof(TYPE));
@@ -330,21 +345,29 @@ SetComputeConstants(const TYPE& data)
 /**
 */
 template<class TYPE> 
-inline uint 
+inline ConstantBufferOffset
 SetComputeConstants(const TYPE* data, SizeT elements)
 {
     return SetComputeConstantsInternal(data, sizeof(TYPE) * elements);
 }
-
 
 //------------------------------------------------------------------------------
 /**
 */
 template<class TYPE>
 inline void 
-SetComputeConstants(uint offset, const TYPE& data)
+SetComputeConstants(ConstantBufferOffset offset, const TYPE& data)
 {
-    return SetComputeConstantsInternal(offset, &data, sizeof(TYPE));
+    SetComputeConstantsInternal(offset, &data, sizeof(TYPE));
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+inline void
+SetComputeConstants(ConstantBufferOffset offset, const void* data, SizeT bytes)
+{
+    SetComputeConstantsInternal(offset, data, bytes);
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkshader.cc
+++ b/code/render/coregraphics/vk/vkshader.cc
@@ -128,7 +128,7 @@ VkShaderSetup(
         {
         // add to resource map
         resourceSlotMapping.Add(block->name.c_str(), block->binding);
-        ResourceTableLayoutCreateInfo& rinfo = layoutCreateInfos.AddUnique(block->set);
+        ResourceTableLayoutCreateInfo& rinfo = layoutCreateInfos.Emplace(block->set);
         numsets = uint_max(numsets, block->set + 1);
 
         if (block->set == NEBULA_DYNAMIC_OFFSET_GROUP || block->set == NEBULA_INSTANCE_GROUP) { cbo.dynamicOffset = true; numUniformDyn += slotsUsed; }
@@ -171,7 +171,7 @@ VkShaderSetup(
         uint32_t slotsUsed = 0;
 
         if (buffer->alignedSize == 0) continue;
-        ResourceTableLayoutCreateInfo& rinfo = layoutCreateInfos.AddUnique(buffer->set);
+        ResourceTableLayoutCreateInfo& rinfo = layoutCreateInfos.Emplace(buffer->set);
         numsets = uint_max(numsets, buffer->set + 1);
 
         if (buffer->HasAnnotation("Visibility"))
@@ -253,7 +253,7 @@ VkShaderSetup(
             smla.slot = sampler->bindingLayout.binding;
             smla.sampler = samp;
 
-            ResourceTableLayoutCreateInfo& rinfo = layoutCreateInfos.AddUnique(sampler->set);
+            ResourceTableLayoutCreateInfo& rinfo = layoutCreateInfos.Emplace(sampler->set);
             rinfo.samplers.Append(smla);
 
             numsets = uint_max(numsets, sampler->set + 1);
@@ -330,7 +330,7 @@ VkShaderSetup(
                     tex.immutableSampler = placeholderSampler;
             }
 
-            ResourceTableLayoutCreateInfo& info = layoutCreateInfos.AddUnique(variable->set);
+            ResourceTableLayoutCreateInfo& info = layoutCreateInfos.Emplace(variable->set);
 
             // if storage, store in rwTextures, otherwise use ordinary textures and figure out if we are to use sampler
             if (storageImage) info.rwTextures.Append(tex);
@@ -347,7 +347,7 @@ VkShaderSetup(
             numInputAttachments += variable->bindingLayout.descriptorCount;
             ia.visibility = PixelShaderVisibility;              // only visible from pixel shaders anyways...
 
-            ResourceTableLayoutCreateInfo& info = layoutCreateInfos.AddUnique(variable->set);
+            ResourceTableLayoutCreateInfo& info = layoutCreateInfos.Emplace(variable->set);
             info.inputAttachments.Append(ia);
 
             numsets = uint_max(numsets, variable->set + 1);

--- a/code/render/frame/frameop.cc
+++ b/code/render/frame/frameop.cc
@@ -129,7 +129,7 @@ FrameOp::AnalyzeAndSetupTextureBarriers(
                 const Util::Tuple<CoreGraphics::PipelineStage, CoreGraphics::PipelineStage> tuple = Util::MakeTuple(stage, dep.stage);
                 CoreGraphics::TextureBarrierInfo barrier{ tex, subres };
 
-                CoreGraphics::BarrierCreateInfo& info = barriers.AddUnique(tuple);
+                CoreGraphics::BarrierCreateInfo& info = barriers.Emplace(tuple);
                 info.name = info.name.IsValid() ? info.name.AsString() + " + " + textureName.AsString() : textureName.AsString();
                 info.domain = domain;
                 info.fromStage = dep.stage;
@@ -239,7 +239,7 @@ FrameOp::AnalyzeAndSetupBufferBarriers(
                 const Util::Tuple<CoreGraphics::PipelineStage, CoreGraphics::PipelineStage> tuple = Util::MakeTuple(stage, dep.stage);
                 CoreGraphics::BufferBarrierInfo barrier{ buf, (IndexT)subres.offset, (IndexT)subres.size };
 
-                CoreGraphics::BarrierCreateInfo& info = barriers.AddUnique(tuple);
+                CoreGraphics::BarrierCreateInfo& info = barriers.Emplace(tuple);
                 info.name = info.name.IsValid() ? info.name.AsString() + " + " + bufferName.AsString() : bufferName.AsString();
                 info.domain = domain;
                 info.fromStage = dep.stage;

--- a/code/render/frame/framescript.cc
+++ b/code/render/frame/framescript.cc
@@ -205,7 +205,7 @@ FrameScript::Build()
         CoreGraphics::TextureId tex = this->textures[i];
         bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(tex));
         CoreGraphics::ImageLayout layout = CoreGraphics::TextureGetDefaultLayout(tex);
-        auto& arr = textures.AddUnique(tex);
+        auto& arr = textures.Emplace(tex);
 
         uint layers = CoreGraphics::TextureGetNumLayers(tex);
         uint mips = CoreGraphics::TextureGetNumMips(tex);

--- a/code/render/materials/material.h
+++ b/code/render/materials/material.h
@@ -17,7 +17,7 @@ namespace Materials
 
 class ShaderConfig;
 ID_32_TYPE(MaterialId);
-ID_32_32_NAMED_TYPE(MaterialInstanceId, surface, instance); // 32 bits instance, 32 bits surface
+ID_32_32_NAMED_TYPE(MaterialInstanceId, material, instance); // 32 bits instance, 32 bits surface
 
 class MaterialCache;
 extern MaterialCache* materialCache;

--- a/code/render/materials/materialcache.h
+++ b/code/render/materials/materialcache.h
@@ -17,7 +17,7 @@ namespace Materials
 
 struct MaterialInfo
 {
-    Resources::ResourceName materialType;
+    Resources::ResourceName shaderConfig;
 };
 
 struct MaterialResourceId;

--- a/code/render/materials/shaderconfig.cc
+++ b/code/render/materials/shaderconfig.cc
@@ -286,8 +286,7 @@ ShaderConfig::GetMaterialTextureIndex(const Util::StringAtom& name)
 const ShaderConfigVariant
 ShaderConfig::GetMaterialConstantDefault(const MaterialId sur, IndexT idx)
 {
-    auto constant = this->constants[idx];
-    return constant.def;
+    return this->constants[idx].def;
 }
 
 //------------------------------------------------------------------------------
@@ -296,7 +295,7 @@ ShaderConfig::GetMaterialConstantDefault(const MaterialId sur, IndexT idx)
 const CoreGraphics::TextureId
 ShaderConfig::GetMaterialTextureDefault(const MaterialId sur, IndexT idx)
 {
-    return (*this->materialAllocator.Get<Textures>(sur.id).Begin())[idx].defaultValue;
+    return this->textures[idx].defaultValue;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/materials/shaderconfig.cc
+++ b/code/render/materials/shaderconfig.cc
@@ -45,33 +45,37 @@ ShaderConfig::Setup()
         IndexT i;
         for (i = 0; i < this->textures.Size(); i++)
         {
-            ShaderConfigTexture tex = this->textures.ValueAtIndex(i);
-            tex.slot = CoreGraphics::ShaderGetResourceSlot(shd, tex.name.AsCharPtr());
-            if (tex.slot != InvalidIndex)
+            const ShaderConfigTexture& tex = this->textures[i];
+            IndexT slot = CoreGraphics::ShaderGetResourceSlot(shd, tex.name.AsCharPtr());
+            if (slot != InvalidIndex)
             {
-                this->texturesByBatch[*it.val].Add(tex.name, tex);
+                ShaderConfigBatchTexture batchTex;
+                batchTex.slot = slot;
+                this->texturesByBatch[*it.val].Append(batchTex);
             }
             else
             {
-                this->texturesByBatch[*it.val].Add(tex.name, { tex.name, CoreGraphics::InvalidTextureId, CoreGraphics::InvalidTextureType, false, InvalidIndex });
+                this->texturesByBatch[*it.val].Append({ InvalidIndex });
             }
         }
 
         for (i = 0; i < this->constants.Size(); i++)
         {
-            ShaderConfigConstant constant = this->constants.ValueAtIndex(i);
-            constant.slot = CoreGraphics::ShaderGetConstantSlot(shd, constant.name);
+            const ShaderConfigConstant& constant = this->constants[i];
+            IndexT slot = CoreGraphics::ShaderGetConstantSlot(shd, constant.name);
             
             // only bind if there is a binding
-            if (constant.slot != -1)
+            if (slot != -1)
             {
-                constant.offset = CoreGraphics::ShaderGetConstantBinding(shd, constant.name.AsCharPtr());
-                constant.group = CoreGraphics::ShaderGetConstantGroup(shd, constant.name);
-                this->constantsByBatch[*it.val].Add(constant.name, constant);
+                ShaderConfigBatchConstant batchConstant;
+                batchConstant.slot = slot;
+                batchConstant.offset = CoreGraphics::ShaderGetConstantBinding(shd, constant.name.AsCharPtr());
+                batchConstant.group = CoreGraphics::ShaderGetConstantGroup(shd, constant.name);
+                this->constantsByBatch[*it.val].Append(batchConstant);
             }
             else
             {
-                this->constantsByBatch[*it.val].Add(constant.name, { constant.name, constant.def, nullptr, nullptr, false, InvalidIndex, InvalidIndex, InvalidIndex });
+                this->constantsByBatch[*it.val].Append({ InvalidIndex, InvalidIndex, InvalidIndex });
             }
         }
 
@@ -83,18 +87,18 @@ ShaderConfig::Setup()
 /**
 */
 MaterialId
-ShaderConfig::CreateSurface()
+ShaderConfig::CreateMaterial()
 {
-    Ids::Id32 sur = this->surfaceAllocator.Alloc();
+    Ids::Id32 sur = this->materialAllocator.Alloc();
 
     // resize all arrays
-    this->surfaceAllocator.Get<SurfaceTable>(sur).Resize(this->batchToIndexMap.Size()); // surface tables
-    this->surfaceAllocator.Get<InstanceTable>(sur).Resize(this->batchToIndexMap.Size()); // instance tables
-    this->surfaceAllocator.Get<SurfaceBuffers>(sur).Resize(this->batchToIndexMap.Size()); // surface buffers
-    this->surfaceAllocator.Get<InstanceBuffers>(sur).Resize(this->batchToIndexMap.Size()); // instance buffers
-    this->surfaceAllocator.Get<Textures>(sur).Resize(this->batchToIndexMap.Size()); // textures
-    this->surfaceAllocator.Get<Constants>(sur).Resize(this->batchToIndexMap.Size()); // constants
-    
+    this->materialAllocator.Get<MaterialTable>(sur).Resize(this->batchToIndexMap.Size()); // surface tables
+    this->materialAllocator.Get<InstanceTable>(sur).Resize(this->batchToIndexMap.Size()); // instance tables
+    this->materialAllocator.Get<MaterialBuffers>(sur).Resize(this->batchToIndexMap.Size()); // surface buffers
+    this->materialAllocator.Get<InstanceBuffers>(sur).Resize(this->batchToIndexMap.Size()); // instance buffers
+    this->materialAllocator.Get<Textures>(sur).Resize(this->batchToIndexMap.Size()); // textures
+    this->materialAllocator.Get<Constants>(sur).Resize(this->batchToIndexMap.Size()); // constants
+
     // go through all batches
     auto batchIt = this->batchToIndexMap.Begin();
     while (batchIt != this->batchToIndexMap.End())
@@ -109,19 +113,20 @@ ShaderConfig::CreateSurface()
         CoreGraphics::ResourceTableId surfaceTable = CoreGraphics::ShaderCreateResourceTable(shd, NEBULA_BATCH_GROUP, 256);
         if (surfaceTable != CoreGraphics::InvalidResourceTableId)
             CoreGraphics::ObjectSetName(surfaceTable, Util::String::Sprintf("Material '%s' batch table", this->name.AsCharPtr()).AsCharPtr());
-        this->surfaceAllocator.Get<SurfaceTable>(sur)[*batchIt.val] = surfaceTable;
+        this->materialAllocator.Get<MaterialTable>(sur)[*batchIt.val] = surfaceTable;
 
         CoreGraphics::ResourceTableId instanceTable = CoreGraphics::ShaderCreateResourceTable(shd, NEBULA_INSTANCE_GROUP, 256);
         if (instanceTable != CoreGraphics::InvalidResourceTableId)
             CoreGraphics::ObjectSetName(instanceTable, Util::String::Sprintf("Material '%s' instance table", this->name.AsCharPtr()).AsCharPtr());
-        this->surfaceAllocator.Get<InstanceTable>(sur)[*batchIt.val] = instanceTable;
+        this->materialAllocator.Get<InstanceTable>(sur)[*batchIt.val] = instanceTable;
         
         // get constant buffer count
         SizeT numBuffers = CoreGraphics::ShaderGetConstantBufferCount(shd);
 
         // get arrays to pre-allocated buffers
-        Util::Array<Util::Tuple<IndexT, CoreGraphics::BufferId>>& surfaceBuffers = this->surfaceAllocator.Get<SurfaceBuffers>(sur)[*batchIt.val];
-        Util::Array<Util::Tuple<IndexT, void*, SizeT>>& instanceBuffers = this->surfaceAllocator.Get<InstanceBuffers>(sur)[*batchIt.val];
+        Util::Array<Util::Tuple<IndexT, CoreGraphics::BufferId>>& surfaceBuffers = this->materialAllocator.Get<MaterialBuffers>(sur)[*batchIt.val];
+        Util::Tuple<IndexT, SizeT>& instanceBuffer = this->materialAllocator.Get<InstanceBuffers>(sur)[*batchIt.val];
+        instanceBuffer = Util::MakeTuple(InvalidIndex, 0);
 
         // create instance of constant buffers
         IndexT j;
@@ -142,38 +147,33 @@ ShaderConfig::CreateSurface()
             }			
             else if (group == NEBULA_INSTANCE_GROUP && instanceTable != CoreGraphics::InvalidResourceTableId)
             {
+                n_assert2(Util::Get<0>(instanceBuffer) == InvalidIndex, "Only one per-instance constant buffer can be present");
                 CoreGraphics::BufferId buf = CoreGraphics::GetGraphicsConstantBuffer();
                 if (buf != CoreGraphics::InvalidBufferId)
                 {
                     SizeT bufSize = CoreGraphics::ShaderGetConstantBufferSize(shd, j);
-                    CoreGraphics::ResourceTableSetConstantBuffer(instanceTable, { buf, slot, 0, true, false, bufSize, 0 });
-
-                    // allocate new intermediate buffer, which will be copied to the constant memory on apply
-                    byte* buf = n_new_array(byte, bufSize);
+                    CoreGraphics::ResourceTableSetConstantBuffer(instanceTable, { buf, slot, 0, false, true, bufSize, 0 });
 
                     // add to surface
-                    instanceBuffers.Append(Util::MakeTuple(slot, buf, bufSize));
+                    instanceBuffer = Util::MakeTuple(slot, bufSize);
                 }
             }
         }
 
-        // setup textures
-        const Util::Dictionary<Util::StringAtom, ShaderConfigTexture>& textures = this->texturesByBatch[*batchIt.val];
-        if (surfaceTable != CoreGraphics::InvalidResourceTableId) 
-            for (j = 0; j < textures.Size(); j++)
-            {
-                const ShaderConfigTexture& tex = textures.ValueAtIndex(j);
-                SurfaceTexture surTex;
-                surTex.slot = tex.slot;
-                surTex.defaultValue = tex.defaultValue;
-                if (tex.slot != InvalidIndex)
-                    CoreGraphics::ResourceTableSetTexture(surfaceTable, { tex.defaultValue, tex.slot, 0, CoreGraphics::InvalidSamplerId, false });
+        // Setup textures
+        const Util::Array<ShaderConfigBatchTexture>& textures = this->texturesByBatch[*batchIt.val];
+        for (j = 0; j < textures.Size(); j++)
+        {
+            const ShaderConfigTexture& baseTex = this->textures[j];
+            const ShaderConfigBatchTexture& tex = textures[j];
+            MaterialTexture surTex;
+            surTex.slot = tex.slot;
+            surTex.defaultValue = baseTex.defaultValue;
+            if (tex.slot != InvalidIndex)
+                CoreGraphics::ResourceTableSetTexture(surfaceTable, { baseTex.defaultValue, tex.slot, 0, CoreGraphics::InvalidSamplerId, false });
 
-                if (batchIt == this->batchToIndexMap.Begin())
-                    this->surfaceAllocator.Get<TextureMap>(sur).Add(tex.name, this->surfaceAllocator.Get<Textures>(sur)[*batchIt.val].Size());
-
-                this->surfaceAllocator.Get<Textures>(sur)[*batchIt.val].Append(surTex);
-            }
+            this->materialAllocator.Get<Textures>(sur)[*batchIt.val].Append(surTex);
+        }
 
         // update tables
         if (surfaceTable != CoreGraphics::InvalidResourceTableId)
@@ -182,18 +182,20 @@ ShaderConfig::CreateSurface()
         if (instanceTable != CoreGraphics::InvalidResourceTableId)
             CoreGraphics::ResourceTableCommitChanges(instanceTable);
 
-        const Util::Dictionary<Util::StringAtom, ShaderConfigConstant>& constants = this->constantsByBatch[*batchIt.val];
+        const Util::Array<ShaderConfigBatchConstant>& constants = this->constantsByBatch[*batchIt.val];
         for (j = 0; j < constants.Size(); j++)
         {
-            const ShaderConfigConstant& constant = constants.ValueAtIndex(j);
-            SurfaceConstant surConst;
-            surConst.defaultValue = constant.def;
+            const ShaderConfigConstant& baseConstant = this->constants[j];
+            const ShaderConfigBatchConstant& constant = constants[j];
+            MaterialConstant surConst;
+            surConst.defaultValue = baseConstant.def;
             surConst.binding = constant.offset;
             surConst.bufferIndex = InvalidIndex;
             surConst.instanceConstant = false;
             if (constant.group == NEBULA_BATCH_GROUP)
             {
                 surConst.instanceConstant = false;
+
                 // go through surface-level buffers to find slot which matches
                 IndexT k;
                 for (k = 0; k < surfaceBuffers.Size(); k++)
@@ -208,25 +210,13 @@ ShaderConfig::CreateSurface()
             }
             else if (constant.group == NEBULA_INSTANCE_GROUP)
             {
+                surConst.defaultValue = nullptr;
                 surConst.instanceConstant = true;
-                // go through instance-level buffers to find slot which matches
-                IndexT k;
-                for (k = 0; k < instanceBuffers.Size(); k++)
-                {
-                    if (Util::Get<0>(instanceBuffers[k]) == constant.slot)
-                    {
-                        surConst.bufferIndex = k;
-                        surConst.mem = Util::Get<1>(instanceBuffers[k]);
-                        break;
-                    }
-                }
+                surConst.bufferIndex = 0;
+                surConst.buffer = CoreGraphics::GetGraphicsConstantBuffer();
             }
 
-            if (batchIt == this->batchToIndexMap.Begin())
-                this->surfaceAllocator.Get<ConstantMap>(sur).Add(constant.name, this->surfaceAllocator.Get<Constants>(sur)[*batchIt.val].Size());
-
-            this->surfaceAllocator.Get<Constants>(sur)[*batchIt.val].Append(surConst);
-            
+            this->materialAllocator.Get<Constants>(sur)[*batchIt.val].Append(surConst);
         }
 
         batchIt++;
@@ -239,47 +229,23 @@ ShaderConfig::CreateSurface()
 /**
 */
 void
-ShaderConfig::DestroySurface(MaterialId sur)
+ShaderConfig::DestroyMaterial(MaterialId sur)
 {
-    this->surfaceAllocator.Dealloc(sur.id);
+    this->materialAllocator.Dealloc(sur.id);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 MaterialInstanceId 
-ShaderConfig::CreateSurfaceInstance(const MaterialId id)
+ShaderConfig::CreateMaterialInstance(const MaterialId id)
 {
-    Ids::Id32 inst = this->surfaceInstanceAllocator.Alloc();
+    Ids::Id32 inst = this->materialInstanceAllocator.Alloc();
 
-    this->surfaceInstanceAllocator.Get<SurfaceInstanceConstants>(inst).Resize(this->batchToIndexMap.Size());
-
-    auto batchIt = this->batchToIndexMap.Begin();
-    while (batchIt != this->batchToIndexMap.End())
-    {
-        // get surface level stuff
-        const Util::Array<SurfaceConstant>& constants = this->surfaceAllocator.Get<Constants>(id.id)[*batchIt.val];
-
-        // get instance level stuff
-        Util::FixedArray<SurfaceInstanceConstant>& surfaceInstanceConstants = this->surfaceInstanceAllocator.Get<SurfaceInstanceConstants>(inst)[*batchIt.val];
-
-        const Util::Array<Util::Tuple<IndexT, void*, SizeT>>& buffers = this->surfaceAllocator.Get<InstanceBuffers>(id.id)[*batchIt.val];
-        SizeT numBuffers = buffers.Size();
-        this->surfaceInstanceAllocator.Get<SurfaceInstanceOffsets>(inst).Resize(numBuffers);
-
-        // resize 
-        surfaceInstanceConstants.Resize(constants.Size());
-        for (IndexT i = 0; i < constants.Size(); i++)
-        {
-            surfaceInstanceConstants[i] = { constants[i].binding, constants[i].mem };
-        }
-        batchIt++;
-    }
-    
     // create id
     MaterialInstanceId ret;
     ret.instance = inst;
-    ret.surface = id.id;
+    ret.material = id.id;
     return ret;
 }
 
@@ -287,75 +253,66 @@ ShaderConfig::CreateSurfaceInstance(const MaterialId id)
 /**
 */
 void 
-ShaderConfig::DestroySurfaceInstance(const MaterialInstanceId id)
+ShaderConfig::DestroyMaterialInstance(const MaterialInstanceId id)
 {
-    this->surfaceInstanceAllocator.Dealloc(id.instance);
+    this->materialInstanceAllocator.Dealloc(id.instance);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 IndexT 
-ShaderConfig::GetSurfaceConstantIndex(const MaterialId sur, const Util::StringAtom& name)
+ShaderConfig::GetMaterialConstantIndex(const Util::StringAtom& name)
 {
-    IndexT idx = this->surfaceAllocator.Get<ConstantMap>(sur.id).FindIndex(name);
-    if (idx != InvalidIndex)	return this->surfaceAllocator.Get<ConstantMap>(sur.id).ValueAtIndex(idx);
-    else						return idx;
+    IndexT idx = this->constantLookup.FindIndex(name);
+    if (idx != InvalidIndex)	return this->constantLookup.ValueAtIndex(idx);
+    else						return InvalidIndex;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 IndexT 
-ShaderConfig::GetSurfaceTextureIndex(const MaterialId sur, const Util::StringAtom& name)
+ShaderConfig::GetMaterialTextureIndex(const Util::StringAtom& name)
 {
-    IndexT idx = this->surfaceAllocator.Get<TextureMap>(sur.id).FindIndex(name);
-    if (idx != InvalidIndex)	return this->surfaceAllocator.Get<TextureMap>(sur.id).ValueAtIndex(idx);
-    else						return idx;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-IndexT 
-ShaderConfig::GetSurfaceConstantInstanceIndex(const MaterialInstanceId sur, const Util::StringAtom& name)
-{
-    IndexT idx = this->surfaceAllocator.Get<ConstantMap>(sur.surface).FindIndex(name);
-    if (idx != InvalidIndex)	return this->surfaceAllocator.Get<ConstantMap>(sur.surface).ValueAtIndex(idx);
-    else						return idx;
+    IndexT idx = this->textureLookup.FindIndex(name);
+    if (idx != InvalidIndex)	return this->textureLookup.ValueAtIndex(idx);
+    else						return InvalidIndex;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 const ShaderConfigVariant
-ShaderConfig::GetSurfaceConstantDefault(const MaterialId sur, IndexT idx)
+ShaderConfig::GetMaterialConstantDefault(const MaterialId sur, IndexT idx)
 {
-    return (*this->surfaceAllocator.Get<Constants>(sur.id).Begin())[idx].defaultValue;
+    auto constant = this->constants[idx];
+    return constant.def;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 const CoreGraphics::TextureId
-ShaderConfig::GetSurfaceTextureDefault(const MaterialId sur, IndexT idx)
+ShaderConfig::GetMaterialTextureDefault(const MaterialId sur, IndexT idx)
 {
-    return (*this->surfaceAllocator.Get<Textures>(sur.id).Begin())[idx].defaultValue;
+    return (*this->materialAllocator.Get<Textures>(sur.id).Begin())[idx].defaultValue;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 void
-ShaderConfig::SetSurfaceConstant(const MaterialId sur, IndexT name, const ShaderConfigVariant& value)
+ShaderConfig::SetMaterialConstant(const MaterialId sur, IndexT name, const ShaderConfigVariant& value)
 {
     auto it = this->batchToIndexMap.Begin();
     while (it != this->batchToIndexMap.End())
     {
-        const SurfaceConstant& constant = this->surfaceAllocator.Get<Constants>(sur.id)[*it.val][name];
-        if (constant.buffer != CoreGraphics::InvalidBufferId && constant.binding != UINT_MAX)
+        const MaterialConstant& constant = this->materialAllocator.Get<Constants>(sur.id)[*it.val][name];
+        if (constant.buffer != CoreGraphics::InvalidBufferId &&
+            constant.binding != UINT_MAX &&
+            constant.instanceConstant == false)
         {
-            n_assert(!constant.instanceConstant);
             if (value.GetType() == ShaderConfigVariant::Type::TextureHandle)
                 CoreGraphics::BufferUpdate(constant.buffer, value.Get<ShaderConfigVariant::TextureHandleTuple>().handle, constant.binding);
             else
@@ -369,14 +326,14 @@ ShaderConfig::SetSurfaceConstant(const MaterialId sur, IndexT name, const Shader
 /**
 */
 void
-ShaderConfig::SetSurfaceTexture(const MaterialId sur, IndexT name, const CoreGraphics::TextureId tex)
+ShaderConfig::SetMaterialTexture(const MaterialId sur, IndexT name, const CoreGraphics::TextureId tex)
 {
     auto it = this->batchToIndexMap.Begin();
     while (it != this->batchToIndexMap.End())
     {
-        const SurfaceTexture& surTex = this->surfaceAllocator.Get<Textures>(sur.id)[*it.val][name];
+        const MaterialTexture& surTex = this->materialAllocator.Get<Textures>(sur.id)[*it.val][name];
         if (surTex.slot != InvalidIndex)
-            CoreGraphics::ResourceTableSetTexture(this->surfaceAllocator.Get<SurfaceTable>(sur.id)[*it.val], { tex, surTex.slot, 0, CoreGraphics::InvalidSamplerId, false });
+            CoreGraphics::ResourceTableSetTexture(this->materialAllocator.Get<MaterialTable>(sur.id)[*it.val], { tex, surTex.slot, 0, CoreGraphics::InvalidSamplerId, false });
         it++;
     }
 }
@@ -384,17 +341,39 @@ ShaderConfig::SetSurfaceTexture(const MaterialId sur, IndexT name, const CoreGra
 //------------------------------------------------------------------------------
 /**
 */
-void 
-ShaderConfig::SetSurfaceInstanceConstant(const MaterialInstanceId sur, const IndexT idx, const Util::Variant& value)
+BatchIndex
+ShaderConfig::GetBatchIndex(const CoreGraphics::BatchGroup::Code batch)
 {
-    auto it = this->batchToIndexMap.Begin();
-    while (it != this->batchToIndexMap.End())
-    {
-        const SurfaceInstanceConstant& constant = this->surfaceInstanceAllocator.Get<0>(sur.instance)[*it.val][idx];
-        if (constant.binding != UINT_MAX)
-            memcpy((void*)constant.mem, value.AsVoidPtr(), value.Size());
-        it++;
-    }
+    IndexT i = this->batchToIndexMap.FindIndex(batch);
+    n_assert(i != InvalidIndex);
+    IndexT batchIndex = this->batchToIndexMap.ValueAtIndex(batch, i);
+    return batchIndex;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+SizeT
+ShaderConfig::GetInstanceBufferSize(const MaterialInstanceId sur, const BatchIndex batch)
+{
+    const Util::Tuple<IndexT, SizeT>& buffer = this->materialAllocator.Get<InstanceBuffers>(sur.material)[batch];
+    return Util::Get<1>(buffer);
+}
+
+//------------------------------------------------------------------------------
+/**
+    Before setting any constants, we need to first allocate constants in our constants ring buffer.
+    This is safe to do once per frame, it doesn't actually allocate any memory.
+*/
+CoreGraphics::ConstantBufferOffset
+ShaderConfig::AllocateInstanceConstants(const MaterialInstanceId sur, const BatchIndex batch)
+{
+    const Util::Tuple<IndexT, SizeT>& buffer = this->materialAllocator.Get<InstanceBuffers>(sur.material)[batch];
+
+    SizeT bufferSize = Util::Get<1>(buffer);
+    CoreGraphics::ConstantBufferOffset offset = CoreGraphics::AllocateGraphicsConstantBufferMemory(bufferSize);
+    this->materialInstanceAllocator.Get<MaterialInstanceOffsets>(sur.instance) = offset;
+    return offset;
 }
 
 //------------------------------------------------------------------------------
@@ -418,7 +397,7 @@ ShaderConfig::BindShader(const CoreGraphics::CmdBufferId buf, CoreGraphics::Batc
 void
 ShaderConfig::ApplyMaterial(const CoreGraphics::CmdBufferId buf, IndexT index, const MaterialId id)
 {
-    CoreGraphics::CmdSetResourceTable(buf, this->surfaceAllocator.Get<SurfaceTable>(id.id)[index], NEBULA_BATCH_GROUP, CoreGraphics::GraphicsPipeline, nullptr);
+    CoreGraphics::CmdSetResourceTable(buf, this->materialAllocator.Get<MaterialTable>(id.id)[index], NEBULA_BATCH_GROUP, CoreGraphics::GraphicsPipeline, nullptr);
 }
 
 //------------------------------------------------------------------------------
@@ -427,17 +406,12 @@ ShaderConfig::ApplyMaterial(const CoreGraphics::CmdBufferId buf, IndexT index, c
 void
 ShaderConfig::ApplyMaterialInstance(const CoreGraphics::CmdBufferId buf, IndexT index, const MaterialInstanceId id)
 {
-    const CoreGraphics::ResourceTableId table = this->surfaceAllocator.Get<InstanceTable>(id.surface)[index];
+    const CoreGraphics::ResourceTableId table = this->materialAllocator.Get<InstanceTable>(id.material)[index];
     if (table != CoreGraphics::InvalidResourceTableId)
     {
-        // update global buffer, save new offsets, and apply table
-        const Util::Array<Util::Tuple<IndexT, void*, SizeT>>& buffers = this->surfaceAllocator.Get<InstanceBuffers>(id.surface)[index];
-        Util::FixedArray<uint>& offsets = this->surfaceInstanceAllocator.Get<SurfaceInstanceOffsets>(id.instance);
-        for (IndexT i = 0; i < buffers.Size(); i++)
-        {
-            offsets[i] = CoreGraphics::SetGraphicsConstants((byte*)Util::Get<1>(buffers[i]), Util::Get<2>(buffers[i]));
-        }
-        CoreGraphics::CmdSetResourceTable(buf, table, NEBULA_INSTANCE_GROUP, CoreGraphics::GraphicsPipeline, nullptr);
+        // Set instance table
+        CoreGraphics::ConstantBufferOffset offset = this->materialInstanceAllocator.Get<MaterialInstanceOffsets>(id.instance);
+        CoreGraphics::CmdSetResourceTable(buf, table, NEBULA_INSTANCE_GROUP, CoreGraphics::GraphicsPipeline, { offset });
     }
 }
 

--- a/code/render/materials/shaderconfigserver.cc
+++ b/code/render/materials/shaderconfigserver.cc
@@ -207,7 +207,7 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
                         type->constantsByBatch.Append({});
 
                         // add material to server
-                        Util::Array<Materials::ShaderConfig*>& mats = this->shaderConfigsByBatch.AddUnique(code);
+                        Util::Array<Materials::ShaderConfig*>& mats = this->shaderConfigsByBatch.Emplace(code);
                         mats.Append(type);
                     }
                 } while (reader->SetToNextChild());

--- a/code/render/materials/shaderconfigserver.cc
+++ b/code/render/materials/shaderconfigserver.cc
@@ -61,7 +61,7 @@ ShaderConfigServer::Open()
 void
 ShaderConfigServer::Close()
 {
-    this->surfaceAllocator.Release();
+    this->materialAllocator.Release();
 }
 
 //------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
         // parse materials
         if (reader->SetToFirstChild()) do
         {
-            ShaderConfig* type = this->surfaceAllocator.Alloc<ShaderConfig>();
+            ShaderConfig* type = this->materialAllocator.Alloc<ShaderConfig>();
             this->shaderConfigs.Append(type);
 
             type->name = reader->GetString("name");
@@ -114,7 +114,7 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
 
             Util::String inherits = reader->GetOptString("inherits", "");
 
-            // load inherited materialx
+            // Insert inherited materials
             if (!inherits.IsEmpty())
             {
                 Util::Array<Util::String> inheritances = inherits.Tokenize("|");
@@ -129,8 +129,23 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
                     {
                         ShaderConfig* mat = this->shaderConfigsByName.ValueAtIndex(index);
 
-                        type->textures.Merge(mat->textures);
-                        type->constants.Merge(mat->constants);
+                        // Update the lookup tables, offset the lookup value from the inherited table
+                        // by the size of the base table, as the lookup values will be offset by the ones from the lookup
+                        for (IndexT j = 0; j < mat->textureLookup.Size(); j++)
+                        {
+                            n_assert(type->textureLookup.FindIndex(mat->textureLookup.KeyAtIndex(j)) == InvalidIndex);
+                            type->textureLookup.Add(mat->textureLookup.KeyAtIndex(j), mat->textureLookup.ValueAtIndex(j) + type->textures.Size());
+                        }
+
+                        for (IndexT j = 0; j < mat->constantLookup.Size(); j++)
+                        {
+                            n_assert(type->constantLookup.FindIndex(mat->constantLookup.KeyAtIndex(j)) == InvalidIndex);
+                            type->constantLookup.Add(mat->constantLookup.KeyAtIndex(j), mat->constantLookup.ValueAtIndex(j) + type->constants.Size());
+                        }
+
+                        // First merge the type level constants and textures
+                        type->textures.AppendArray(mat->textures);
+                        type->constants.AppendArray(mat->constants);
 
                         // merge materials by adding new entry
                         auto it = mat->batchToIndexMap.Begin();
@@ -150,8 +165,8 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
                                 // if entry exists, merge constants and texture dictionaries
                                 idx = type->batchToIndexMap.FindIndex(idx);
                                 type->programs[idx] = mat->programs[*it.val]; // this actually replaces the program, perhaps we want this to overload shaders
-                                type->texturesByBatch[idx].Merge(mat->texturesByBatch[*it.val]);
-                                type->constantsByBatch[idx].Merge(mat->constantsByBatch[*it.val]);
+                                type->texturesByBatch[idx].AppendArray(mat->texturesByBatch[*it.val]);
+                                type->constantsByBatch[idx].AppendArray(mat->constantsByBatch[*it.val]);
                             }
                             it++;
                         }
@@ -221,10 +236,8 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
 
                         constant.system = system;
                         constant.name = name;
-                        constant.offset = InvalidIndex;
-                        constant.slot = InvalidIndex;
-                        constant.group = InvalidIndex;
-                        type->constants.Add(name, constant);
+                        type->constantLookup.Add(name, type->constants.Size());
+                        type->constants.Append(constant);
                     }
                     else if (ptype.BeginsWithString("texture"))
                     {
@@ -244,8 +257,8 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
                         texture.defaultValue = res.As<CoreGraphics::TextureId>();
                         texture.system = system;
                         texture.name = name;
-                        texture.slot = InvalidIndex;
-                        type->textures.Add(name, texture);
+                        type->textureLookup.Add(name, type->textures.Size());
+                        type->textures.Append(texture);
                     }
                     else
                     {
@@ -294,10 +307,8 @@ ShaderConfigServer::LoadShaderConfigs(const IO::URI& file)
 
                         constant.system = system;
                         constant.name = name;
-                        constant.offset = InvalidIndex;
-                        constant.slot = InvalidIndex;
-                        constant.group = InvalidIndex;
-                        type->constants.Add(name, constant);
+                        type->constantLookup.Add(name, type->constants.Size());
+                        type->constants.Append(constant);
                     }
                 } while (reader->SetToNextChild());
                 reader->SetToParent();

--- a/code/render/materials/shaderconfigserver.h
+++ b/code/render/materials/shaderconfigserver.h
@@ -50,7 +50,7 @@ private:
     Threading::CriticalSection variantAllocatorLock;
     Memory::ArenaAllocator<0x10000> shaderConfigVariantAllocator;
 
-    Memory::ArenaAllocator<0x400> surfaceAllocator;
+    Memory::ArenaAllocator<0x400> materialAllocator;
     Util::Dictionary<Resources::ResourceName, ShaderConfig*> shaderConfigsByName;
     Util::HashTable<CoreGraphics::BatchGroup::Code, Util::Array<ShaderConfig*>> shaderConfigsByBatch;
     Util::Array<ShaderConfig*> shaderConfigs;

--- a/code/render/models/nodes/particlesystemnode.cc
+++ b/code/render/models/nodes/particlesystemnode.cc
@@ -74,9 +74,9 @@ ParticleSystemNode::OnFinishedLoading()
     TransformNode::OnFinishedLoading();
 
     // load surface ourselves since state node does the resource table setup too, but we need it explicit
-    this->surRes = Resources::CreateResource(this->materialName, this->tag, nullptr, nullptr, true);
-    this->materialType = Materials::materialCache->GetType(this->surRes);
-    this->surface = Materials::materialCache->GetId(this->surRes);
+    this->materialRes = Resources::CreateResource(this->materialName, this->tag, nullptr, nullptr, true);
+    this->shaderConfig = Materials::materialCache->GetType(this->materialRes);
+    this->material = Materials::materialCache->GetId(this->materialRes);
 
     float activityDist = this->emitterAttrs.GetFloat(EmitterAttrs::ActivityDistance) * 0.5f;
 

--- a/code/render/models/nodes/shaderstatenode.cc
+++ b/code/render/models/nodes/shaderstatenode.cc
@@ -38,7 +38,7 @@ ShaderStateNode::~ShaderStateNode()
 void 
 ShaderStateNode::SetMaxLOD(const float lod)
 {
-    Materials::materialCache->SetMaxLOD(this->surRes, lod);
+    Materials::materialCache->SetMaxLOD(this->materialRes, lod);
 }
 
 //------------------------------------------------------------------------------
@@ -126,7 +126,7 @@ void
 ShaderStateNode::Unload()
 {
     // free material
-    Resources::DiscardResource(this->surRes);
+    Resources::DiscardResource(this->materialRes);
 
     // destroy table and constant buffer
     CoreGraphics::DestroyResourceTable(this->resourceTable);
@@ -141,9 +141,9 @@ ShaderStateNode::OnFinishedLoading()
     TransformNode::OnFinishedLoading();
 
     // load surface immediately, however it will load textures async
-    this->surRes = Resources::CreateResource(this->materialName, this->tag, nullptr, nullptr, true);
-    this->materialType = Materials::materialCache->GetType(this->surRes);
-    this->surface = Materials::materialCache->GetId(this->surRes);
+    this->materialRes = Resources::CreateResource(this->materialName, this->tag, nullptr, nullptr, true);
+    this->shaderConfig = Materials::materialCache->GetType(this->materialRes);
+    this->material = Materials::materialCache->GetId(this->materialRes);
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderServer::Instance()->GetShader("shd:objects_shared.fxb"_atm);
     CoreGraphics::BufferId cbo = CoreGraphics::GetGraphicsConstantBuffer();
     this->objectTransformsIndex = CoreGraphics::ShaderGetResourceSlot(shader, "ObjectBlock");
@@ -162,8 +162,8 @@ void
 ShaderStateNode::DrawPacket::Apply(const CoreGraphics::CmdBufferId cmdBuf, IndexT batchIndex, Materials::ShaderConfig* type)
 {
     // Apply per-draw surface parameters
-    if (this->surfaceInstance != Materials::MaterialInstanceId::Invalid())
-        type->ApplyMaterialInstance(cmdBuf, batchIndex, this->surfaceInstance);
+    if (this->materialInstance != Materials::MaterialInstanceId::Invalid())
+        type->ApplyMaterialInstance(cmdBuf, batchIndex, this->materialInstance);
 
     // Set per-draw resource tables
     IndexT prevOffset = 0;

--- a/code/render/models/nodes/shaderstatenode.h
+++ b/code/render/models/nodes/shaderstatenode.h
@@ -33,7 +33,7 @@ public:
 
     struct DrawPacket
     {
-        Materials::MaterialInstanceId surfaceInstance;
+        Materials::MaterialInstanceId materialInstance;
         SizeT numTables;
         CoreGraphics::ResourceTableId tables[NumTables];
         uint32 numOffsets[NumTables];
@@ -50,7 +50,7 @@ public:
     };
 
     /// get surface
-    const Materials::MaterialId GetSurface() const { return this->surface; };
+    const Materials::MaterialId GetSurface() const { return this->material; };
     /// trigger an LOD update
     void SetMaxLOD(const float lod);
 
@@ -65,9 +65,9 @@ protected:
     /// called when loading finished
     virtual void OnFinishedLoading();
     
-    Materials::ShaderConfig* materialType;
-    Materials::MaterialId surface;
-    Materials::MaterialResourceId surRes;
+    Materials::ShaderConfig* shaderConfig;
+    Materials::MaterialId material;
+    Materials::MaterialResourceId materialRes;
     Resources::ResourceName materialName;
 
     uint8_t objectTransformsIndex;

--- a/code/render/visibility/visibilitycontext.cc
+++ b/code/render/visibility/visibilitycontext.cc
@@ -293,7 +293,7 @@ ObserverContext::RunVisibilityTests(const Graphics::FrameContext& ctx)
                 if (currentMaterialType != otherMaterialType)
                 {
                     // Add new draw command and get reference to it
-                    cmd = &context->drawList->visibilityTable.AddUnique(otherMaterialType);
+                    cmd = &context->drawList->visibilityTable.Emplace(otherMaterialType);
 
                     // Setup initial state for command
                     cmd->packetOffset = numDraws;

--- a/code/render/visibility/visibilitycontext.cc
+++ b/code/render/visibility/visibilitycontext.cc
@@ -289,7 +289,7 @@ ObserverContext::RunVisibilityTests(const Graphics::FrameContext& ctx)
                 uint32 index = indexBuffer[i] & 0x00000000FFFFFFFF;
 
                 // If new material, add a new entry into the lookup table
-                auto otherMaterialType = context->renderables->nodeMaterialTypes[index];
+                auto otherMaterialType = context->renderables->nodeShaderConfigs[index];
                 if (currentMaterialType != otherMaterialType)
                 {
                     // Add new draw command and get reference to it
@@ -315,7 +315,7 @@ ObserverContext::RunVisibilityTests(const Graphics::FrameContext& ctx)
                     batchCmd.offset = cmd->packetOffset + cmd->numDrawPackets;
                     batchCmd.modelApplyCallback = context->renderables->nodeModelApplyCallbacks[index];
                     batchCmd.primitiveNodeApplyCallback = context->renderables->modelNodeGetPrimitiveGroup[index];
-                    batchCmd.surface = context->renderables->nodeSurfaces[index];
+                    batchCmd.material = context->renderables->nodeMaterials[index];
 
 #if NEBULA_GRAPHICS_DEBUG
                     batchCmd.nodeName = context->renderables->nodeNames[index];
@@ -343,7 +343,7 @@ ObserverContext::RunVisibilityTests(const Graphics::FrameContext& ctx)
                 packet->numOffsets[0] = context->renderables->nodeStates[index].resourceTableOffsets.Size();
                 packet->numTables = 1;
                 packet->tables[0] = context->renderables->nodeStates[index].resourceTable;
-                packet->surfaceInstance = context->renderables->nodeStates[index].surfaceInstance;
+                packet->materialInstance = context->renderables->nodeStates[index].materialInstance;
 #ifndef PUBLIC_BUILD
                 packet->boundingBox = context->renderables->nodeBoundingBoxes[index];
                 packet->nodeInstanceHash = index;

--- a/code/render/visibility/visibilitycontext.h
+++ b/code/render/visibility/visibilitycontext.h
@@ -106,7 +106,7 @@ public:
         uint32 offset;
         std::function<void(const CoreGraphics::CmdBufferId)> modelApplyCallback;
         std::function<const CoreGraphics::PrimitiveGroup()> primitiveNodeApplyCallback;
-        Materials::MaterialId surface;
+        Materials::MaterialId material;
 
 #if NEBULA_GRAPHICS_DEBUG
         Util::StringAtom nodeName;

--- a/work/materials/notamaterials.json
+++ b/work/materials/notamaterials.json
@@ -56,12 +56,9 @@
           },
           {
             "name": "TeamColor",
-            "type": "vec4",
-            "defaultValue": [ 0.0, 0.0, 0.0, 0.0 ],
-            "max": [ 10.0, 10.0, 10.0, 10.0 ],
-            "desc": "Color of the unit"
+            "type": "vec4"
           }
-        ],
+        ]
       },
       {
         "name": "NotACastleChar",
@@ -118,12 +115,9 @@
           },
           {
             "name": "TeamColor",
-            "type": "vec4",
-            "defaultValue": [ 0.0, 0.0, 0.0, 0.0 ],
-            "max": [ 10.0, 10.0, 10.0, 10.0 ],
-            "desc": "Color of the unit"
+            "type": "vec4"
           }
-        ],
+        ]
       }
     ]
 

--- a/work/shaders/vk/unit.fx
+++ b/work/shaders/vk/unit.fx
@@ -11,6 +11,10 @@ group(BATCH_GROUP) shared constant UnitBlock
     textureHandle TeamColorMask;
     textureHandle SpecularMap;
     textureHandle RoughnessMap;
+};
+
+group(INSTANCE_GROUP) shared constant UnitInstanceBlock
+{
     vec4 TeamColor;
 };
 


### PR DESCRIPTION
This PR fixes issues related to per-instance material constants and textures.

It provides a more workable API for allocating constants per objects on a frame by frame basis, internally setting the constant offsets to be applied at draw time, and allows for the standard CoreGraphics::SetGraphicsConstants with an offset to actually update the constants.

It also does a bunch of internal refactoring of materials, reducing the memory footprint and lookup times of shader variables somewhat.

Finally there are a few bugfixes in Array, as well as a refactor of AddUnique to Emplace for Dictionary and HashTable. 