### PR TITLE
Make resource table binding terser

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -45,8 +45,8 @@ UltralightRenderer::UltralightRenderer()
             CoreGraphics::GetGraphicsConstantBuffer(),
             Staticui::Table_DynamicOffset::PerDrawState::SLOT,
             0,
+            Staticui::Table_DynamicOffset::PerDrawState::SIZE, 0,
             false, true,
-            Staticui::Table_DynamicOffset::PerDrawState::SIZE, 0
         });
     CoreGraphics::ResourceTableCommitChanges(ultralightState.resourceTable);
 

--- a/code/render/clustering/clustercontext.cc
+++ b/code/render/clustering/clustercontext.cc
@@ -112,11 +112,11 @@ ClusterContext::Create(float ZNear, float ZFar, const CoreGraphics::WindowId win
         CoreGraphics::ResourceTableId computeTable = Graphics::GetFrameResourceTableCompute(i);
         CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
-        ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+        ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, sizeof(ClusterGenerate::ClusterUniforms), 0 });
 
-        ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, sizeof(ClusterGenerate::ClusterUniforms), 0 });
     }
 
     Frame::FrameCode* op = state.frameOpAllocator.Alloc<Frame::FrameCode>();
@@ -230,12 +230,12 @@ ClusterContext::WindowResized(const CoreGraphics::WindowId id, SizeT width, Size
             CoreGraphics::ResourceTableId computeTable = Graphics::GetFrameResourceTableCompute(i);
             CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
-            ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
-            ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+            ResourceTableSetRWBuffer(computeTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+            ResourceTableSetConstantBuffer(computeTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, sizeof(ClusterGenerate::ClusterUniforms), 0 });
             ResourceTableCommitChanges(computeTable);
 
-            ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, false, false, -1, 0 });
-            ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, false, false, sizeof(ClusterGenerate::ClusterUniforms), 0 });
+            ResourceTableSetRWBuffer(graphicsTable, { state.clusterBuffer, Shared::Table_Frame::ClusterAABBs::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+            ResourceTableSetConstantBuffer(graphicsTable, { state.constantBuffer, Shared::Table_Frame::ClusterUniforms::SLOT, 0, sizeof(ClusterGenerate::ClusterUniforms), 0 });
             ResourceTableCommitChanges(graphicsTable);
         }
     }

--- a/code/render/coregraphics/resourcetable.h
+++ b/code/render/coregraphics/resourcetable.h
@@ -91,6 +91,42 @@ extern Threading::CriticalSection PendingTableCommitsLock;
 
 struct ResourceTableTexture
 {
+    ResourceTableTexture()
+        : tex(InvalidTextureId)
+        , slot(0)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(false)
+        , isStencil(false)
+    {};
+
+    ResourceTableTexture(const CoreGraphics::TextureId tex, IndexT slot)
+        : tex(tex)
+        , slot(slot)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(false)
+        , isStencil(false)
+    {};
+
+    ResourceTableTexture(const CoreGraphics::TextureId tex, IndexT slot, bool isDepth, bool isStencil)
+        : tex(tex)
+        , slot(slot)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(isDepth)
+        , isStencil(isStencil)
+    {};
+
+    ResourceTableTexture(const CoreGraphics::TextureId tex, IndexT slot, IndexT index, CoreGraphics::SamplerId sampler, bool isDepth = false, bool isStencil = false)
+        : tex(tex)
+        , slot(slot)
+        , index(index)
+        , sampler(sampler)
+        , isDepth(isDepth)
+        , isStencil(isStencil)
+    {};
+
     CoreGraphics::TextureId tex;
     IndexT slot;
     IndexT index;
@@ -101,6 +137,42 @@ struct ResourceTableTexture
 
 struct ResourceTableTextureView
 {
+    ResourceTableTextureView()
+        : tex(InvalidTextureViewId)
+        , slot(0)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(false)
+        , isStencil(false)
+    {};
+
+    ResourceTableTextureView(const CoreGraphics::TextureViewId tex, IndexT slot)
+        : tex(tex)
+        , slot(slot)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(false)
+        , isStencil(false)
+    {};
+
+    ResourceTableTextureView(const CoreGraphics::TextureViewId tex, IndexT slot, bool isDepth = false, bool isStencil = false)
+        : tex(tex)
+        , slot(slot)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(isDepth)
+        , isStencil(isStencil)
+    {};
+
+    ResourceTableTextureView(const CoreGraphics::TextureViewId tex, IndexT slot, IndexT index, CoreGraphics::SamplerId sampler, bool isDepth = false, bool isStencil = false)
+        : tex(tex)
+        , slot(slot)
+        , index(index)
+        , sampler(sampler)
+        , isDepth(isDepth)
+        , isStencil(isStencil)
+    {};
+
     CoreGraphics::TextureViewId tex;
     IndexT slot;
     IndexT index;
@@ -109,26 +181,98 @@ struct ResourceTableTextureView
     bool isStencil : 1;
 };
 
-struct ResourceTableBuffer
-{
-    CoreGraphics::BufferId buf;
-    IndexT slot;
-    IndexT index;
-
-    bool texelBuffer;
-    bool dynamicOffset;
-
-    SizeT size;
-    SizeT offset;
-};
-
 struct ResourceTableInputAttachment
 {
+    ResourceTableInputAttachment()
+        : tex(InvalidTextureViewId)
+        , slot(0)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(false)
+    {};
+
+    ResourceTableInputAttachment(const CoreGraphics::TextureViewId tex, IndexT slot)
+        : tex(tex)
+        , slot(slot)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(false)
+    {};
+
+    ResourceTableInputAttachment(const CoreGraphics::TextureViewId tex, IndexT slot, bool isDepth = false)
+        : tex(tex)
+        , slot(slot)
+        , index(0)
+        , sampler(CoreGraphics::InvalidSamplerId)
+        , isDepth(isDepth)
+    {};
+
+    ResourceTableInputAttachment(const CoreGraphics::TextureViewId tex, IndexT slot, IndexT index, CoreGraphics::SamplerId sampler, bool isDepth = false)
+        : tex(tex)
+        , slot(slot)
+        , index(index)
+        , sampler(sampler)
+        , isDepth(isDepth)
+    {};
+
     CoreGraphics::TextureViewId tex;
     IndexT slot;
     IndexT index;
     CoreGraphics::SamplerId sampler;
     bool isDepth : 1;
+};
+
+struct ResourceTableBuffer
+{
+    ResourceTableBuffer()
+        : buf(InvalidBufferId)
+        , slot(0)
+        , index(0)
+        , texelBuffer(false)
+        , dynamicOffset(false)
+        , size(NEBULA_WHOLE_BUFFER_SIZE)
+        , offset(0)
+    {};
+
+    ResourceTableBuffer(const CoreGraphics::BufferId buf, IndexT slot)
+        : buf(buf)
+        , slot(slot)
+        , index(0)
+        , texelBuffer(false)
+        , dynamicOffset(false)
+        , size(NEBULA_WHOLE_BUFFER_SIZE)
+        , offset(0)
+    {};
+
+    ResourceTableBuffer(const CoreGraphics::BufferId buf, IndexT slot, SizeT size)
+        : buf(buf)
+        , slot(slot)
+        , index(0)
+        , texelBuffer(false)
+        , dynamicOffset(false)
+        , size(size)
+        , offset(0)
+    {};
+
+    ResourceTableBuffer(const CoreGraphics::BufferId buf, IndexT slot, SizeT index, SizeT size, SizeT offset, bool texelBuffer = false, bool dynamicOffset = false)
+        : buf(buf)
+        , slot(slot)
+        , index(index)
+        , texelBuffer(texelBuffer)
+        , dynamicOffset(dynamicOffset)
+        , size(size)
+        , offset(offset)
+    {};
+
+    CoreGraphics::BufferId buf;
+    IndexT slot;
+    IndexT index;
+
+    SizeT size;
+    SizeT offset;
+
+    bool texelBuffer;
+    bool dynamicOffset;
 };
 
 struct ResourceTableSampler

--- a/code/render/decals/decalcontext.cc
+++ b/code/render/decals/decalcontext.cc
@@ -36,8 +36,6 @@ struct
     CoreGraphics::BufferId clusterPointDecals;
     CoreGraphics::BufferId clusterSpotDecals;
 
-    IndexT uniformsSlot;
-
     // these are used to update the light clustering
     DecalsCluster::PBRDecal pbrDecals[256];
     DecalsCluster::EmissiveDecal emissiveDecals[256];
@@ -110,14 +108,14 @@ DecalContext::Create()
         CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
         // update resource table
-        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, false, false, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
+        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
         ResourceTableCommitChanges(computeTable);
 
-        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, false, false, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 
@@ -399,9 +397,9 @@ DecalContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(bufferIndex);
 
     uint offset = SetConstants(decalUniforms);
-    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(), decalState.uniformsSlot, 0, false, false, sizeof(DecalsCluster::DecalUniforms), (SizeT)offset });
+    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(computeTable);
-    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(), decalState.uniformsSlot, 0, false, false, sizeof(DecalsCluster::DecalUniforms), (SizeT)offset });
+    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(graphicsTable);
 
     // update list of point lights

--- a/code/render/fog/volumetricfogcontext.cc
+++ b/code/render/fog/volumetricfogcontext.cc
@@ -123,14 +123,14 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
         CoreGraphics::ResourceTableId computeTable = Graphics::GetFrameResourceTableCompute(i);
         CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
-        ResourceTableSetRWBuffer(computeTable, { fogState.clusterFogIndexLists, Shared::Table_Frame::FogIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(computeTable, { fogState.clusterFogLists, Shared::Table_Frame::FogLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, false, false, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
+        ResourceTableSetRWBuffer(computeTable, { fogState.clusterFogIndexLists, Shared::Table_Frame::FogIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(computeTable, { fogState.clusterFogLists, Shared::Table_Frame::FogLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
         ResourceTableCommitChanges(computeTable);
 
-        ResourceTableSetRWBuffer(graphicsTable, { fogState.clusterFogIndexLists, Shared::Table_Frame::FogIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(graphicsTable, { fogState.clusterFogLists, Shared::Table_Frame::FogLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, false, false, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { fogState.clusterFogIndexLists, Shared::Table_Frame::FogIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { fogState.clusterFogLists, Shared::Table_Frame::FogLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 
@@ -473,9 +473,9 @@ VolumetricFogContext::UpdateViewDependentResources(const Ptr<Graphics::View>& vi
     CoreGraphics::ResourceTableId viewTablesGraphics = Graphics::GetFrameResourceTableGraphics(bufferIndex);
 
     uint offset = SetConstants(fogUniforms);
-    ResourceTableSetConstantBuffer(viewTablesCompute, { GetComputeConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, false, false, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(viewTablesCompute, { GetComputeConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(viewTablesCompute);
-    ResourceTableSetConstantBuffer(viewTablesGraphics, { GetGraphicsConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, false, false, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(viewTablesGraphics, { GetGraphicsConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(viewTablesGraphics);
 
     // setup blur tables

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -1097,7 +1097,7 @@ FrameScriptLoader::ParseShaderVariables(
             if (bufferIndex == InvalidIndex)
             {
                 cbo = ShaderCreateConstantBuffer(shd, block);
-                ResourceTableSetConstantBuffer(table, { cbo, slot, 0, false, false, -1, 0 });
+                ResourceTableSetConstantBuffer(table, { cbo, slot, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
                 constantBuffers.Add(block, cbo);
             }
             else

--- a/code/render/graphics/globalconstants.cc
+++ b/code/render/graphics/globalconstants.cc
@@ -15,7 +15,6 @@ struct
     Util::FixedArray<CoreGraphics::ResourceTableId> tickResourceTablesGraphics;
     Util::FixedArray<CoreGraphics::ResourceTableId> tickResourceTablesCompute;
     CoreGraphics::ResourcePipelineId tableLayout;
-    IndexT tickParamsCboSlot, viewConstantsSlot, shadowViewConstantsSlot;
 
     Shared::PerTickParams tickParams;
 
@@ -46,9 +45,6 @@ CreateGlobalConstants(const GlobalConstantsCreateInfo& info)
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderGet("shd:shared.fxb"_atm);
 
     state.tableLayout = CoreGraphics::ShaderGetResourcePipeline(shader);
-    state.tickParamsCboSlot = CoreGraphics::ShaderGetResourceSlot(shader, "PerTickParams");
-    state.viewConstantsSlot = CoreGraphics::ShaderGetResourceSlot(shader, "ViewConstants");
-    state.shadowViewConstantsSlot = CoreGraphics::ShaderGetResourceSlot(shader, "ShadowViewConstants");
 
     state.frameResourceTablesGraphics.Resize(CoreGraphics::GetNumBufferedFrames());
     state.frameResourceTablesCompute.Resize(CoreGraphics::GetNumBufferedFrames());
@@ -99,12 +95,12 @@ AllocateGlobalConstants()
     IndexT bufferedFrameIndex = CoreGraphics::GetBufferedFrameIndex();
 
     // Bind tables with memory allocated
-    ResourceTableSetConstantBuffer(state.frameResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), state.viewConstantsSlot, 0, false, false, sizeof(Shared::ViewConstants), (SizeT)state.viewCboOffset });
-    ResourceTableSetConstantBuffer(state.frameResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), state.shadowViewConstantsSlot, 0, false, false, sizeof(Shared::ShadowViewConstants), (SizeT)state.shadowViewCboOffset });
+    ResourceTableSetConstantBuffer(state.frameResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::ViewConstants::SLOT, 0, Shared::Table_Frame::ViewConstants::SIZE, (SizeT)state.viewCboOffset });
+    ResourceTableSetConstantBuffer(state.frameResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::ShadowViewConstants::SLOT, 0, Shared::Table_Frame::ShadowViewConstants::SIZE, (SizeT)state.shadowViewCboOffset });
     ResourceTableCommitChanges(state.frameResourceTablesGraphics[bufferedFrameIndex]);
 
-    ResourceTableSetConstantBuffer(state.frameResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), state.viewConstantsSlot, 0, false, false, sizeof(Shared::ViewConstants), (SizeT)state.viewCboOffset });
-    ResourceTableSetConstantBuffer(state.frameResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), state.shadowViewConstantsSlot, 0, false, false, sizeof(Shared::ShadowViewConstants), (SizeT)state.shadowViewCboOffset });
+    ResourceTableSetConstantBuffer(state.frameResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::ViewConstants::SLOT, 0, Shared::Table_Frame::ViewConstants::SIZE, (SizeT)state.viewCboOffset });
+    ResourceTableSetConstantBuffer(state.frameResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::ShadowViewConstants::SLOT, 0, Shared::Table_Frame::ShadowViewConstants::SIZE, (SizeT)state.shadowViewCboOffset });
     ResourceTableCommitChanges(state.frameResourceTablesCompute[bufferedFrameIndex]);
 
     // Set frame tables
@@ -112,9 +108,9 @@ AllocateGlobalConstants()
     CoreGraphics::SetFrameResourceTableCompute(state.frameResourceTablesCompute[bufferedFrameIndex]);
 
     // Update tick resource tables
-    ResourceTableSetConstantBuffer(state.tickResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), state.tickParamsCboSlot, 0, false, false, sizeof(Shared::PerTickParams), (SizeT)state.tickCboOffset });
+    ResourceTableSetConstantBuffer(state.tickResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Tick::PerTickParams::SLOT, 0, Shared::Table_Tick::PerTickParams::SIZE, (SizeT)state.tickCboOffset });
     ResourceTableCommitChanges(state.tickResourceTablesGraphics[bufferedFrameIndex]);
-    ResourceTableSetConstantBuffer(state.tickResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), state.tickParamsCboSlot, 0, false, false, sizeof(Shared::PerTickParams), (SizeT)state.tickCboOffset });
+    ResourceTableSetConstantBuffer(state.tickResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Tick::PerTickParams::SLOT, 0, Shared::Table_Tick::PerTickParams::SIZE, (SizeT)state.tickCboOffset });
     ResourceTableCommitChanges(state.tickResourceTablesCompute[bufferedFrameIndex]);
 
     // Set tick tables

--- a/code/render/lighting/lightcontext.cc
+++ b/code/render/lighting/lightcontext.cc
@@ -196,14 +196,14 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
         CoreGraphics::ResourceTableId computeTable = Graphics::GetFrameResourceTableCompute(i);
         CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(i);
 
-        ResourceTableSetRWBuffer(computeTable, { clusterState.clusterLightIndexLists, Shared::Table_Frame::LightIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(computeTable, { clusterState.clusterLightsList, Shared::Table_Frame::LightLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, false, false, sizeof(LightsCluster::LightUniforms), 0 });
+        ResourceTableSetRWBuffer(computeTable, { clusterState.clusterLightIndexLists, Shared::Table_Frame::LightIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(computeTable, { clusterState.clusterLightsList, Shared::Table_Frame::LightLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), 0 });
         ResourceTableCommitChanges(computeTable);
 
-        ResourceTableSetRWBuffer(graphicsTable, { clusterState.clusterLightIndexLists, Shared::Table_Frame::LightIndexLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetRWBuffer(graphicsTable, { clusterState.clusterLightsList, Shared::Table_Frame::LightLists::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, false, false, sizeof(LightsCluster::LightUniforms), 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { clusterState.clusterLightIndexLists, Shared::Table_Frame::LightIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetRWBuffer(graphicsTable, { clusterState.clusterLightsList, Shared::Table_Frame::LightLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 
@@ -1068,9 +1068,9 @@ LightContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     consts.NumLightClusters = Clustering::ClusterContext::GetNumClusters();
     consts.SSAOBuffer = CoreGraphics::TextureGetBindlessHandle(textureState.aoTexture);
     IndexT offset = SetConstants(consts);
-    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, false, false, sizeof(LightsCluster::LightUniforms), (SizeT)offset });
+    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), (SizeT)offset });
     ResourceTableCommitChanges(computeTable);
-    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, false, false, sizeof(LightsCluster::LightUniforms), (SizeT)offset });
+    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), (SizeT)offset });
     ResourceTableCommitChanges(graphicsTable);
 
     TextureDimensions dims = TextureGetDimensions(textureState.lightingTexture);
@@ -1078,7 +1078,7 @@ LightContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     combineConsts.LowresResolution[0] = 1.0f / dims.width;
     combineConsts.LowresResolution[1] = 1.0f / dims.height;
     offset = SetConstants(combineConsts);
-    ResourceTableSetConstantBuffer(combineState.resourceTables[bufferIndex], { GetGraphicsConstantBuffer(), Combine::Table_Batch::CombineUniforms::SLOT, 0, false, false, Combine::Table_Batch::CombineUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(combineState.resourceTables[bufferIndex], { GetGraphicsConstantBuffer(), Combine::Table_Batch::CombineUniforms::SLOT, 0, Combine::Table_Batch::CombineUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(combineState.resourceTables[bufferIndex]);
 }
 

--- a/code/render/materials/shaderconfig.cc
+++ b/code/render/materials/shaderconfig.cc
@@ -139,7 +139,7 @@ ShaderConfig::CreateMaterial()
                 CoreGraphics::BufferId buf = CoreGraphics::ShaderCreateConstantBuffer(shd, j);
                 if (buf != CoreGraphics::InvalidBufferId)
                 {
-                    CoreGraphics::ResourceTableSetConstantBuffer(surfaceTable, { buf, slot, 0, false, false, -1, 0 });
+                    CoreGraphics::ResourceTableSetConstantBuffer(surfaceTable, { buf, slot, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
 
                     // add to surface
                     surfaceBuffers.Append(Util::MakeTuple(slot, buf));
@@ -152,7 +152,7 @@ ShaderConfig::CreateMaterial()
                 if (buf != CoreGraphics::InvalidBufferId)
                 {
                     SizeT bufSize = CoreGraphics::ShaderGetConstantBufferSize(shd, j);
-                    CoreGraphics::ResourceTableSetConstantBuffer(instanceTable, { buf, slot, 0, false, true, bufSize, 0 });
+                    CoreGraphics::ResourceTableSetConstantBuffer(instanceTable, { buf, slot, 0, bufSize, 0, false, true });
 
                     // add to surface
                     instanceBuffer = Util::MakeTuple(slot, bufSize);

--- a/code/render/models/nodes/characterskinnode.cc
+++ b/code/render/models/nodes/characterskinnode.cc
@@ -77,7 +77,7 @@ CharacterSkinNode::OnFinishedLoading()
     PrimitiveNode::OnFinishedLoading();
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderServer::Instance()->GetShader("shd:objects_shared.fxb"_atm);
     CoreGraphics::BufferId cbo = CoreGraphics::GetGraphicsConstantBuffer();
-    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, ObjectsShared::Table_DynamicOffset::JointBlock::SLOT, 0, false, true, (SizeT)(sizeof(Math::mat4) * this->skinFragments[0].jointPalette.Size()), 0 });
+    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, ObjectsShared::Table_DynamicOffset::JointBlock::SLOT, 0, (SizeT)(sizeof(Math::mat4) * this->skinFragments[0].jointPalette.Size()), 0, false, true });
     CoreGraphics::ResourceTableCommitChanges(this->resourceTable);
 }
 

--- a/code/render/models/nodes/particlesystemnode.cc
+++ b/code/render/models/nodes/particlesystemnode.cc
@@ -94,7 +94,7 @@ ParticleSystemNode::OnFinishedLoading()
     this->skinningTransformsIndex = ::Particle::Table_DynamicOffset::JointBlock::SLOT;
     this->particleConstantsIndex = ::Particle::Table_DynamicOffset::ParticleObjectBlock::SLOT;
     this->resourceTable = ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
-    ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->particleConstantsIndex, 0, false, true, sizeof(::Particle::ParticleObjectBlock), 0 });
+    ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->particleConstantsIndex, 0, sizeof(::Particle::ParticleObjectBlock), 0, false, true });
     ResourceTableCommitChanges(this->resourceTable);
 }
 

--- a/code/render/models/nodes/shaderstatenode.cc
+++ b/code/render/models/nodes/shaderstatenode.cc
@@ -150,7 +150,7 @@ ShaderStateNode::OnFinishedLoading()
     this->skinningTransformsIndex = ObjectsShared::Table_DynamicOffset::JointBlock::SLOT;
 
     this->resourceTable = CoreGraphics::ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
-    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->objectTransformsIndex, 0, false, true, sizeof(ObjectsShared::ObjectBlock), 0 });
+    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->objectTransformsIndex, 0, sizeof(ObjectsShared::ObjectBlock), 0, false, true });
     CoreGraphics::ResourceTableCommitChanges(this->resourceTable);
 }
 

--- a/code/render/posteffects/histogramcontext.cc
+++ b/code/render/posteffects/histogramcontext.cc
@@ -121,8 +121,6 @@ HistogramContext::Create()
         histogramState.histogramCounters,
         HistogramCs::Table_Batch::HistogramBuffer::SLOT,
         0,
-        false,
-        false,
         CoreGraphics::BufferGetByteSize(histogramState.histogramCounters),
         0
     });
@@ -130,8 +128,6 @@ HistogramContext::Create()
         histogramState.histogramConstants,
         HistogramCs::Table_Batch::HistogramConstants::SLOT,
         0,
-        false,
-        false,
         CoreGraphics::BufferGetByteSize(histogramState.histogramConstants),
         0
     });
@@ -164,8 +160,6 @@ HistogramContext::Create()
         histogramState.downsampleCounter,
         DownsampleCsMin::Table_Batch::AtomicCounter::SLOT,
         0,
-        false,
-        false,
         CoreGraphics::BufferGetByteSize(histogramState.downsampleCounter),
         0
     });
@@ -173,8 +167,6 @@ HistogramContext::Create()
         histogramState.downsampleConstants,
         DownsampleCsMin::Table_Batch::DownsampleUniforms::SLOT,
         0,
-        false,
-        false,
         CoreGraphics::BufferGetByteSize(histogramState.downsampleConstants),
         0
     });

--- a/code/render/posteffects/ssaocontext.cc
+++ b/code/render/posteffects/ssaocontext.cc
@@ -370,7 +370,7 @@ SSAOContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, const
 
     IndexT bufferIndex = CoreGraphics::GetBufferedFrameIndex();
 
-    ResourceTableSetConstantBuffer(ssaoState.hbaoTable[bufferIndex], { ssaoState.hbaoConstants, HbaoCs::Table_Batch::HBAOBlock::SLOT, 0, false, false, HbaoCs::Table_Batch::HBAOBlock::SIZE, (SizeT)hbaoOffset });
+    ResourceTableSetConstantBuffer(ssaoState.hbaoTable[bufferIndex], { ssaoState.hbaoConstants, HbaoCs::Table_Batch::HBAOBlock::SLOT, 0, HbaoCs::Table_Batch::HBAOBlock::SIZE, (SizeT)hbaoOffset });
     ResourceTableCommitChanges(ssaoState.hbaoTable[bufferIndex]);
 
     HbaoblurCs::HBAOBlur blurBlock;
@@ -379,8 +379,8 @@ SSAOContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, const
     blurBlock.PowerExponent = 1.5f;
     uint blurOffset = CoreGraphics::SetConstants(blurBlock);
 
-    ResourceTableSetConstantBuffer(ssaoState.blurTableX[bufferIndex], { ssaoState.blurConstants, HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, false, false, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
-    ResourceTableSetConstantBuffer(ssaoState.blurTableY[bufferIndex], { ssaoState.blurConstants, HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, false, false, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
+    ResourceTableSetConstantBuffer(ssaoState.blurTableX[bufferIndex], { ssaoState.blurConstants, HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
+    ResourceTableSetConstantBuffer(ssaoState.blurTableY[bufferIndex], { ssaoState.blurConstants, HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
     ResourceTableCommitChanges(ssaoState.blurTableX[bufferIndex]);
     ResourceTableCommitChanges(ssaoState.blurTableY[bufferIndex]);
 }

--- a/code/render/posteffects/ssrcontext.cc
+++ b/code/render/posteffects/ssrcontext.cc
@@ -191,7 +191,7 @@ SSRContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, const 
 
     IndexT bufferIndex = CoreGraphics::GetBufferedFrameIndex();
 
-    ResourceTableSetConstantBuffer(ssrState.ssrTraceTables[bufferIndex], { ssrState.constants, SsrCs::Table_Batch::SSRBlock::SLOT, 0, false, false, SsrCs::Table_Batch::SSRBlock::SIZE, (SizeT)ssrOffset });
+    ResourceTableSetConstantBuffer(ssrState.ssrTraceTables[bufferIndex], { ssrState.constants, SsrCs::Table_Batch::SSRBlock::SLOT, 0, SsrCs::Table_Batch::SSRBlock::SIZE, (SizeT)ssrOffset });
     ResourceTableCommitChanges(ssrState.ssrTraceTables[bufferIndex]);
 }
 

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -295,9 +295,9 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
 
     Lighting::LightContext::SetupTerrainShadows(terrainState.terrainShadowMap, settings.worldSizeX);
 
-    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.biomeBuffer, Terrain::Table_System::MaterialLayers::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.systemConstants, Terrain::Table_System::TerrainSystemUniforms::SLOT, 0, false, false, NEBULA_WHOLE_BUFFER_SIZE, 0});
-    ResourceTableSetRWTexture(terrainState.resourceTable, { terrainState.terrainShadowMap, Terrain::Table_System::TerrainShadowMap_SLOT, 0, CoreGraphics::InvalidSamplerId, false, false });
+    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.biomeBuffer, Terrain::Table_System::MaterialLayers::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
+    ResourceTableSetConstantBuffer(terrainState.resourceTable, { terrainState.systemConstants, Terrain::Table_System::TerrainSystemUniforms::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0});
+    ResourceTableSetRWTexture(terrainState.resourceTable, { terrainState.terrainShadowMap, Terrain::Table_System::TerrainShadowMap_SLOT, 0, CoreGraphics::InvalidSamplerId });
     ResourceTableCommitChanges(terrainState.resourceTable);
 
     //------------------------------------------------------------------------------
@@ -516,7 +516,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             terrainState.biomeBuffer,
             Terrain::Table_System::MaterialLayers::SLOT,
             0,
-            false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
             0
         });
@@ -526,7 +525,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             terrainState.systemConstants,
             Terrain::Table_System::TerrainSystemUniforms::SLOT,
             0,
-            false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
             0
         });
@@ -536,7 +534,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             terrainVirtualTileState.subTextureBuffer,
             Terrain::Table_System::TerrainSubTexturesBuffer::SLOT,
             0, 
-            false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
             0
         });
@@ -546,7 +543,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             terrainVirtualTileState.pageUpdateListBuffer,
             Terrain::Table_System::PageUpdateListBuffer::SLOT,
             0,
-            false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
             0
         });
@@ -556,7 +552,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             terrainVirtualTileState.pageStatusBuffer,
             Terrain::Table_System::PageStatusBuffer::SLOT,
             0,
-            false, false,
             NEBULA_WHOLE_BUFFER_SIZE,
             0
         });
@@ -568,7 +563,6 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             terrainVirtualTileState.runtimeConstants,
             Terrain::Table_Batch::TerrainRuntimeUniforms::SLOT,
             0,
-            false, false,
             sizeof(Terrain::TerrainRuntimeUniforms),
             0
         });
@@ -579,9 +573,9 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
             CoreGraphics::GetGraphicsConstantBuffer(),
             Terrain::Table_DynamicOffset::TerrainTileUpdateUniforms::SLOT,
             0,
-            false, true,
             sizeof(Terrain::TerrainTileUpdateUniforms),
-            0
+            0,
+            false, true
         });
     ResourceTableCommitChanges(terrainVirtualTileState.virtualTerrainDynamicResourceTable);
 
@@ -1106,7 +1100,7 @@ TerrainContext::SetupTerrain(
 
     // setup resource tables, one for the per-chunk draw arguments, and one for the whole terrain 
     runtimeInfo.patchTable = ShaderCreateResourceTable(terrainState.terrainShader, NEBULA_DYNAMIC_OFFSET_GROUP);
-    ResourceTableSetConstantBuffer(runtimeInfo.patchTable, { CoreGraphics::GetGraphicsConstantBuffer(), Terrain::Table_DynamicOffset::PatchUniforms::SLOT, 0, false, true, sizeof(Terrain::PatchUniforms), 0 });
+    ResourceTableSetConstantBuffer(runtimeInfo.patchTable, { CoreGraphics::GetGraphicsConstantBuffer(), Terrain::Table_DynamicOffset::PatchUniforms::SLOT, 0, Terrain::Table_DynamicOffset::PatchUniforms::SIZE, 0, false, true });
     ResourceTableCommitChanges(runtimeInfo.patchTable);
 
     // allocate a tile vertex buffer

--- a/code/render/vegetation/vegetationcontext.cc
+++ b/code/render/vegetation/vegetationcontext.cc
@@ -304,7 +304,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.systemUniforms,
             Vegetation::Table_System::VegetationGenerateUniforms::SLOT,
             0,
-            false, false,
             Vegetation::Table_System::VegetationGenerateUniforms::SIZE,
             0
         });
@@ -314,7 +313,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.materialUniformsBuffer,
             Vegetation::Table_System::VegetationMaterialUniforms::SLOT,
             0,
-            false, false,
             Vegetation::Table_System::VegetationMaterialUniforms::SIZE,
             0
         });
@@ -325,7 +323,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.meshInfoBuffer,
             Vegetation::Table_System::MeshInfoUniforms::SLOT,
             0,
-            false, false,
             sizeof(Vegetation::MeshInfo) * Vegetation::MAX_MESH_INFOS,
             0
         });
@@ -335,7 +332,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.grassInfoBuffer,
             Vegetation::Table_System::GrassInfoUniforms::SLOT,
             0,
-            false, false,
             sizeof(Vegetation::GrassInfo) * Vegetation::MAX_GRASS_INFOS,
             0
         });
@@ -345,7 +341,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.grassDrawCallsBuffer,
             Vegetation::Table_System::IndirectGrassDrawBuffer::SLOT,
             0,
-            false, false,
             BufferGetByteSize(vegetationState.grassDrawCallsBuffer),
             0
         });
@@ -355,7 +350,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.meshDrawCallsBuffer,
             Vegetation::Table_System::IndirectMeshDrawBuffer::SLOT,
             0,
-            false, false,
             BufferGetByteSize(vegetationState.meshDrawCallsBuffer),
             0
         });
@@ -365,7 +359,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.drawCountBuffer,
             Vegetation::Table_System::DrawCount::SLOT,
             0,
-            false, false,
             BufferGetByteSize(vegetationState.drawCountBuffer),
             0
         });
@@ -378,7 +371,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.grassArgumentsBuffer,
             Vegetation::Table_Batch::InstanceGrassArguments::SLOT,
             0,
-            false, false,
             BufferGetByteSize(vegetationState.grassArgumentsBuffer),
             0
         });
@@ -388,7 +380,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
             vegetationState.meshArgumentsBuffer,
             Vegetation::Table_Batch::InstanceMeshArguments::SLOT,
             0,
-            false, false,
             BufferGetByteSize(vegetationState.meshArgumentsBuffer),
             0
         });
@@ -405,7 +396,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
                 vegetationState.indirectGrassArgumentBuffer[i],
                 Vegetation::Table_Batch::InstanceGrassArguments::SLOT,
                 0,
-                false, false,
                 BufferGetByteSize(vegetationState.indirectGrassArgumentBuffer[i]),
                 0
             });
@@ -415,7 +405,6 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
                 vegetationState.indirectMeshArgumentsBuffer[i],
                 Vegetation::Table_Batch::InstanceMeshArguments::SLOT,
                 0,
-                false, false,
                 BufferGetByteSize(vegetationState.indirectMeshArgumentsBuffer[i]),
                 0
             });


### PR DESCRIPTION
Remove the need to initialize the whole ResourceTableBuffer/Texture/TextureView/InputAttachment structs before binding a resource by providing a set of constructors for said structs.