### PR TITLE
Fixes delete race

### DIFF
--- a/code/render/coregraphics/vk/vkbuffer.cc
+++ b/code/render/coregraphics/vk/vkbuffer.cc
@@ -237,14 +237,16 @@ CreateBuffer(const BufferCreateInfo& info)
 void 
 DestroyBuffer(const BufferId id)
 {
-    VkBufferLoadInfo& loadInfo = bufferAllocator.GetUnsafe<Buffer_LoadInfo>(id.id24);
-    VkBufferRuntimeInfo& runtimeInfo = bufferAllocator.GetUnsafe<Buffer_RuntimeInfo>(id.id24);
-    VkBufferMapInfo& mapInfo = bufferAllocator.GetUnsafe<Buffer_MapInfo>(id.id24);
+    bufferAllocator.Lock(Util::ArrayAllocatorAccess::Write);
+    VkBufferLoadInfo& loadInfo = bufferAllocator.Get<Buffer_LoadInfo>(id.id24);
+    VkBufferRuntimeInfo& runtimeInfo = bufferAllocator.Get<Buffer_RuntimeInfo>(id.id24);
+    VkBufferMapInfo& mapInfo = bufferAllocator.Get<Buffer_MapInfo>(id.id24);
 
     n_assert(mapInfo.mapCount == 0);
     CoreGraphics::DelayedDeleteBuffer(id);
     CoreGraphics::DelayedFreeMemory(loadInfo.mem);
     loadInfo.mem = CoreGraphics::Alloc{};
+    bufferAllocator.Unlock(Util::ArrayAllocatorAccess::Write);
     bufferAllocator.Dealloc(id.id24);
 }
 

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -1976,6 +1976,10 @@ ParseMarkersAndTime(CoreGraphics::FrameProfilingMarker& marker, uint64* data, co
 void
 NewFrame()
 {
+    // We need to lock here so that we don't accidentally insert a delete resource inbetween updating
+    // the current buffer index and deleting pending resources
+    Threading::CriticalScope scope(&delayedDeleteSection);
+
     // Progress to next frame and wait for that buffer
     state.currentBufferedFrameIndex = (state.currentBufferedFrameIndex + 1) % state.maxNumBufferedFrames;
 


### PR DESCRIPTION
Previously, a thread could add a buffer to delete after going to the next frame and before clearing that frames resources, resulting in the buffer getting deleted before it was finished being used.