### PR TITLE
Budget counters colors

### DIFF
--- a/code/foundation/core/types.h
+++ b/code/foundation/core/types.h
@@ -71,6 +71,15 @@ operator"" _MB(const unsigned long long val)
     return val * 1024 * 1024;
 }
 
+//------------------------------------------------------------------------------
+/**
+*/
+constexpr uint64
+operator"" _GB(const unsigned long long val)
+{
+    return val * 1024 * 1024 * 1024;
+}
+
 #define N_BIT(x) (1 << x)
 template <class MASK, class BITS>
 constexpr MASK

--- a/code/foundation/profiling/profiling.cc
+++ b/code/foundation/profiling/profiling.cc
@@ -214,7 +214,7 @@ ProfilingSetupBudgetCounter(const char* id, uint64 budget)
     // Add budget
     IndexT idx = budgetCounters.FindIndex(id);
     n_assert(idx == InvalidIndex);
-    budgetCounters.Add(id, { budget, budget });
+    budgetCounters.Add(id, { budget, 0 });
 
     counterLock.Leave();
 }

--- a/code/foundation/profiling/profiling.h
+++ b/code/foundation/profiling/profiling.h
@@ -56,9 +56,6 @@
 #define N_DECLARE_COUNTER(name, label)
 #endif
 
-N_DECLARE_COUNTER(N_GPU_MEMORY_COUNTER, GPU Allocated Memory);
-
-
 namespace Profiling
 {
 

--- a/code/render/coregraphics/memory.h
+++ b/code/render/coregraphics/memory.h
@@ -80,6 +80,7 @@ struct MemoryPool
 
     AllocationMethod allocMethod;
 
+    const char* budgetCounter;
     DeviceSize maxSize;
     bool mapMemory;
 


### PR DESCRIPTION
Viewerapp colors the different budget counter visualisations.
VkMemory uses budget counters instead of the typical counters.
Fixed bug where budget counters were setup to be already reaching budget.