### PR TITLE
Refactor/move vsync to window create

### DIFF
--- a/code/render/coregraphics/glfw/glfwdisplaydevice.cc
+++ b/code/render/coregraphics/glfw/glfwdisplaydevice.cc
@@ -93,16 +93,6 @@ GLFWDisplayDevice::ProcessWindowMessages()
 //------------------------------------------------------------------------------
 /**
 */
-void
-GLFWDisplayDevice::SetVerticalSyncEnabled(bool b)
-{
-    DisplayDeviceBase::SetVerticalSyncEnabled(b);
-    glfwSwapInterval(b ? 1 : 0);
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
 bool
 MatchPixelFormat(PixelFormat::Code format, const GLFWvidmode & mode)
 {

--- a/code/render/coregraphics/glfw/glfwdisplaydevice.h
+++ b/code/render/coregraphics/glfw/glfwdisplaydevice.h
@@ -35,9 +35,6 @@ public:
     /// process window system messages, call this method once per frame
     static void ProcessWindowMessages();
 
-    /// set if vertical sync should be used
-    void SetVerticalSyncEnabled(bool b);
-
     /// return true if adapter exists
     bool AdapterExists(CoreGraphics::Adapter::Code adapter);
     /// get available display modes on given adapter

--- a/code/render/coregraphics/glfw/glfwwindow.h
+++ b/code/render/coregraphics/glfw/glfwwindow.h
@@ -46,11 +46,11 @@ struct VkBackbufferInfo
 /// get surface
 const VkSurfaceKHR& GetSurface(const CoreGraphics::WindowId& id);
 /// setup Vulkan swapchain
-void SetupVulkanSwapchain(const CoreGraphics::WindowId& id, const CoreGraphics::DisplayMode& mode, const Util::StringAtom& title);
+void SetupVulkanSwapchain(const CoreGraphics::WindowId& id, const CoreGraphics::DisplayMode& mode, bool vsync, const Util::StringAtom& title);
 /// destroy Vulkan swapchain
 void DiscardVulkanSwapchain(const CoreGraphics::WindowId& id);
 /// recreate Vulkan swapchain (used when swapchain is no longer valid due to resize of window or similar)
-void RecreateVulkanSwapchain(const CoreGraphics::WindowId& id, const CoreGraphics::DisplayMode& mode, const Util::StringAtom& title);
+void RecreateVulkanSwapchain(const CoreGraphics::WindowId& id, const CoreGraphics::DisplayMode& mode, bool vsync, const Util::StringAtom& title);
 /// perform a present
 void Present(const CoreGraphics::WindowId& id);
 
@@ -62,8 +62,9 @@ namespace CoreGraphics
 
 struct ResizeInfo
 {
-    uint newWidth, newHeight;
-    bool done;
+    uint newWidth : 16, newHeight : 16;
+    bool done : 1;
+    bool vsync : 1;
 };
 
 enum

--- a/code/render/coregraphics/window.h
+++ b/code/render/coregraphics/window.h
@@ -34,6 +34,7 @@ struct WindowCreateInfo
     bool resizable : 1;
     bool decorated : 1;
     bool fullscreen : 1;
+    bool vsync : 1;
 };
 
 /// create new window

--- a/tests/testviewer/viewerapp.cc
+++ b/tests/testviewer/viewerapp.cc
@@ -140,7 +140,7 @@ SimpleViewerApplication::Open()
         CoreGraphics::WindowCreateInfo wndInfo =
         {
             CoreGraphics::DisplayMode{ 100, 100, width, height },
-            this->GetAppTitle(), "", CoreGraphics::AntiAliasQuality::None, true, true, false
+            this->GetAppTitle(), "", CoreGraphics::AntiAliasQuality::None, true, true, false, true
         };
         this->wnd = CreateWindow(wndInfo);
         this->cam = Graphics::CreateEntity();


### PR DESCRIPTION
Moved the vsync switch to CreateWindowInfo instead of the awkward DisplayDevice.