### PR TITLE
Changed job sequence to be a lateral linked list

### DIFF
--- a/code/foundation/jobs2/jobs2.h
+++ b/code/foundation/jobs2/jobs2.h
@@ -113,6 +113,8 @@ void JobSystemUninit();
 
 /// Allocate memory and progress memory iterator
 template <typename T> T* JobAlloc(SizeT count);
+/// Allocate memory
+void* JobAlloc(SizeT bytes);
 /// Progress to new buffer
 void JobNewFrame();
 
@@ -150,10 +152,7 @@ void JobEndSequence(Threading::Event* signalEvent = nullptr);
 template <typename T> T*
 JobAlloc(SizeT count)
 {
-    n_assert((ctx.iterator + count * sizeof(T)) < ctx.scratchMemorySize);
-    T* ret = (T*)(ctx.scratchMemory[ctx.activeBuffer] + ctx.iterator);
-    ctx.iterator += count * sizeof(T);
-    return ret;
+    return (T*)JobAlloc(count * sizeof(T));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Instead of having the sequence node be in the main list, taking up space and forcing an iteration over a sequence where each node is dependent on each other, we now have a dummy node acting as the sequence anchor, which then has a separate linked list for each job in the sequence. These nodes automatically setup a wait/done counter pair for each, making sure that no other thread will pickup the job and run the next one before the first finishes.

It also removes the 'ugly' pattern of having the nodes in the sequence wait for a certain value of the counter to be reached, and instead an implicit counter is created for each node to wait for the previous node in the sequence. With this, we can also supply a wait counter on the sequence, a done counter which will be applied to the last job in the chain, and a done event to be signaled by the last job in the event, just like ordinary job dispatches.

In essence, this allows us to intuitively have a counter which counts down for each sequence, allowing us to wait for a set of sequences of jobs to finish, such as particles where each system can have multiple particle steps.