### PR TITLE
Feature/static resource table bindings

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -43,11 +43,10 @@ UltralightRenderer::UltralightRenderer()
     CoreGraphics::ResourceTableSetConstantBuffer(ultralightState.resourceTable,
         {
             CoreGraphics::GetGraphicsConstantBuffer(),
-            CoreGraphics::ShaderGetResourceSlot(shader, "PerDrawState"),
+            Staticui::Table_DynamicOffset::PerDrawState::SLOT,
             0,
-
             false, true,
-            sizeof(Staticui::PerDrawState), 0
+            Staticui::Table_DynamicOffset::PerDrawState::SIZE, 0
         });
     CoreGraphics::ResourceTableCommitChanges(ultralightState.resourceTable);
 

--- a/code/render/clustering/clustercontext.cc
+++ b/code/render/clustering/clustercontext.cc
@@ -28,7 +28,6 @@ struct
 
     ClusterGenerate::ClusterUniforms uniforms;
     CoreGraphics::BufferId constantBuffer;
-    IndexT uniformsSlot, clusterAABBSlot;
 
     CoreGraphics::WindowId window;
 
@@ -80,8 +79,6 @@ ClusterContext::Create(float ZNear, float ZFar, const CoreGraphics::WindowId win
 
     uint numBuffers = CoreGraphics::GetNumBufferedFrames();
 
-    state.uniformsSlot = ShaderGetResourceSlot(state.clusterShader, "ClusterUniforms");
-    state.clusterAABBSlot = ShaderGetResourceSlot(state.clusterShader, "ClusterAABBs");
 
     state.window = window;
     state.zNear = ZNear;
@@ -108,18 +105,18 @@ ClusterContext::Create(float ZNear, float ZFar, const CoreGraphics::WindowId win
     rwb3Info.usageFlags = CoreGraphics::ReadWriteBuffer;
     rwb3Info.queueSupport = CoreGraphics::GraphicsQueueSupport | CoreGraphics::ComputeQueueSupport;
     state.clusterBuffer = CreateBuffer(rwb3Info);
-    state.constantBuffer = ShaderCreateConstantBuffer(state.clusterShader, "ClusterUniforms");
+    state.constantBuffer = ShaderCreateConstantBuffer(state.clusterShader, "ClusterUniforms", CoreGraphics::DeviceAndHost);
 
     for (IndexT i = 0; i < CoreGraphics::GetNumBufferedFrames(); i++)
     {
         CoreGraphics::ResourceTableId computeTable = Graphics::GetFrameResourceTableCompute(i);
         CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
-        ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, state.clusterAABBSlot, 0, false, false, -1, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, state.uniformsSlot, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+        ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
 
-        ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, state.clusterAABBSlot, 0, false, false, -1, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, state.uniformsSlot, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
     }
 
     Frame::FrameCode* op = state.frameOpAllocator.Alloc<Frame::FrameCode>();
@@ -181,7 +178,7 @@ ClusterContext::UpdateResources(const Graphics::FrameContext& ctx)
     state.uniforms.BlockSize[1] = ClusterSubdivsY;
 
     // update constant buffer, probably super unnecessary since these values never change
-    BufferUpdate(state.constantBuffer, state.uniforms, 0);
+    BufferUpdate(state.constantBuffer, state.uniforms);
     BufferFlush(state.constantBuffer);
 }
 
@@ -233,12 +230,12 @@ ClusterContext::WindowResized(const CoreGraphics::WindowId id, SizeT width, Size
             CoreGraphics::ResourceTableId computeTable = Graphics::GetFrameResourceTableCompute(i);
             CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
-            ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, state.clusterAABBSlot, 0, false, false, -1, 0 });
-            ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, state.uniformsSlot, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+            ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
+            ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
             ResourceTableCommitChanges(computeTable);
 
-            ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, state.clusterAABBSlot, 0, false, false, -1, 0 });
-            ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, state.uniformsSlot, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+            ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
+            ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
             ResourceTableCommitChanges(graphicsTable);
         }
     }

--- a/code/render/coregraphics/vk/vkpass.cc
+++ b/code/render/coregraphics/vk/vkpass.cc
@@ -523,30 +523,22 @@ SetupPass(const PassId pid)
         // setup input attachments
         for (i = 0; i < loadInfo.colorAttachments.Size(); i++)
         {
-            // update descriptor set based on images attachments
-            IndexT inputAttachmentLocation = ShaderGetResourceSlot(sid, Util::String::Sprintf("InputAttachment%d", i));
-            n_assert(inputAttachmentLocation != InvalidIndex);
-
             n_assert(loadInfo.colorAttachments.Size() < 16); // only allow 8 input attachments in the shader, so we must limit it
             CoreGraphics::ResourceTableInputAttachment write;
             write.tex = loadInfo.colorAttachments[i];
             write.isDepth = false;
             write.sampler = InvalidSamplerId;
-            write.slot = inputAttachmentLocation;
+            write.slot = Shared::Table_Pass::InputAttachment0_SLOT + i;
             write.index = 0;
             ResourceTableSetInputAttachment(runtimeInfo.passDescriptorSet, write);
         }
         if (loadInfo.depthStencilAttachment != CoreGraphics::InvalidTextureViewId)
         {
-            // update descriptor set based on images attachments
-            IndexT inputAttachmentLocation = ShaderGetResourceSlot(sid, Util::String::Sprintf("DepthAttachment", i));
-            n_assert(inputAttachmentLocation != InvalidIndex);
-
             CoreGraphics::ResourceTableInputAttachment write;
             write.tex = loadInfo.depthStencilAttachment;
             write.isDepth = true;
             write.sampler = InvalidSamplerId;
-            write.slot = inputAttachmentLocation;
+            write.slot = Shared::Table_Pass::DepthAttachment_SLOT;
             write.index = 0;
             ResourceTableSetInputAttachment(runtimeInfo.passDescriptorSet, write);
         }

--- a/code/render/decals/decalcontext.cc
+++ b/code/render/decals/decalcontext.cc
@@ -75,12 +75,6 @@ DecalContext::Create()
     using namespace CoreGraphics;
     decalState.classificationShader = ShaderServer::Instance()->GetShader("shd:decals_cluster.fxb");
 
-    IndexT decalIndexListsSlot = ShaderGetResourceSlot(decalState.classificationShader, "DecalIndexLists");
-    IndexT decalListSlot = ShaderGetResourceSlot(decalState.classificationShader, "DecalLists");
-
-    IndexT clusterAABBSlot = ShaderGetResourceSlot(decalState.classificationShader, "ClusterAABBs");
-    decalState.uniformsSlot = ShaderGetResourceSlot(decalState.classificationShader, "DecalUniforms");
-
     decalState.cullProgram = ShaderGetProgram(decalState.classificationShader, ShaderServer::Instance()->FeatureStringToMask("Cull"));
     decalState.renderPBRProgram = ShaderGetProgram(decalState.classificationShader, ShaderServer::Instance()->FeatureStringToMask("RenderPBR"));
     decalState.renderEmissiveProgram = ShaderGetProgram(decalState.classificationShader, ShaderServer::Instance()->FeatureStringToMask("RenderEmissive"));
@@ -116,14 +110,14 @@ DecalContext::Create()
         CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
         // update resource table
-        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalIndexLists, decalIndexListsSlot, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalsList, decalListSlot, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), decalState.uniformsSlot, 0, false, false, sizeof(DecalsCluster::DecalUniforms), 0 });
+        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, false, false, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
         ResourceTableCommitChanges(computeTable);
 
-        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalIndexLists, decalIndexListsSlot, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalsList, decalListSlot, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), decalState.uniformsSlot, 0, false, false, sizeof(DecalsCluster::DecalUniforms), 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, false, false, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 

--- a/code/render/graphics/bindlessregistry.cc
+++ b/code/render/graphics/bindlessregistry.cc
@@ -19,21 +19,6 @@ struct
     Util::FixedPool<uint32_t> textureCubePool;
     Util::FixedPool<uint32_t> textureCubeArrayPool;
 
-    IndexT texture2DTextureVar;
-    IndexT texture2DMSTextureVar;
-    IndexT texture2DArrayTextureVar;
-    IndexT texture3DTextureVar;
-    IndexT textureCubeTextureVar;
-
-    IndexT normalBufferTextureVar;
-    IndexT depthBufferTextureVar;
-    IndexT specularBufferTextureVar;
-    IndexT depthBufferCopyTextureVar;
-    
-    IndexT environmentMapVar;
-    IndexT irradianceMapVar;
-    IndexT numEnvMipsVar;
-
     Threading::CriticalSection bindResourceCriticalSection;
 
 } state;
@@ -58,24 +43,6 @@ CreateBindlessRegistry(const BindlessRegistryCreateInfo& info)
     state.textureCubePool.Resize(Shared::MAX_CUBE_TEXTURES);
     state.texture2DArrayPool.SetSetupFunc(func);
     state.texture2DArrayPool.Resize(Shared::MAX_2D_ARRAY_TEXTURES);
-    
-    // create shader state for textures, and fetch variables
-    CoreGraphics::ShaderId shader = CoreGraphics::ShaderGet("shd:shared.fxb"_atm);
-    
-    state.texture2DTextureVar = CoreGraphics::ShaderGetResourceSlot(shader, "Textures2D");
-    state.texture2DMSTextureVar = CoreGraphics::ShaderGetResourceSlot(shader, "Textures2DMS");
-    state.texture2DArrayTextureVar = CoreGraphics::ShaderGetResourceSlot(shader, "Textures2DArray");
-    state.textureCubeTextureVar = CoreGraphics::ShaderGetResourceSlot(shader, "TexturesCube");
-    state.texture3DTextureVar = CoreGraphics::ShaderGetResourceSlot(shader, "Textures3D");
-    
-    state.normalBufferTextureVar = CoreGraphics::ShaderGetConstantBinding(shader, "NormalBuffer");
-    state.depthBufferTextureVar = CoreGraphics::ShaderGetConstantBinding(shader, "DepthBuffer");
-    state.specularBufferTextureVar = CoreGraphics::ShaderGetConstantBinding(shader, "SpecularBuffer");
-    state.depthBufferCopyTextureVar = CoreGraphics::ShaderGetConstantBinding(shader, "DepthBufferCopy");
-    
-    state.environmentMapVar = CoreGraphics::ShaderGetConstantBinding(shader, "EnvironmentMap");
-    state.irradianceMapVar = CoreGraphics::ShaderGetConstantBinding(shader, "IrradianceMap");
-    state.numEnvMipsVar = CoreGraphics::ShaderGetConstantBinding(shader, "NumEnvMips");
 }
 
 //------------------------------------------------------------------------------
@@ -100,22 +67,22 @@ RegisterTexture(const CoreGraphics::TextureId& tex, CoreGraphics::TextureType ty
     case CoreGraphics::Texture2D:
         n_assert(!state.texture2DPool.IsFull());
         idx = state.texture2DPool.Alloc();
-        var = state.texture2DTextureVar;
+        var = Shared::Table_Tick::Textures2D_SLOT;
         break;
     case CoreGraphics::Texture2DArray:
         n_assert(!state.texture2DArrayPool.IsFull());
         idx = state.texture2DArrayPool.Alloc();
-        var = state.texture2DArrayTextureVar;
+        var = Shared::Table_Tick::Textures2DArray_SLOT;
         break;
     case CoreGraphics::Texture3D:
         n_assert(!state.texture3DPool.IsFull());
         idx = state.texture3DPool.Alloc();
-        var = state.texture3DTextureVar;
+        var = Shared::Table_Tick::Textures3D_SLOT;
         break;
     case CoreGraphics::TextureCube:
         n_assert(!state.textureCubePool.IsFull());
         idx = state.textureCubePool.Alloc();
-        var = state.textureCubeTextureVar;
+        var = Shared::Table_Tick::TexturesCube_SLOT;
         break;
     default:
         n_error("Should not happen");
@@ -154,16 +121,16 @@ ReregisterTexture(const CoreGraphics::TextureId& tex, CoreGraphics::TextureType 
     switch (type)
     {
     case CoreGraphics::Texture2D:
-        var = state.texture2DTextureVar;
+        var = Shared::Table_Tick::Textures2D_SLOT;
         break;
     case CoreGraphics::Texture2DArray:
-        var = state.texture2DArrayTextureVar;
+        var = Shared::Table_Tick::Textures2DArray_SLOT;
         break;
     case CoreGraphics::Texture3D:
-        var = state.texture3DTextureVar;
+        var = Shared::Table_Tick::Textures3D_SLOT;
         break;
     case CoreGraphics::TextureCube:
-        var = state.textureCubeTextureVar;
+        var = Shared::Table_Tick::TexturesCube_SLOT;
         break;
     }
 
@@ -196,19 +163,19 @@ UnregisterTexture(const BindlessIndex id, const CoreGraphics::TextureType type)
     switch (type)
     {
     case CoreGraphics::Texture2D:
-        var = state.texture2DTextureVar;
+        var = Shared::Table_Tick::Textures2D_SLOT;
         state.texture2DPool.Free(id);
         break;
     case CoreGraphics::Texture2DArray:
-        var = state.texture2DArrayTextureVar;
+        var = Shared::Table_Tick::Textures2DArray_SLOT;
         state.texture2DArrayPool.Free(id);
         break;
     case CoreGraphics::Texture3D:
-        var = state.texture3DTextureVar;
+        var = Shared::Table_Tick::Textures3D_SLOT;
         state.texture3DPool.Free(id);
         break;
     case CoreGraphics::TextureCube:
-        var = state.textureCubeTextureVar;
+        var = Shared::Table_Tick::TexturesCube_SLOT;
         state.textureCubePool.Free(id);
         break;
     }

--- a/code/render/models/nodes/characterskinnode.cc
+++ b/code/render/models/nodes/characterskinnode.cc
@@ -6,6 +6,8 @@
 #include "characterskinnode.h"
 #include "coregraphics/shaderserver.h"
 
+#include "objects_shared.h"
+
 namespace Models
 {
 
@@ -75,8 +77,7 @@ CharacterSkinNode::OnFinishedLoading()
     PrimitiveNode::OnFinishedLoading();
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderServer::Instance()->GetShader("shd:objects_shared.fxb"_atm);
     CoreGraphics::BufferId cbo = CoreGraphics::GetGraphicsConstantBuffer();
-    IndexT index = CoreGraphics::ShaderGetResourceSlot(shader, "JointBlock");
-    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, index, 0, false, true, (SizeT)(sizeof(Math::mat4) * this->skinFragments[0].jointPalette.Size()), 0 });
+    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, ObjectsShared::Table_DynamicOffset::JointBlock::SLOT, 0, false, true, (SizeT)(sizeof(Math::mat4) * this->skinFragments[0].jointPalette.Size()), 0 });
     CoreGraphics::ResourceTableCommitChanges(this->resourceTable);
 }
 

--- a/code/render/models/nodes/particlesystemnode.cc
+++ b/code/render/models/nodes/particlesystemnode.cc
@@ -89,10 +89,10 @@ ParticleSystemNode::OnFinishedLoading()
 
     ShaderId shader = ShaderServer::Instance()->GetShader("shd:particle.fxb"_atm);
     BufferId cbo = GetGraphicsConstantBuffer();
-    this->objectTransformsIndex = ShaderGetResourceSlot(shader, "ObjectBlock");
-    this->instancingTransformsIndex = ShaderGetResourceSlot(shader, "InstancingBlock");
-    this->skinningTransformsIndex = ShaderGetResourceSlot(shader, "JointBlock");
-    this->particleConstantsIndex = ShaderGetResourceSlot(shader, "ParticleObjectBlock");
+    this->objectTransformsIndex = ::Particle::Table_DynamicOffset::ObjectBlock::SLOT;
+    this->instancingTransformsIndex = ::Particle::Table_DynamicOffset::InstancingBlock::SLOT;
+    this->skinningTransformsIndex = ::Particle::Table_DynamicOffset::JointBlock::SLOT;
+    this->particleConstantsIndex = ::Particle::Table_DynamicOffset::ParticleObjectBlock::SLOT;
     this->resourceTable = ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
     ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->particleConstantsIndex, 0, false, true, sizeof(::Particle::ParticleObjectBlock), 0 });
     ResourceTableCommitChanges(this->resourceTable);

--- a/code/render/models/nodes/shaderstatenode.cc
+++ b/code/render/models/nodes/shaderstatenode.cc
@@ -145,9 +145,9 @@ ShaderStateNode::OnFinishedLoading()
     this->material = Materials::materialCache->GetId(this->materialRes);
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderServer::Instance()->GetShader("shd:objects_shared.fxb"_atm);
     CoreGraphics::BufferId cbo = CoreGraphics::GetGraphicsConstantBuffer();
-    this->objectTransformsIndex = CoreGraphics::ShaderGetResourceSlot(shader, "ObjectBlock");
-    this->instancingTransformsIndex = CoreGraphics::ShaderGetResourceSlot(shader, "InstancingBlock");
-    this->skinningTransformsIndex = CoreGraphics::ShaderGetResourceSlot(shader, "JointBlock");
+    this->objectTransformsIndex = ObjectsShared::Table_DynamicOffset::ObjectBlock::SLOT;
+    this->instancingTransformsIndex = ObjectsShared::Table_DynamicOffset::InstancingBlock::SLOT;
+    this->skinningTransformsIndex = ObjectsShared::Table_DynamicOffset::JointBlock::SLOT;
 
     this->resourceTable = CoreGraphics::ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
     CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->objectTransformsIndex, 0, false, true, sizeof(ObjectsShared::ObjectBlock), 0 });

--- a/code/render/posteffects/histogramcontext.cc
+++ b/code/render/posteffects/histogramcontext.cc
@@ -119,7 +119,7 @@ HistogramContext::Create()
     histogramState.histogramResourceTable = CoreGraphics::ShaderCreateResourceTable(histogramState.histogramShader, NEBULA_BATCH_GROUP);
     CoreGraphics::ResourceTableSetRWBuffer(histogramState.histogramResourceTable, {
         histogramState.histogramCounters,
-        CoreGraphics::ShaderGetResourceSlot(histogramState.histogramShader, "HistogramBuffer"),
+        HistogramCs::Table_Batch::HistogramBuffer::SLOT,
         0,
         false,
         false,
@@ -128,7 +128,7 @@ HistogramContext::Create()
     });
     CoreGraphics::ResourceTableSetConstantBuffer(histogramState.histogramResourceTable, {
         histogramState.histogramConstants,
-        CoreGraphics::ShaderGetResourceSlot(histogramState.histogramShader, "HistogramConstants"),
+        HistogramCs::Table_Batch::HistogramConstants::SLOT,
         0,
         false,
         false,
@@ -162,7 +162,7 @@ HistogramContext::Create()
 
     CoreGraphics::ResourceTableSetRWBuffer(histogramState.downsampleResourceTable, {
         histogramState.downsampleCounter,
-        CoreGraphics::ShaderGetResourceSlot(histogramState.downsampleShader, "AtomicCounter"),
+        DownsampleCsMin::Table_Batch::AtomicCounter::SLOT,
         0,
         false,
         false,
@@ -171,7 +171,7 @@ HistogramContext::Create()
     });
     CoreGraphics::ResourceTableSetConstantBuffer(histogramState.downsampleResourceTable, {
         histogramState.downsampleConstants,
-        CoreGraphics::ShaderGetResourceSlot(histogramState.downsampleShader, "DownsampleUniforms"),
+        DownsampleCsMin::Table_Batch::DownsampleUniforms::SLOT,
         0,
         false,
         false,
@@ -233,7 +233,7 @@ HistogramContext::Setup(const Ptr<Frame::FrameScript>& script)
             CoreGraphics::ResourceTableSetRWTexture(histogramState.downsampleResourceTable,
             {
                     histogramState.downsampledColorBufferViews[i],
-                    CoreGraphics::ShaderGetResourceSlot(histogramState.downsampleShader, "Output6"),
+                    DownsampleCsMin::Table_Batch::Output6_SLOT,
                     0,
                     CoreGraphics::InvalidSamplerId,
                     false,
@@ -245,7 +245,7 @@ HistogramContext::Setup(const Ptr<Frame::FrameScript>& script)
             CoreGraphics::ResourceTableSetRWTexture(histogramState.downsampleResourceTable,
             {
                     histogramState.downsampledColorBufferViews[i],
-                    CoreGraphics::ShaderGetResourceSlot(histogramState.downsampleShader, "Output"),
+                    DownsampleCsMin::Table_Batch::Output_SLOT,
                     i,
                     CoreGraphics::InvalidSamplerId,
                     false,
@@ -255,7 +255,7 @@ HistogramContext::Setup(const Ptr<Frame::FrameScript>& script)
     }
     CoreGraphics::ResourceTableCommitChanges(histogramState.downsampleResourceTable);
 
-    histogramState.sourceTextureBinding = CoreGraphics::ShaderGetResourceSlot(histogramState.histogramShader, "ColorSource");
+    histogramState.sourceTextureBinding = HistogramCs::Table_Batch::ColorSource_SLOT;
     histogramState.sourceTextureDimensions = dims;
     CoreGraphics::ResourceTableSetTexture(histogramState.histogramResourceTable,
     {
@@ -452,7 +452,7 @@ HistogramContext::WindowResized(const CoreGraphics::WindowId windowId, SizeT wid
             CoreGraphics::ResourceTableSetRWTexture(histogramState.downsampleResourceTable,
             {
                 histogramState.downsampledColorBufferViews[i],
-                CoreGraphics::ShaderGetResourceSlot(histogramState.downsampleShader, "Output6"),
+                DownsampleCsMin::Table_Batch::Output6_SLOT,
                 0,
                 CoreGraphics::InvalidSamplerId,
                 false,
@@ -464,7 +464,7 @@ HistogramContext::WindowResized(const CoreGraphics::WindowId windowId, SizeT wid
             CoreGraphics::ResourceTableSetRWTexture(histogramState.downsampleResourceTable,
             {
                 histogramState.downsampledColorBufferViews[i],
-                CoreGraphics::ShaderGetResourceSlot(histogramState.downsampleShader, "Output"),
+                DownsampleCsMin::Table_Batch::Output_SLOT,
                 i,
                 CoreGraphics::InvalidSamplerId,
                 false,

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -268,9 +268,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     terrainState.resourceTable = ShaderCreateResourceTable(terrainState.terrainShader, NEBULA_SYSTEM_GROUP);
     terrainState.terrainShadowProgram = ShaderGetProgram(terrainState.terrainShader, ShaderFeatureFromString("TerrainShadows"));
 
-    IndexT systemConstantsSlot = ShaderGetResourceSlot(terrainState.terrainShader, "TerrainSystemUniforms");
-    IndexT biomeSlot = ShaderGetResourceSlot(terrainState.terrainShader, "MaterialLayers");
-    IndexT shadowMapSlot = ShaderGetResourceSlot(terrainState.terrainShader, "TerrainShadowMap");
 
     CoreGraphics::BufferCreateInfo sysBufInfo;
     sysBufInfo.name = "VirtualSystemBuffer"_atm;
@@ -298,9 +295,9 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
 
     Lighting::LightContext::SetupTerrainShadows(terrainState.terrainShadowMap, settings.worldSizeX);
 
-    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.biomeBuffer, biomeSlot, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.systemConstants, systemConstantsSlot, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0});
-    ResourceTableSetRWTexture(terrainState.resourceTable, { terrainState.terrainShadowMap, shadowMapSlot, 0, CoreGraphics::InvalidSamplerId, false, false });
+    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.biomeBuffer, Terrain::Table_System::MaterialLayers::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.systemConstants, Terrain::Table_System::TerrainSystemUniforms::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0});
+    ResourceTableSetRWTexture(terrainState.resourceTable, { terrainState.terrainShadowMap, Terrain::Table_System::TerrainShadowMap_SLOT, 0, CoreGraphics::InvalidSamplerId, false, false });
     ResourceTableCommitChanges(terrainState.resourceTable);
 
     //------------------------------------------------------------------------------
@@ -517,7 +514,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetConstantBuffer(terrainVirtualTileState.virtualTerrainSystemResourceTable, 
         {
             terrainState.biomeBuffer,
-            ShaderGetResourceSlot(terrainState.terrainShader, "MaterialLayers"),
+            Terrain::Table_System::MaterialLayers::SLOT,
             0,
             false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
@@ -527,7 +524,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetConstantBuffer(terrainVirtualTileState.virtualTerrainSystemResourceTable, 
         {
             terrainState.systemConstants,
-            ShaderGetResourceSlot(terrainState.terrainShader, "TerrainSystemUniforms"),
+            Terrain::Table_System::TerrainSystemUniforms::SLOT,
             0,
             false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
@@ -537,7 +534,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetRWBuffer(terrainVirtualTileState.virtualTerrainSystemResourceTable,
         {
             terrainVirtualTileState.subTextureBuffer,
-            ShaderGetResourceSlot(terrainState.terrainShader, "TerrainSubTexturesBuffer"),
+            Terrain::Table_System::TerrainSubTexturesBuffer::SLOT,
             0, 
             false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
@@ -547,7 +544,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetRWBuffer(terrainVirtualTileState.virtualTerrainSystemResourceTable,
         {
             terrainVirtualTileState.pageUpdateListBuffer,
-            ShaderGetResourceSlot(terrainState.terrainShader, "PageUpdateListBuffer"),
+            Terrain::Table_System::PageUpdateListBuffer::SLOT,
             0,
             false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
@@ -557,7 +554,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetRWBuffer(terrainVirtualTileState.virtualTerrainSystemResourceTable,
         {
             terrainVirtualTileState.pageStatusBuffer,
-            ShaderGetResourceSlot(terrainState.terrainShader, "PageStatusBuffer"),
+            Terrain::Table_System::PageStatusBuffer::SLOT,
             0,
             false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
@@ -569,7 +566,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetConstantBuffer(terrainVirtualTileState.virtualTerrainRuntimeResourceTable,
         {
             terrainVirtualTileState.runtimeConstants,
-            ShaderGetResourceSlot(terrainState.terrainShader, "TerrainRuntimeUniforms"),
+            Terrain::Table_Batch::TerrainRuntimeUniforms::SLOT,
             0,
             false, false,
             sizeof(Terrain::TerrainRuntimeUniforms),
@@ -580,7 +577,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     ResourceTableSetConstantBuffer(terrainVirtualTileState.virtualTerrainDynamicResourceTable,
         {
             CoreGraphics::GetGraphicsConstantBuffer(),
-            ShaderGetResourceSlot(terrainState.terrainShader, "TerrainTileUpdateUniforms"),
+            Terrain::Table_DynamicOffset::TerrainTileUpdateUniforms::SLOT,
             0,
             false, true,
             sizeof(Terrain::TerrainTileUpdateUniforms),
@@ -1109,8 +1106,7 @@ TerrainContext::SetupTerrain(
 
     // setup resource tables, one for the per-chunk draw arguments, and one for the whole terrain 
     runtimeInfo.patchTable = ShaderCreateResourceTable(terrainState.terrainShader, NEBULA_DYNAMIC_OFFSET_GROUP);
-    IndexT slot = ShaderGetResourceSlot(terrainState.terrainShader, "PatchUniforms");
-    ResourceTableSetConstantBuffer(runtimeInfo.patchTable, { CoreGraphics::GetGraphicsConstantBuffer(), slot, 0, false, true, sizeof(Terrain::PatchUniforms), 0 });
+    ResourceTableSetConstantBuffer(runtimeInfo.patchTable, { CoreGraphics::GetGraphicsConstantBuffer(), Terrain::Table_DynamicOffset::PatchUniforms::SLOT, 0, false, true, sizeof(Terrain::PatchUniforms), 0 });
     ResourceTableCommitChanges(runtimeInfo.patchTable);
 
     // allocate a tile vertex buffer

--- a/code/render/vegetation/vegetationcontext.cc
+++ b/code/render/vegetation/vegetationcontext.cc
@@ -302,20 +302,20 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetConstantBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.systemUniforms,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "VegetationGenerateUniforms"),
+            Vegetation::Table_System::VegetationGenerateUniforms::SLOT,
             0,
             false, false,
-            sizeof(Vegetation::VegetationGenerateUniforms),
+            Vegetation::Table_System::VegetationGenerateUniforms::SIZE,
             0
         });
 
     ResourceTableSetConstantBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.materialUniformsBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "VegetationMaterialUniforms"),
+            Vegetation::Table_System::VegetationMaterialUniforms::SLOT,
             0,
             false, false,
-            sizeof(Vegetation::VegetationMaterialUniforms),
+            Vegetation::Table_System::VegetationMaterialUniforms::SIZE,
             0
         });
 
@@ -323,7 +323,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetConstantBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.meshInfoBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "MeshInfoUniforms"),
+            Vegetation::Table_System::MeshInfoUniforms::SLOT,
             0,
             false, false,
             sizeof(Vegetation::MeshInfo) * Vegetation::MAX_MESH_INFOS,
@@ -333,7 +333,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetConstantBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.grassInfoBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "GrassInfoUniforms"),
+            Vegetation::Table_System::GrassInfoUniforms::SLOT,
             0,
             false, false,
             sizeof(Vegetation::GrassInfo) * Vegetation::MAX_GRASS_INFOS,
@@ -343,7 +343,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetRWBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.grassDrawCallsBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "IndirectGrassDrawBuffer"),
+            Vegetation::Table_System::IndirectGrassDrawBuffer::SLOT,
             0,
             false, false,
             BufferGetByteSize(vegetationState.grassDrawCallsBuffer),
@@ -353,7 +353,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetRWBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.meshDrawCallsBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "IndirectMeshDrawBuffer"),
+            Vegetation::Table_System::IndirectMeshDrawBuffer::SLOT,
             0,
             false, false,
             BufferGetByteSize(vegetationState.meshDrawCallsBuffer),
@@ -363,7 +363,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetRWBuffer(vegetationState.systemResourceTable,
         {
             vegetationState.drawCountBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "DrawCount"),
+            Vegetation::Table_System::DrawCount::SLOT,
             0,
             false, false,
             BufferGetByteSize(vegetationState.drawCountBuffer),
@@ -376,7 +376,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetRWBuffer(vegetationState.argumentsTable,
         {
             vegetationState.grassArgumentsBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "InstanceGrassArguments"),
+            Vegetation::Table_Batch::InstanceGrassArguments::SLOT,
             0,
             false, false,
             BufferGetByteSize(vegetationState.grassArgumentsBuffer),
@@ -386,7 +386,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
     ResourceTableSetRWBuffer(vegetationState.argumentsTable,
         {
             vegetationState.meshArgumentsBuffer,
-            ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "InstanceMeshArguments"),
+            Vegetation::Table_Batch::InstanceMeshArguments::SLOT,
             0,
             false, false,
             BufferGetByteSize(vegetationState.meshArgumentsBuffer),
@@ -403,7 +403,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
         ResourceTableSetRWBuffer(vegetationState.indirectArgumentsTable[i],
             {
                 vegetationState.indirectGrassArgumentBuffer[i],
-                ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "InstanceGrassArguments"),
+                Vegetation::Table_Batch::InstanceGrassArguments::SLOT,
                 0,
                 false, false,
                 BufferGetByteSize(vegetationState.indirectGrassArgumentBuffer[i]),
@@ -413,7 +413,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
         ResourceTableSetRWBuffer(vegetationState.indirectArgumentsTable[i],
             {
                 vegetationState.indirectMeshArgumentsBuffer[i],
-                ShaderGetResourceSlot(vegetationState.vegetationBaseShader, "InstanceMeshArguments"),
+                Vegetation::Table_Batch::InstanceMeshArguments::SLOT,
                 0,
                 false, false,
                 BufferGetByteSize(vegetationState.indirectMeshArgumentsBuffer[i]),

--- a/toolkit/shaderc/singleshadercompiler.cc
+++ b/toolkit/shaderc/singleshadercompiler.cc
@@ -201,8 +201,28 @@ SingleShaderCompiler::CompileGLSL(const Util::String& srcf)
     target.Format("gl%d%d", major, minor);
     Util::String escapedSrc = src.LocalPath();
     Util::String escapedDst = dst.LocalPath();
+    std::vector<std::pair<unsigned, std::string>> resourceTableNames = {
+        std::make_pair(NEBULA_TICK_GROUP, "Tick")
+        , std::make_pair(NEBULA_FRAME_GROUP, "Frame")
+        , std::make_pair(NEBULA_PASS_GROUP, "Pass")
+        , std::make_pair(NEBULA_BATCH_GROUP, "Batch")
+        , std::make_pair(NEBULA_INSTANCE_GROUP, "Instance")
+        , std::make_pair(NEBULA_SYSTEM_GROUP, "System")
+        , std::make_pair(NEBULA_DYNAMIC_OFFSET_GROUP, "DynamicOffset")
+    };
 
-    bool res = AnyFXCompile(escapedSrc.AsCharPtr(), escapedDst.AsCharPtr(), target.AsCharPtr(), nullptr, "Khronos", defines, flags, &errors);
+    bool res = AnyFXCompile(
+        escapedSrc.AsCharPtr()
+        , escapedDst.AsCharPtr()
+        , target.AsCharPtr()
+        , nullptr
+        , "Khronos"
+        , defines
+        , flags
+        , resourceTableNames
+        , &errors
+    );
+
     if (!res)
     {
         if (errors)
@@ -302,8 +322,27 @@ SingleShaderCompiler::CompileSPIRV(const Util::String& srcf)
     Util::String escapedSrc = src.LocalPath();
     Util::String escapedDst = dst.LocalPath();
     Util::String escapedHeader = dstH.LocalPath();
+    std::vector<std::pair<unsigned, std::string>> resourceTableNames = {
+        std::make_pair(NEBULA_TICK_GROUP, "Tick")
+        , std::make_pair(NEBULA_FRAME_GROUP, "Frame")
+        , std::make_pair(NEBULA_PASS_GROUP, "Pass")
+        , std::make_pair(NEBULA_BATCH_GROUP, "Batch")
+        , std::make_pair(NEBULA_INSTANCE_GROUP, "Instance")
+        , std::make_pair(NEBULA_SYSTEM_GROUP, "System")
+        , std::make_pair(NEBULA_DYNAMIC_OFFSET_GROUP, "DynamicOffset")
+    };
 
-    bool res = AnyFXCompile(escapedSrc.AsCharPtr(), escapedDst.AsCharPtr(), escapedHeader.AsCharPtr(), target.AsCharPtr(), "Khronos", defines, flags, &errors);
+    bool res = AnyFXCompile(
+        escapedSrc.AsCharPtr()
+        , escapedDst.AsCharPtr()
+        , escapedHeader.AsCharPtr()
+        , target.AsCharPtr()
+        , "Khronos"
+        , defines
+        , flags
+        , resourceTableNames
+        , &errors
+    );
     if (!res)
     {
         if (errors)


### PR DESCRIPTION
With the new AnyFX feature of being able to generate resource table layouts, the engine now utilizes this feature to avoid having to query the shader reflection information for resource bindings. 

Fixes #97.