### PR TITLE
Make the submission wait events simpler.

### DIFF
--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -1231,6 +1231,7 @@ CmdEndMarker(const CmdBufferId id)
     if (queryBundle.enabled[CoreGraphics::TimestampsQueryType])
     {
         CmdBufferMarkerBundle& markers = commandBuffers.GetUnsafe<CmdBuffer_ProfilingMarkers>(id.id24);
+        n_assert(!markers.markerStack.IsEmpty());
         FrameProfilingMarker marker = markers.markerStack.Pop();
         marker.gpuEnd = queryBundle.offset[CoreGraphics::TimestampsQueryType] + queryBundle.queryCount[CoreGraphics::TimestampsQueryType]++;
         vkCmdWriteTimestamp(cmdBuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, pool, marker.gpuEnd);


### PR DESCRIPTION
Instead of having a fixed array of wait events per queue, we can still have an array with queue and wait event pairs that we go through. This simplifies the waiting for queues as we can just traverse a single array for all queues. 