### PR TITLE
Refactored how we call graphics contexts

### DIFF
--- a/code/addons/dynui/im3d/im3dcontext.cc
+++ b/code/addons/dynui/im3d/im3dcontext.cc
@@ -125,8 +125,6 @@ Im3dContext::~Im3dContext()
 void
 Im3dContext::Create()
 {
-    __bundle.OnBeforeFrame = Im3dContext::OnBeforeFrame;
-    __bundle.OnPrepareView = Im3dContext::OnPrepareView;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
     imState.inputHandler = Im3dInputHandler::Create();
@@ -343,7 +341,7 @@ Im3dContext::DrawSphere(const Math::point& pos, float radius, const Math::vec4& 
 /**
 */
 void
-Im3dContext::OnBeforeFrame(const Graphics::FrameContext& ctx)
+Im3dContext::NewFrame(const Graphics::FrameContext& ctx)
 {
     Im3d::NewFrame();
 }

--- a/code/addons/dynui/im3d/im3dcontext.h
+++ b/code/addons/dynui/im3d/im3dcontext.h
@@ -61,7 +61,7 @@ public:
     static void DrawCone(const Math::mat4& modelTransform, const Math::vec4& color, uint32_t renderFlags = CheckDepth | Wireframe);
 
     /// Start a new Im3d frame
-    static void OnBeforeFrame(const Graphics::FrameContext& ctx);
+    static void NewFrame(const Graphics::FrameContext& ctx);
 
     /// called before frame
     static void OnPrepareView(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);

--- a/code/addons/dynui/imguicontext.cc
+++ b/code/addons/dynui/imguicontext.cc
@@ -653,7 +653,7 @@ ImguiContext::OnWindowResized(const CoreGraphics::WindowId windowId, SizeT width
 /**
 */
 void 
-ImguiContext::OnBeforeFrame(const Graphics::FrameContext& ctx)
+ImguiContext::NewFrame(const Graphics::FrameContext& ctx)
 {
     ImGuiIO& io = ImGui::GetIO();
     io.DeltaTime = ctx.frameTime;
@@ -670,7 +670,7 @@ ImguiContext::OnBeforeFrame(const Graphics::FrameContext& ctx)
 /**
 */
 void
-ImguiContext::OnWorkFinished(const Graphics::FrameContext& ctx)
+ImguiContext::Render(const Graphics::FrameContext& ctx)
 {
     ImGui::Render();
 }

--- a/code/addons/dynui/imguicontext.cc
+++ b/code/addons/dynui/imguicontext.cc
@@ -317,8 +317,6 @@ ImguiContext::Create()
 {
     ui_opacity = Core::CVarCreate(Core::CVar_Float, "ui_opacity", "1.0", "Global UI opacity (0..1)");
 
-    __bundle.OnBegin = ImguiContext::OnBeforeFrame;
-    __bundle.OnWorkFinished = ImguiContext::OnWorkFinished; // this is basically OnBeforeViews (plural)
     __bundle.OnWindowResized = ImguiContext::OnWindowResized;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 

--- a/code/addons/dynui/imguicontext.h
+++ b/code/addons/dynui/imguicontext.h
@@ -60,9 +60,9 @@ public:
     /// called if the window size has changed
     static void OnWindowResized(const CoreGraphics::WindowId windowId, SizeT width, SizeT height);
     /// called before frame
-    static void OnBeforeFrame(const Graphics::FrameContext& ctx);
+    static void NewFrame(const Graphics::FrameContext& ctx);
     /// called before frame
-    static void OnWorkFinished(const Graphics::FrameContext& ctx);
+    static void Render(const Graphics::FrameContext& ctx);
 
     struct ImguiState
     {

--- a/code/addons/staticui/staticuicontext.cc
+++ b/code/addons/staticui/staticuicontext.cc
@@ -57,14 +57,6 @@ StaticUIContext::~StaticUIContext()
 void
 StaticUIContext::Create()
 {
-    __bundle.OnUpdateResources = [](const Graphics::FrameContext& ctx)
-    {
-        state.Renderer->Update();
-        state.Renderer->Render();
-
-        state.Backend->PreDraw(state.view->render_target());
-    };
-
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
     ultralight::Config config;
@@ -127,6 +119,18 @@ StaticUIContext::Create()
 void
 StaticUIContext::Discard()
 {
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+StaticUIContext::Render()
+{
+    state.Renderer->Update();
+    state.Renderer->Render();
+
+    state.Backend->PreDraw(state.view->render_target());
 }
 
 //------------------------------------------------------------------------------

--- a/code/addons/staticui/staticuicontext.h
+++ b/code/addons/staticui/staticuicontext.h
@@ -27,6 +27,9 @@ public:
     /// Discard context
     static void Discard();
 
+    /// Render
+    static void Render();
+
     /// Register function
     static void RegisterFunction(const char* name, std::function<void()> func);
 };

--- a/code/render/characters/charactercontext.cc
+++ b/code/render/characters/charactercontext.cc
@@ -55,13 +55,9 @@ void
 CharacterContext::Create()
 {
     __CreateContext();
-    __bundle.OnBegin = CharacterContext::UpdateAnimations;
-    __bundle.OnWaitForWork = CharacterContext::WaitForCharacterJobs;
-    __bundle.StageBits = &CharacterContext::__state.currentStage;
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = CharacterContext::OnRenderDebug;
 #endif
-    CharacterContext::__state.allowedRemoveStages = Graphics::OnBeforeFrameStage;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
 }

--- a/code/render/clustering/clustercontext.cc
+++ b/code/render/clustering/clustercontext.cc
@@ -67,8 +67,6 @@ ClusterContext::~ClusterContext()
 void 
 ClusterContext::Create(float ZNear, float ZFar, const CoreGraphics::WindowId window)
 {
-    __bundle.OnUpdateResources = ClusterContext::UpdateResources;
-    __bundle.StageBits = &ClusterContext::__state.currentStage;
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = ClusterContext::OnRenderDebug;
 #endif

--- a/code/render/decals/decalcontext.cc
+++ b/code/render/decals/decalcontext.cc
@@ -66,9 +66,6 @@ void
 DecalContext::Create()
 {
     __CreateContext();
-
-    __bundle.OnUpdateViewResources = DecalContext::UpdateViewDependentResources;
-
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = DecalContext::OnRenderDebug;
 #endif

--- a/code/render/fog/volumetricfogcontext.cc
+++ b/code/render/fog/volumetricfogcontext.cc
@@ -89,9 +89,6 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
 {
     __CreateContext();
 
-    __bundle.OnUpdateViewResources = VolumetricFogContext::UpdateViewDependentResources;
-    __bundle.OnBegin = VolumetricFogContext::RenderUI;
-
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
     using namespace CoreGraphics;

--- a/code/render/graphics/cameracontext.cc
+++ b/code/render/graphics/cameracontext.cc
@@ -37,7 +37,6 @@ CameraContext::Create()
 {
     __CreateContext();
 
-    __bundle.OnBegin = CameraContext::UpdateCameras;
     __bundle.OnWindowResized = CameraContext::OnWindowResized;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 }

--- a/code/render/graphics/environmentcontext.cc
+++ b/code/render/graphics/environmentcontext.cc
@@ -50,10 +50,6 @@ __ImplementPluginContext(EnvironmentContext);
 void 
 EnvironmentContext::Create(const Graphics::GraphicsEntityId sun)
 {
-    __bundle.OnBeforeFrame = EnvironmentContext::OnBeforeFrame;
-    __bundle.OnBegin = EnvironmentContext::RenderUI;
-    __bundle.StageBits = &EnvironmentContext::__state.currentStage;
-
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
     envState.sunEntity = sun;
 

--- a/code/render/graphics/graphicscontext.cc
+++ b/code/render/graphics/graphicscontext.cc
@@ -52,15 +52,7 @@ GraphicsContext::InternalDeregisterEntity(const Graphics::GraphicsEntityId id, G
 {
     IndexT i = state.entitySliceMap.FindIndex(id);
     n_assert(i != InvalidIndex);
-    if (state.allowedRemoveStages & state.currentStage)
-    {
-        state.Dealloc(state.entitySliceMap.ValueAtIndex(id, i));
-        state.entitySliceMap.EraseIndex(id, i);
-    }
-    else
-    {
-        state.delayedRemoveQueue.Append(id);
-    }
+    state.delayedRemoveQueue.Append(id);
 }
 
 } // namespace Graphics

--- a/code/render/graphics/graphicscontext.h
+++ b/code/render/graphics/graphicscontext.h
@@ -97,8 +97,7 @@ void ctx::Defragment()\
 
 #define __CreatePluginContext() \
     __state.Alloc = Alloc; \
-    __state.Dealloc = Dealloc; \
-    __state.currentStage = Graphics::NoStage;
+    __state.Dealloc = Dealloc;
 
 #define __CreateContext() \
     __CreatePluginContext() \
@@ -111,38 +110,8 @@ class View;
 class Stage;
 struct FrameContext;
 
-enum StageBits
-{
-    NoStage                     = 1 << 0,
-    OnBeginStage                = 1 << 1,
-    OnPrepareViewStage          = 1 << 2,
-    OnUpdateViewResourcesStage  = 1 << 3,
-    OnUpdateResourcesStage      = 1 << 4,
-    OnBeforeFrameStage          = 1 << 5,
-    OnWaitForWorkStage          = 1 << 6,
-    OnWorkFinishedStage         = 1 << 7,
-    OnBeforeViewStage           = 1 << 8,
-    OnAfterViewStage            = 1 << 9,
-    OnAfterFrameStage           = 1 << 10,
-
-    AllStages = OnBeginStage | OnPrepareViewStage | OnBeforeFrameStage | OnWaitForWorkStage | OnBeforeViewStage | OnAfterViewStage | OnAfterFrameStage
-};
-__ImplementEnumBitOperators(StageBits);
-
 struct GraphicsContextFunctionBundle
 {
-    // frame stages
-    void(*OnBegin)(const Graphics::FrameContext& ctx);
-    void(*OnPrepareView)(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
-    void(*OnUpdateViewResources)(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
-    void(*OnUpdateResources)(const Graphics::FrameContext& ctx);
-    void(*OnBeforeFrame)(const Graphics::FrameContext& ctx);
-    void(*OnWaitForWork)(const Graphics::FrameContext& ctx);
-    void(*OnWorkFinished)(const Graphics::FrameContext& ctx);
-    void(*OnBeforeView)(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
-    void(*OnAfterView)(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
-    void(*OnAfterFrame)(const Graphics::FrameContext& ctx);
-
     // debug callbacks
     void(*OnRenderDebug)(uint32_t flags);
 
@@ -155,11 +124,8 @@ struct GraphicsContextFunctionBundle
     void(*OnRemoveEntity)(Graphics::GraphicsEntityId entity);
     void(*OnWindowResized)(const CoreGraphics::WindowId windowId, SizeT width, SizeT height);
 
-    StageBits* StageBits;
-    GraphicsContextFunctionBundle() : OnBegin(nullptr), OnPrepareView(nullptr), OnUpdateViewResources(nullptr), OnUpdateResources(nullptr),
-        OnBeforeFrame(nullptr), OnWaitForWork(nullptr), OnWorkFinished(nullptr), OnBeforeView(nullptr), OnAfterView(nullptr), OnAfterFrame(nullptr),
-        OnStageCreated(nullptr), OnDiscardStage(nullptr), OnViewCreated(nullptr), OnDiscardView(nullptr), OnAttachEntity(nullptr), OnRemoveEntity(nullptr), OnWindowResized(nullptr),
-        StageBits(nullptr), OnRenderDebug(nullptr)
+    GraphicsContextFunctionBundle() : OnStageCreated(nullptr), OnDiscardStage(nullptr), OnViewCreated(nullptr), OnDiscardView(nullptr), 
+        OnAttachEntity(nullptr), OnRemoveEntity(nullptr), OnWindowResized(nullptr), OnRenderDebug(nullptr)
     {
     };
 };
@@ -168,8 +134,6 @@ ID_32_TYPE(ContextEntityId)
 
 struct GraphicsContextState
 {
-    StageBits currentStage; // used by the GraphicsServer to set the state
-    StageBits allowedRemoveStages = StageBits::NoStage; // if a delete is done while not in one of these stages, it will be added as a deferred delete
     Util::ArrayStack<GraphicsEntityId, 8> delayedRemoveQueue;
 
     Util::Array<GraphicsEntityId> entities; // ContextEntityId -> GraphicsEntityId. kept adjacent to allocator data.

--- a/code/render/graphics/graphicsserver.cc
+++ b/code/render/graphics/graphicsserver.cc
@@ -478,7 +478,6 @@ GraphicsServer::RunPreLogic()
             call(view, this->frameContext);
         }
         N_MARKER_END();
-
         this->currentView = nullptr;
     }
 }
@@ -511,11 +510,10 @@ void GraphicsServer::RunPostLogic()
             call(view, this->frameContext);
         }
         N_MARKER_END();
-
         this->currentView = nullptr;
     }
 
-    // Update shader server resources (textures and tick params)
+    // Update pending texture views
     this->shaderServer->UpdateResources();
 
     // Consider this whole block of code viable for updating resource tables
@@ -556,7 +554,6 @@ GraphicsServer::EndFrame()
 {
     N_SCOPE(EndFrame, Graphics);
     CoreGraphics::FinishFrame(this->frameContext.frameIndex);
-    N_MARKER_END();
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/graphics/view.cc
+++ b/code/render/graphics/view.cc
@@ -27,8 +27,7 @@ View::View() :
     script(nullptr),
     camera(GraphicsEntityId::Invalid()),
     stage(nullptr),
-    enabled(true),
-    inBeginFrame(false)
+    enabled(true)
 {
     // empty
 }
@@ -44,16 +43,17 @@ View::~View()
 //------------------------------------------------------------------------------
 /**
 */
-void 
-View::UpdateResources(const IndexT frameIndex, const IndexT bufferIndex)
+void
+View::Render(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex)
 {
-    if (this->camera != GraphicsEntityId::Invalid())
+    // run the actual script
+    if (this->camera != GraphicsEntityId::Invalid() && this->script != nullptr)
     {
         // update camera
         ShaderServer* shaderServer = ShaderServer::Instance();
         auto settings = CameraContext::GetSettings(this->camera);
 
-        alignas(16) Shared::ViewConstants constants;
+        Shared::ViewConstants constants = Graphics::GetViewConstants();
         Math::mat4 view = CameraContext::GetView(this->camera);
         Math::mat4 proj = CameraContext::GetProjection(this->camera);
         proj.row1 = -proj.row1;
@@ -80,50 +80,11 @@ View::UpdateResources(const IndexT frameIndex, const IndexT bufferIndex)
 
         // Apply view transforms
         Graphics::UpdateViewConstants(constants);
-    }   
-}
 
-//------------------------------------------------------------------------------
-/**
-*/
-void 
-View::BeginFrame(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex)
-{
-    n_assert(!inBeginFrame);
-    DisplayDevice* displayDevice = DisplayDevice::Instance();
-    if (this->camera != GraphicsEntityId::Invalid())
-    {
-        //n_assert(this->stage.isvalid()); // hmm, we never use stages
-        inBeginFrame = true;
-    }
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-void
-View::Render(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex)
-{
-    n_assert(inBeginFrame);
-
-    // run the actual script
-    if (this->script != nullptr)
-    {
         N_SCOPE(ViewExecute, Graphics);
         this->script->Run(frameIndex, bufferIndex);
     }
 }
-
-//------------------------------------------------------------------------------
-/**
-*/
-void 
-View::EndFrame(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex)
-{
-    n_assert(inBeginFrame);
-    inBeginFrame = false;
-}
-
 
 //------------------------------------------------------------------------------
 /**

--- a/code/render/graphics/view.h
+++ b/code/render/graphics/view.h
@@ -28,15 +28,8 @@ public:
     /// destructor
     virtual ~View();
 
-    /// apply view settings
-    void UpdateResources(const IndexT frameIndex, const IndexT bufferIndex);
-    
-    /// begin frame
-    void BeginFrame(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex);
     /// render through view
     void Render(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex);
-    /// end frame
-    void EndFrame(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex);
 
     /// get frame script
     const Ptr<Frame::FrameScript> GetFrameScript() const;
@@ -67,7 +60,6 @@ private:
     Ptr<Frame::FrameScript> script;
     GraphicsEntityId camera;
     Ptr<Stage> stage;
-    bool inBeginFrame;
     bool enabled;
 };
 

--- a/code/render/lighting/lightcontext.cc
+++ b/code/render/lighting/lightcontext.cc
@@ -149,15 +149,7 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
     Core::CVarCreate(Core::CVarType::CVar_Int, "r_shadow_debug", "0", "Show shadowmap framescript inspector [0,1]");
 #endif
 
-    __bundle.OnPrepareView = LightContext::OnPrepareView;
-    __bundle.OnUpdateViewResources = LightContext::UpdateViewDependentResources;
     __bundle.OnWindowResized = LightContext::WindowResized;
-    __bundle.OnBeforeView = [](const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx)
-    {
-        lightServerState.shadowMappingFrameScript->Run(ctx.frameIndex, ctx.bufferIndex);
-    };
-
-    __bundle.StageBits = &LightContext::__state.currentStage;
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = LightContext::OnRenderDebug;
 #endif
@@ -906,8 +898,8 @@ LightContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     using namespace CoreGraphics;
 
     // get camera view
-    Math::mat4 viewTransform = Graphics::CameraContext::GetView(view->GetCamera());
-    Math::mat4 invViewTransform = Graphics::CameraContext::GetTransform(view->GetCamera());
+    const Math::mat4 viewTransform = Graphics::CameraContext::GetView(view->GetCamera());
+    const Math::mat4 invViewTransform = Graphics::CameraContext::GetTransform(view->GetCamera());
 
     // update constant buffer
     Ids::Id32 globalLightId = genericLightAllocator.Get<TypedLightId>(cid.id);
@@ -1123,6 +1115,15 @@ LightContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     offset = SetConstants(combineConsts);
     ResourceTableSetConstantBuffer(combineState.resourceTables[bufferIndex], { GetGraphicsConstantBuffer(), combineState.combineUniforms, 0, false, false, sizeof(Combine::CombineUniforms), (SizeT)offset });
     ResourceTableCommitChanges(combineState.resourceTables[bufferIndex]);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+LightContext::RenderShadows(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx)
+{
+    lightServerState.shadowMappingFrameScript->Run(ctx.frameIndex, ctx.bufferIndex);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/lighting/lightcontext.h
+++ b/code/render/lighting/lightcontext.h
@@ -93,6 +93,8 @@ public:
 
     /// prepare light lists
     static void UpdateViewDependentResources(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
+    /// Render shadows
+    static void RenderShadows(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
     /// run framescript when visibility is done
     static void RunFrameScriptJobs(const Graphics::FrameContext& ctx);
     /// React to window resize event

--- a/code/render/models/modelcontext.cc
+++ b/code/render/models/modelcontext.cc
@@ -62,13 +62,9 @@ ModelContext::Create()
 
     setupCompleteQueue.Resize(65535);
 
-    __bundle.OnBegin = ModelContext::UpdateTransforms;
-    __bundle.OnWaitForWork = ModelContext::WaitForWork;
-    __bundle.StageBits = &ModelContext::__state.currentStage;
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = ModelContext::OnRenderDebug;
 #endif
-    ModelContext::__state.allowedRemoveStages = Graphics::OnBeforeFrameStage;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 }
 

--- a/code/render/particles/particlecontext.cc
+++ b/code/render/particles/particlecontext.cc
@@ -76,15 +76,10 @@ void
 ParticleContext::Create()
 {
     __CreateContext();
-    __bundle.OnBegin = ParticleContext::UpdateParticles;
-    __bundle.OnPrepareView = ParticleContext::OnPrepareView;
-    __bundle.OnBeforeFrame = ParticleContext::WaitForParticleUpdates; // wait for jobs before we issue visibility
-    __bundle.StageBits = &ParticleContext::__state.currentStage;
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = ParticleContext::OnRenderDebug;
 #endif
 
-    ParticleContext::__state.allowedRemoveStages = Graphics::OnBeforeFrameStage;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
     struct VectorB4N

--- a/code/render/posteffects/histogramcontext.cc
+++ b/code/render/posteffects/histogramcontext.cc
@@ -75,7 +75,6 @@ void
 HistogramContext::Create()
 {
     __CreatePluginContext();
-    __bundle.OnUpdateViewResources = HistogramContext::UpdateViewResources;
     __bundle.OnWindowResized = HistogramContext::WindowResized;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 

--- a/code/render/posteffects/ssaocontext.cc
+++ b/code/render/posteffects/ssaocontext.cc
@@ -86,7 +86,6 @@ SSAOContext::Create()
 {
     __CreatePluginContext();
 
-    __bundle.OnUpdateViewResources = SSAOContext::UpdateViewDependentResources;
     __bundle.OnWindowResized = SSAOContext::WindowResized;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 }

--- a/code/render/posteffects/ssrcontext.cc
+++ b/code/render/posteffects/ssrcontext.cc
@@ -60,7 +60,6 @@ void
 SSRContext::Create()
 {
     __CreatePluginContext();
-    __bundle.OnUpdateViewResources = SSRContext::UpdateViewDependentResources;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
     // TODO: Convert to subgraph

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -246,10 +246,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
 
     Core::CVarCreate(Core::CVarType::CVar_Int, "r_terrain_debug", "0", "Show debug interface for the terrain system [0,1]");
 
-    __bundle.OnPrepareView = TerrainContext::CullPatches;
-    __bundle.OnUpdateViewResources = TerrainContext::UpdateLOD;
-    __bundle.OnBegin = TerrainContext::RenderUI;
-
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = TerrainContext::OnRenderDebug;
 #endif

--- a/code/render/vegetation/vegetationcontext.cc
+++ b/code/render/vegetation/vegetationcontext.cc
@@ -143,8 +143,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     __CreateContext();
     using namespace CoreGraphics;
 
-    __bundle.OnUpdateViewResources = VegetationContext::UpdateViewResources;
-
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
 
     vegetationState.minHeight = settings.minHeight;

--- a/code/render/visibility/visibilitycontext.cc
+++ b/code/render/visibility/visibilitycontext.cc
@@ -389,16 +389,10 @@ void
 ObserverContext::Create()
 {
     __CreateContext();
-    
-    __bundle.OnBegin = ObserverContext::RunVisibilityTests;
-    __bundle.OnBeforeFrame = ObserverContext::GenerateDrawLists;
-    __bundle.OnWaitForWork = ObserverContext::WaitForVisibility;
-    __bundle.StageBits = &ObservableContext::__state.currentStage;
 #ifndef PUBLIC_BUILD
     __bundle.OnRenderDebug = ObserverContext::OnRenderDebug;
 #endif 
 
-    ObserverContext::__state.allowedRemoveStages = Graphics::OnBeginStage;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
     __CreateContext();
 }
@@ -662,7 +656,6 @@ void
 ObservableContext::Create()
 {
     __CreateContext();
-    ObservableContext::__state.allowedRemoveStages = Graphics::OnBeforeFrameStage;
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&ObservableContext::__bundle, &ObservableContext::__state);
 }
 

--- a/tests/testrender/rendertest.cc
+++ b/tests/testrender/rendertest.cc
@@ -68,26 +68,23 @@ RenderTest::Run()
     {
         inputServer->OnFrame();
         resMgr->Update(frameIndex);
-        gfxServer->BeginFrame();
+        gfxServer->RunPreLogic();
 
-        // put game code which doesn't need visibility data or animation here
+        // Run game logic here
 
-        gfxServer->BeforeViews();
+        gfxServer->RunPostLogic();
 
-        // put game code which need visibility data here
+        // Run graphics independent updates here
 
-        gfxServer->RenderViews();
-
-        // put game code which needs rendering to be done (animation etc) here
-
-        gfxServer->EndViews();
-
-        // do stuff after rendering is done
+        gfxServer->Render();
 
         gfxServer->EndFrame();
         WindowPresent(wnd, frameIndex);
         if (inputServer->GetDefaultKeyboard()->KeyPressed(Input::Key::Escape)) run = false;
         frameIndex++;
+
+        // Progress to next frame
+        gfxServer->NewFrame();
     }
 
     DestroyWindow(wnd);

--- a/tests/testviewer/viewerapp.cc
+++ b/tests/testviewer/viewerapp.cc
@@ -245,14 +245,14 @@ SimpleViewerApplication::Open()
         Util::FixedArray<Graphics::ViewIndependentCall> preLogicCalls = 
         {
             Im3d::Im3dContext::NewFrame,
-            Dynui::ImguiContext::OnBeforeFrame,
+            Dynui::ImguiContext::NewFrame,
             CameraContext::UpdateCameras,
             ModelContext::UpdateTransforms,
             Characters::CharacterContext::UpdateAnimations,
-            Particles::ParticleContext::UpdateParticles,
             Fog::VolumetricFogContext::RenderUI,
             EnvironmentContext::OnBeforeFrame,
             EnvironmentContext::RenderUI,
+            Particles::ParticleContext::UpdateParticles,
             //Terrain::TerrainContext::RenderUI
         };
 
@@ -261,6 +261,12 @@ SimpleViewerApplication::Open()
             Lighting::LightContext::OnPrepareView,
             Particles::ParticleContext::OnPrepareView,
             Im3d::Im3dContext::OnPrepareView,
+            PostEffects::SSAOContext::UpdateViewDependentResources,
+            PostEffects::HistogramContext::UpdateViewResources,
+            Decals::DecalContext::UpdateViewDependentResources,
+            Fog::VolumetricFogContext::UpdateViewDependentResources,
+            Lighting::LightContext::UpdateViewDependentResources,
+
             //Terrain::TerrainContext::CullPatches
         };
 
@@ -271,7 +277,7 @@ SimpleViewerApplication::Open()
             ObserverContext::GenerateDrawLists,
 
             // At the very latest point, wait for work to finish
-            Dynui::ImguiContext::OnWorkFinished,
+            Dynui::ImguiContext::Render,
             ModelContext::WaitForWork,
             Characters::CharacterContext::WaitForCharacterJobs,
             Particles::ParticleContext::WaitForParticleUpdates,
@@ -280,13 +286,8 @@ SimpleViewerApplication::Open()
 
         Util::FixedArray<Graphics::ViewDependentCall> postLogicViewCalls = 
         {
-            Lighting::LightContext::UpdateViewDependentResources,
             Lighting::LightContext::RenderShadows,
-            PostEffects::SSAOContext::UpdateViewDependentResources,
-            PostEffects::HistogramContext::UpdateViewResources,
-            //PostEffects::SSRContext::UpdateViewDependentResources,
-            Decals::DecalContext::UpdateViewDependentResources,
-            Fog::VolumetricFogContext::UpdateViewDependentResources,
+
             //Terrain::TerrainContext::UpdateLOD,
             //Vegetation::VegetationContext::UpdateViewResources
         };

--- a/tests/testvisibility/visibilitytest.cc
+++ b/tests/testvisibility/visibilitytest.cc
@@ -187,22 +187,18 @@ VisibilityTest::Run()
         inputServer->BeginFrame();
         inputServer->OnFrame();
 
-        gfxServer->BeginFrame();
+        gfxServer->RunPreLogic();
         
         ImGui::Begin("VisibilityTest", NULL);
         ImGui::Text("FPS: %.2f", 1 / (previousTime /1000.0f));
         ImGui::End();
         // put game code which doesn't need visibility data or animation here
 
-        gfxServer->BeforeViews();
+        gfxServer->RunPostLogic();
 
         // put game code which need visibility data here
 
-        gfxServer->RenderViews();
-
-        // put game code which needs rendering to be done (animation etc) here
-
-        gfxServer->EndViews();
+        gfxServer->Render();
 
         // do stuff after rendering is done
 
@@ -211,6 +207,8 @@ VisibilityTest::Run()
         // force wait immediately
         WindowPresent(wnd, frameIndex);
         if (kdb->KeyPressed(Input::Key::Escape)) run = false;
+
+        gfxServer->NewFrame();
 
         // standard input handling: manipulate camera
         mayaCamera.SetOrbitButton(mouse->ButtonPressed(MouseButton::LeftButton));


### PR DESCRIPTION
The old way would provide a plethora of entry points, for example OnBegin, OnBeforeView, onAfterView, etc. This new way allows us you more freely setup in which order to call graphics context functions, and provides a better overview of how they are run. 