### PR TITLE
Fixes blinking visibility

### DIFF
--- a/code/addons/graphicsfeature/graphicsfeatureunit.cc
+++ b/code/addons/graphicsfeature/graphicsfeatureunit.cc
@@ -199,12 +199,12 @@ GraphicsFeatureUnit::OnActivate()
         ModelContext::WaitForWork,
         Characters::CharacterContext::WaitForCharacterJobs,
         Particles::ParticleContext::WaitForParticleUpdates,
-        ObserverContext::WaitForVisibility
+        ObserverContext::WaitForVisibility,
+        Lighting::LightContext::RenderShadows,
     };
 
     Util::FixedArray<Graphics::ViewDependentCall> postLogicViewCalls =
     {
-        Lighting::LightContext::RenderShadows,
 
         //Terrain::TerrainContext::UpdateLOD,
         //Vegetation::VegetationContext::UpdateViewResources

--- a/code/render/characters/charactercontext.cc
+++ b/code/render/characters/charactercontext.cc
@@ -30,7 +30,7 @@ __ImplementContext(CharacterContext, CharacterContext::characterContextAllocator
 
 Util::HashTable<Util::StringAtom, CoreAnimation::AnimSampleMask> CharacterContext::masks;
 Threading::Event CharacterContext::totalCompletionEvent;
-Threading::AtomicCounter CharacterContext::constantUpdateCounter = 0;
+Threading::AtomicCounter CharacterContext::ConstantUpdateCounter = 0;
 
 //------------------------------------------------------------------------------
 /**
@@ -59,7 +59,6 @@ CharacterContext::Create()
     __bundle.OnRenderDebug = CharacterContext::OnRenderDebug;
 #endif
     Graphics::GraphicsServer::Instance()->RegisterGraphicsContext(&__bundle, &__state);
-
 }
 
 //------------------------------------------------------------------------------
@@ -72,7 +71,6 @@ CharacterContext::Setup(const Graphics::GraphicsEntityId id, const Resources::Re
     n_assert_fmt(cid != InvalidContextEntityId, "Entity %d is not registered in CharacterContext", id.HashCode());
     characterContextAllocator.Set<Loaded>(cid.id, NoneLoaded);
     characterContextAllocator.Set<EntityId>(cid.id, id);
-
 
     // check to make sure we registered this entity for observation, then get the visibility context
     const ContextEntityId visId = Visibility::ObservableContext::GetContextId(id);
@@ -814,8 +812,8 @@ CharacterContext::UpdateAnimations(const Graphics::FrameContext& ctx)
         // Run job
         Jobs2::JobDispatch(EvalCharacter, models.Size(), 64, charCtx, nullptr, &animationCounter, nullptr);
 
-        n_assert(constantUpdateCounter == 0);
-        constantUpdateCounter = 1;
+        n_assert(ConstantUpdateCounter == 0);
+        ConstantUpdateCounter = 1;
 
         struct UpdateJointsContext
         {
@@ -873,7 +871,7 @@ CharacterContext::UpdateAnimations(const Graphics::FrameContext& ctx)
                 renderables.nodeStates[node].resourceTableOffsets[renderables.nodeStates[node].skinningConstantsIndex] = offset;
             }
 
-        }, characterSkinNodeIndices.Size(), 64, jobCtx, { &animationCounter }, &constantUpdateCounter, &CharacterContext::totalCompletionEvent);
+        }, characterSkinNodeIndices.Size(), 64, jobCtx, { &animationCounter }, &ConstantUpdateCounter, &CharacterContext::totalCompletionEvent);
     }
     else // If we have no jobs, just signal completion event
         CharacterContext::totalCompletionEvent.Signal();

--- a/code/render/characters/charactercontext.h
+++ b/code/render/characters/charactercontext.h
@@ -131,7 +131,7 @@ public:
         AnimationLoaded = N_BIT(2),
     };
 
-    static Threading::AtomicCounter constantUpdateCounter;
+    static Threading::AtomicCounter ConstantUpdateCounter;
 private:
     friend struct CharacterJobContext;
 

--- a/code/render/graphics/graphicsserver.cc
+++ b/code/render/graphics/graphicsserver.cc
@@ -472,6 +472,7 @@ GraphicsServer::RunPreLogic()
 
         // begin frame on view, this will construct view build jobs
         this->currentView = view;
+        view->UpdateConstants();
         N_MARKER_BEGIN(ContextPerView, Graphics);
         for (auto& call : this->preLogicViewCalls)
         {

--- a/code/render/graphics/view.cc
+++ b/code/render/graphics/view.cc
@@ -44,13 +44,11 @@ View::~View()
 /**
 */
 void
-View::Render(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex)
+View::UpdateConstants()
 {
-    // run the actual script
-    if (this->camera != GraphicsEntityId::Invalid() && this->script != nullptr)
+    if (this->camera != GraphicsEntityId::Invalid())
     {
         // update camera
-        ShaderServer* shaderServer = ShaderServer::Instance();
         auto settings = CameraContext::GetSettings(this->camera);
 
         Shared::ViewConstants constants = Graphics::GetViewConstants();
@@ -80,6 +78,19 @@ View::Render(const IndexT frameIndex, const Timing::Time time, const IndexT buff
 
         // Apply view transforms
         Graphics::UpdateViewConstants(constants);
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+View::Render(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex)
+{
+    // run the actual script
+    if (this->script != nullptr)
+    {
+        
 
         N_SCOPE(ViewExecute, Graphics);
         this->script->Run(frameIndex, bufferIndex);

--- a/code/render/graphics/view.h
+++ b/code/render/graphics/view.h
@@ -28,6 +28,8 @@ public:
     /// destructor
     virtual ~View();
 
+    /// Update constants
+    void UpdateConstants();
     /// render through view
     void Render(const IndexT frameIndex, const Timing::Time time, const IndexT bufferIndex);
 

--- a/code/render/lighting/lightcontext.h
+++ b/code/render/lighting/lightcontext.h
@@ -94,7 +94,7 @@ public:
     /// prepare light lists
     static void UpdateViewDependentResources(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
     /// Render shadows
-    static void RenderShadows(const Ptr<Graphics::View>& view, const Graphics::FrameContext& ctx);
+    static void RenderShadows(const Graphics::FrameContext& ctx);
     /// run framescript when visibility is done
     static void RunFrameScriptJobs(const Graphics::FrameContext& ctx);
     /// React to window resize event

--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -158,7 +158,8 @@ public:
     /// Get node transformable context
     static const ModelInstance::Transformable& GetModelTransformables();
 
-    static Threading::AtomicCounter constantsUpdateCounter;
+    static Threading::AtomicCounter ConstantsUpdateCounter;
+    static Threading::AtomicCounter TransformsUpdateCounter;
 
 private:
     friend class VisibilityContext;

--- a/code/render/particles/particlecontext.cc
+++ b/code/render/particles/particlecontext.cc
@@ -33,7 +33,7 @@ Timing::Time StepTime = 1.0f / 60.0f;
 
 const SizeT ParticleContextNumEnvelopeSamples = 192;
 Threading::AtomicCounter allSystemsCompleteCounter = 0;
-Threading::AtomicCounter ParticleContext::constantUpdateCounter = 0;
+Threading::AtomicCounter ParticleContext::ConstantUpdateCounter = 0;
 Threading::Event ParticleContext::totalCompletionEvent;
 
 struct
@@ -451,8 +451,8 @@ ParticleContext::OnPrepareView(const Ptr<Graphics::View>& view, const Graphics::
         jobCtx.models = &graphicsEntities;
         jobCtx.invViewMatrix = Graphics::CameraContext::GetTransform(view->GetCamera());
 
-        n_assert(ParticleContext::constantUpdateCounter == 0);
-        ParticleContext::constantUpdateCounter = 1;
+        n_assert(ParticleContext::ConstantUpdateCounter == 0);
+        ParticleContext::ConstantUpdateCounter = 1;
 
         // Run job to update constants, can be per-view because of the billboard flag
         Jobs2::JobDispatch([](SizeT totalJobs, SizeT groupSize, IndexT groupIndex, SizeT invocationOffset, void* ctx)
@@ -504,10 +504,10 @@ ParticleContext::OnPrepareView(const Ptr<Graphics::View>& view, const Graphics::
                 }
             }
 
-        }, allSystems.Size(), 128, jobCtx, { &allSystemsCompleteCounter }, &ParticleContext::constantUpdateCounter, &ParticleContext::totalCompletionEvent);
+        }, allSystems.Size(), 128, jobCtx, { &allSystemsCompleteCounter }, &ParticleContext::ConstantUpdateCounter, &ParticleContext::totalCompletionEvent);
     }
 
-    if (ParticleContext::constantUpdateCounter == 0)
+    if (ParticleContext::ConstantUpdateCounter == 0)
         ParticleContext::totalCompletionEvent.Signal();
 }
 

--- a/code/render/particles/particlecontext.h
+++ b/code/render/particles/particlecontext.h
@@ -77,7 +77,7 @@ public:
 
     static CoreGraphics::MeshId DefaultEmitterMesh;
 
-    static Threading::AtomicCounter constantUpdateCounter;
+    static Threading::AtomicCounter ConstantUpdateCounter;
     static Threading::Event totalCompletionEvent;
 private:
 

--- a/code/render/visibility/systems/bruteforcesystem.h
+++ b/code/render/visibility/systems/bruteforcesystem.h
@@ -21,7 +21,7 @@ private:
     void Setup(const BruteforceSystemLoadInfo& info);
 
     /// run system
-    void Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters) override;
+    void Run(const Threading::AtomicCounter* const* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters) override;
 };
 
 } // namespace Visibility

--- a/code/render/visibility/systems/visibilitysystem.cc
+++ b/code/render/visibility/systems/visibilitysystem.cc
@@ -20,8 +20,9 @@ VisibilitySystem::VisibilitySystem()
 void
 VisibilitySystem::PrepareObservers(const Math::mat4* transforms, Util::Array<Math::ClipStatus::Type>* results, const SizeT count)
 {
-    const Threading::AtomicCounter c = 0;
-    this->obs.completionCounters.Fill(0, count, c);
+    this->obs.completionCounters.Reserve(count);
+    for (IndexT i = 0; i < count; i++)
+        this->obs.completionCounters.Append(new Threading::AtomicCounter(0));
     this->obs.transforms = transforms;
     this->obs.results = results;
     this->obs.count = count;
@@ -44,7 +45,7 @@ VisibilitySystem::PrepareEntities(const Math::bbox* boxes, const uint32* ids, co
 /**
 */
 void
-VisibilitySystem::Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters)
+VisibilitySystem::Run(const Threading::AtomicCounter* const* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters)
 {
     // do nothing
 }
@@ -52,19 +53,19 @@ VisibilitySystem::Run(const Threading::AtomicCounter* previousSystemCompletionCo
 //------------------------------------------------------------------------------
 /**
 */
-Threading::AtomicCounter*
-VisibilitySystem::GetCompletionCounter(IndexT i)
+const Threading::AtomicCounter*
+VisibilitySystem::GetCompletionCounter(IndexT i) const
 {
-    return &this->obs.completionCounters[i];
+    return this->obs.completionCounters[i];
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-const Threading::AtomicCounter*
+const Threading::AtomicCounter* const*
 VisibilitySystem::GetCompletionCounters() const
 {
-    return this->obs.completionCounters.Begin();
+    return this->obs.completionCounters.ConstBegin();
 }
 
 } // namespace Visibility

--- a/code/render/visibility/systems/visibilitysystem.h
+++ b/code/render/visibility/systems/visibilitysystem.h
@@ -92,12 +92,12 @@ public:
     /// prepare system with entities to insert into the structure
     virtual void PrepareEntities(const Math::bbox* transforms, const uint32* ranges, const Graphics::GraphicsEntityId* entities, const uint32_t* entityFlags, const SizeT count);
     /// run system
-    virtual void Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters);
+    virtual void Run(const Threading::AtomicCounter* const* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters);
 
     /// Return completion counter for an observer
-    Threading::AtomicCounter* GetCompletionCounter(IndexT i);
+    const Threading::AtomicCounter* GetCompletionCounter(IndexT i) const;
     /// Return completion counter for all observers
-    const Threading::AtomicCounter* GetCompletionCounters() const;
+    const Threading::AtomicCounter* const* GetCompletionCounters() const;
 
 protected:
 
@@ -109,7 +109,7 @@ protected:
         const Math::mat4* transforms;
         Util::Array<Math::ClipStatus::Type>* results;
         SizeT count;
-        Util::Array<Threading::AtomicCounter> completionCounters;
+        Util::Array<Threading::AtomicCounter*> completionCounters;
     } obs;
 
     struct Entity

--- a/tests/testviewer/viewerapp.cc
+++ b/tests/testviewer/viewerapp.cc
@@ -266,7 +266,6 @@ SimpleViewerApplication::Open()
             Decals::DecalContext::UpdateViewDependentResources,
             Fog::VolumetricFogContext::UpdateViewDependentResources,
             Lighting::LightContext::UpdateViewDependentResources,
-
             //Terrain::TerrainContext::CullPatches
         };
 
@@ -281,12 +280,12 @@ SimpleViewerApplication::Open()
             ModelContext::WaitForWork,
             Characters::CharacterContext::WaitForCharacterJobs,
             Particles::ParticleContext::WaitForParticleUpdates,
-            ObserverContext::WaitForVisibility
+            ObserverContext::WaitForVisibility,
+            Lighting::LightContext::RenderShadows,
         };
 
         Util::FixedArray<Graphics::ViewDependentCall> postLogicViewCalls = 
         {
-            Lighting::LightContext::RenderShadows,
 
             //Terrain::TerrainContext::UpdateLOD,
             //Vegetation::VegetationContext::UpdateViewResources


### PR DESCRIPTION
Changes the wait sequence for the different rendering jobs, to ensure we wait for particles, characters and models before we start the visibility tests. 