### PR TITLE
Added an API for getting and setting constants for a specific node in the model

### DIFF
--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -63,8 +63,14 @@ public:
     /// get the transform for a model
     static Math::mat4 GetTransform(const Graphics::ContextEntityId id);
 
+    /// Get node index based on name
+    static IndexT GetNodeIndex(const Graphics::GraphicsEntityId id, const Util::StringAtom& name);
+    /// Setup material instance context
+    static MaterialInstanceContext& SetupMaterialInstanceContext(const Graphics::GraphicsEntityId id, const IndexT nodeIndex, const CoreGraphics::BatchGroup::Code batch);
     /// Setup material instance context
     static MaterialInstanceContext& SetupMaterialInstanceContext(const Graphics::GraphicsEntityId id, const CoreGraphics::BatchGroup::Code batch);
+    /// Allocate constant memory for instance constants in this frame
+    static CoreGraphics::ConstantBufferOffset AllocateInstanceConstants(const Graphics::GraphicsEntityId id, const IndexT nodeIndex, const Materials::BatchIndex batch);
     /// Allocate constant memory for instance constants in this frame
     static CoreGraphics::ConstantBufferOffset AllocateInstanceConstants(const Graphics::GraphicsEntityId id, const Materials::BatchIndex batch);
 
@@ -160,6 +166,7 @@ private:
         Model_NodeInstanceRoots,
         Model_NodeInstanceTransform,
         Model_NodeInstanceStates,
+        Model_NodeLookup,
         Model_Transform,
         Model_Dirty
     };
@@ -168,6 +175,7 @@ private:
         Util::Array<uint32>,
         NodeInstanceRange,
         NodeInstanceRange,
+        Util::Dictionary<Util::StringAtom, IndexT>,
         Math::mat4,         // pending transforms
         bool                // transform is dirty
     > ModelContextAllocator;


### PR DESCRIPTION
In order to set constants for a specific node in the model, you'd need to get the node index based on name, and then be able to set constants per node instance using that index. 

That's what's been added in this PR.