### PR TITLE
Tightened up nomenclature for barriers

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -198,7 +198,7 @@ UltralightRenderer::UpdateTexture(uint32_t texture_id, ultralight::Ref<ultraligh
                             CoreGraphics::TextureBarrierInfo
                             {
                                 storage.tex,
-                                CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                             }
                         });
     CoreGraphics::CmdCopy(setupCmd, tempBuf, { from }, storage.tex, { to });
@@ -207,7 +207,7 @@ UltralightRenderer::UpdateTexture(uint32_t texture_id, ultralight::Ref<ultraligh
                             CoreGraphics::TextureBarrierInfo
                             {
                                 storage.tex,
-                                CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                             }
                         });
 

--- a/code/render/coregraphics/barrier.h
+++ b/code/render/coregraphics/barrier.h
@@ -20,12 +20,12 @@ namespace CoreGraphics
 ID_24_8_TYPE(BarrierId);
 
 struct CmdBufferId;
-struct ImageSubresourceInfo
+struct TextureSubresourceInfo
 {
     CoreGraphics::ImageAspect aspect;
     uint mip, mipCount, layer, layerCount;
 
-    ImageSubresourceInfo() :
+    TextureSubresourceInfo() :
         aspect(CoreGraphics::ImageAspect::ColorBits),
         mip(0),
         mipCount(1),
@@ -33,7 +33,7 @@ struct ImageSubresourceInfo
         layerCount(1)
     {}
 
-    ImageSubresourceInfo(CoreGraphics::ImageAspect aspect, uint mip, uint mipCount, uint layer, uint layerCount) :
+    TextureSubresourceInfo(CoreGraphics::ImageAspect aspect, uint mip, uint mipCount, uint layer, uint layerCount) :
         aspect(aspect),
         mip(mip),
         mipCount(mipCount),
@@ -41,37 +41,37 @@ struct ImageSubresourceInfo
         layerCount(layerCount)
     {}
 
-    static ImageSubresourceInfo ColorNoMipNoLayer()
+    static TextureSubresourceInfo ColorNoMipNoLayer()
     {
-        return ImageSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, 1, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, 1, 0, 1);
     }
 
-    static ImageSubresourceInfo ColorNoMip(uint layerCount)
+    static TextureSubresourceInfo ColorNoMip(uint layerCount)
     {
-        return ImageSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, 1, 0, layerCount);
+        return TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, 1, 0, layerCount);
     }
 
-    static ImageSubresourceInfo ColorNoLayer(uint mipCount)
+    static TextureSubresourceInfo ColorNoLayer(uint mipCount)
     {
-        return ImageSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, mipCount, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, mipCount, 0, 1);
     }
 
-    static ImageSubresourceInfo DepthStencilNoMipNoLayer()
+    static TextureSubresourceInfo DepthStencilNoMipNoLayer()
     {
-        return ImageSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, 1, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, 1, 0, 1);
     }
 
-    static ImageSubresourceInfo DepthStencilNoMip(uint layerCount)
+    static TextureSubresourceInfo DepthStencilNoMip(uint layerCount)
     {
-        return ImageSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, 1, 0, layerCount);
+        return TextureSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, 1, 0, layerCount);
     }
 
-    static ImageSubresourceInfo DepthStencilNoLayer(uint mipCount)
+    static TextureSubresourceInfo DepthStencilNoLayer(uint mipCount)
     {
-        return ImageSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, mipCount, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, mipCount, 0, 1);
     }
 
-    const bool Overlaps(const ImageSubresourceInfo& rhs) const
+    const bool Overlaps(const TextureSubresourceInfo& rhs) const
     {
         return ((this->aspect & rhs.aspect) != 0) && (this->mip <= rhs.mip && this->mip + this->mipCount >= rhs.mip) && (this->layer <= rhs.layer && this->layer + this->layerCount >= rhs.layer);
     }
@@ -83,7 +83,12 @@ struct BufferSubresourceInfo
 
     BufferSubresourceInfo() :
         offset(0),
-        size(-1)
+        size(NEBULA_WHOLE_BUFFER_SIZE)
+    {}
+
+    BufferSubresourceInfo(uint offset, uint size) :
+        offset(offset),
+        size(size)
     {}
 
     const bool Overlaps(const BufferSubresourceInfo& rhs) const
@@ -95,7 +100,7 @@ struct BufferSubresourceInfo
 struct TextureBarrier
 {
     TextureId tex;
-    ImageSubresourceInfo subres;
+    TextureSubresourceInfo subres;
     CoreGraphics::PipelineStage fromStage;
     CoreGraphics::PipelineStage toStage;
 };
@@ -112,14 +117,13 @@ struct BufferBarrier
 struct TextureBarrierInfo
 {
     TextureId tex;
-    ImageSubresourceInfo subres;
+    TextureSubresourceInfo subres;
 };
 
 struct BufferBarrierInfo
 {
     BufferId buf;
-    IndexT offset;
-    SizeT size; // set to -1 to use whole buffer
+    BufferSubresourceInfo subres;
 };
 
 struct BarrierCreateInfo

--- a/code/render/coregraphics/texture.cc
+++ b/code/render/coregraphics/texture.cc
@@ -41,7 +41,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
         {
             {
                 id,
-                CoreGraphics::ImageSubresourceInfo{ ImageAspect::ColorBits, 0, (uint)numMips, 0, 1 },
+                CoreGraphics::TextureSubresourceInfo{ ImageAspect::ColorBits, 0, (uint)numMips, 0, 1 },
             },
         });
 
@@ -78,7 +78,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             {
                 {
                     id,
-                    CoreGraphics::ImageSubresourceInfo{ CoreGraphics::ImageAspect::ColorBits, (uint)mip, 1, 0, 1 },
+                    CoreGraphics::TextureSubresourceInfo{ CoreGraphics::ImageAspect::ColorBits, (uint)mip, 1, 0, 1 },
                 }
             },
             nullptr);
@@ -91,7 +91,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             {
                 {
                     id,
-                    CoreGraphics::ImageSubresourceInfo{ CoreGraphics::ImageAspect::ColorBits, (uint)mip + 1, 1, 0, 1 },
+                    CoreGraphics::TextureSubresourceInfo{ CoreGraphics::ImageAspect::ColorBits, (uint)mip + 1, 1, 0, 1 },
                 }
             },
             nullptr);
@@ -111,7 +111,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             CoreGraphics::TextureBarrierInfo
             {
                 id,
-                CoreGraphics::ImageSubresourceInfo(ImageAspect::ColorBits, mip, 1, 0, 1),
+                CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, mip, 1, 0, 1),
             }
         },
         nullptr);

--- a/code/render/coregraphics/texture.h
+++ b/code/render/coregraphics/texture.h
@@ -18,7 +18,7 @@ namespace CoreGraphics
 {
 
 struct CmdBufferId;
-struct ImageSubresourceInfo;
+struct TextureSubresourceInfo;
 
 /// texture type
 RESOURCE_ID_TYPE(TextureId);
@@ -235,9 +235,9 @@ void TextureSparseCommitChanges(const CoreGraphics::TextureId id);
 void TextureUpdate(const CoreGraphics::CmdBufferId cmd, CoreGraphics::QueueType queue, CoreGraphics::TextureId tex, const SizeT width, SizeT height, SizeT mip, SizeT layer, SizeT size, const void* data);
 
 /// clear texture with color
-void TextureClearColor(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, Math::vec4 color, const CoreGraphics::ImageLayout layout, const CoreGraphics::ImageSubresourceInfo& subres);
+void TextureClearColor(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, Math::vec4 color, const CoreGraphics::ImageLayout layout, const CoreGraphics::TextureSubresourceInfo& subres);
 /// clear texture with depth-stencil
-void TextureClearDepthStencil(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, float depth, uint stencil, const CoreGraphics::ImageLayout layout, const CoreGraphics::ImageSubresourceInfo& subres);
+void TextureClearDepthStencil(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, float depth, uint stencil, const CoreGraphics::ImageLayout layout, const CoreGraphics::TextureSubresourceInfo& subres);
 
 /// helper function to setup RenderTextureInfo, already implemented
 TextureCreateInfoAdjusted TextureGetAdjustedInfo(const TextureCreateInfo& info);

--- a/code/render/coregraphics/textureloader.cc
+++ b/code/render/coregraphics/textureloader.cc
@@ -94,7 +94,7 @@ TextureLoader::LoadFromStream(Ids::Id32 entry, const Util::StringAtom& tag, cons
         textureInfo.format = format;
         CoreGraphics::TextureId texture = CoreGraphics::CreateTexture(textureInfo);
 
-        CoreGraphics::ImageSubresourceInfo subres(CoreGraphics::ImageAspect::ColorBits, streamData->lowestLod, mipsToLoad, 0, textureInfo.layers);
+        CoreGraphics::TextureSubresourceInfo subres(CoreGraphics::ImageAspect::ColorBits, streamData->lowestLod, mipsToLoad, 0, textureInfo.layers);
 
         // use resource submission
         CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockTransferSetupCommandBuffer();
@@ -232,7 +232,7 @@ TextureLoader::StreamMaxLOD(const Resources::ResourceId& id, const float lod, bo
     texture.resourceType = id.resourceType;
 
     const gliml::context& ctx = streamData->ctx;
-    CoreGraphics::ImageSubresourceInfo subres(CoreGraphics::ImageAspect::ColorBits, adjustedLod, streamData->lowestLod, 0, ctx.num_faces());
+    CoreGraphics::TextureSubresourceInfo subres(CoreGraphics::ImageAspect::ColorBits, adjustedLod, streamData->lowestLod, 0, ctx.num_faces());
 
     // use resource submission
     CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockTransferSetupCommandBuffer();

--- a/code/render/coregraphics/vk/vkbarrier.cc
+++ b/code/render/coregraphics/vk/vkbarrier.cc
@@ -66,7 +66,7 @@ CreateBarrier(const BarrierCreateInfo& info)
         vkInfo.imageBarriers[vkInfo.numImageBarriers].srcAccessMask = VkTypes::AsVkAccessFlags(info.fromStage);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].dstAccessMask = VkTypes::AsVkAccessFlags(info.toStage);
 
-        const ImageSubresourceInfo& subres = info.textures[i].subres;
+        const TextureSubresourceInfo& subres = info.textures[i].subres;
         bool isDepth = (subres.aspect & CoreGraphics::ImageAspect::DepthBits) == CoreGraphics::ImageAspect::DepthBits;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseMipLevel = subres.mip;
@@ -104,15 +104,15 @@ CreateBarrier(const BarrierCreateInfo& info)
         vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = 0;
         vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = VK_WHOLE_SIZE; 
 
-        if (info.buffers[i].size == -1)
+        if (info.buffers[i].subres.size == -1)
         {
             vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = 0;
             vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = VK_WHOLE_SIZE;
         }
         else
         {
-            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = info.buffers[i].offset;
-            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = info.buffers[i].size;
+            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = info.buffers[i].subres.offset;
+            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = info.buffers[i].subres.size;
         }
 
         vkInfo.numBufferBarriers++;

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -589,8 +589,8 @@ CmdBarrier(
         vkBar.srcAccessMask = VkTypes::AsVkAccessFlags(fromStage);
         vkBar.dstAccessMask = VkTypes::AsVkAccessFlags(toStage);
         vkBar.buffer = CoreGraphics::BufferGetVk(nebBar.buf);
-        vkBar.offset = nebBar.offset;
-        vkBar.size = (nebBar.size == -1) ? VK_WHOLE_SIZE : nebBar.size;
+        vkBar.offset = nebBar.subres.offset;
+        vkBar.size = (nebBar.subres.size == -1) ? VK_WHOLE_SIZE : nebBar.subres.size;
         vkBar.srcQueueFamilyIndex = fromQueue == InvalidIndex ? VK_QUEUE_FAMILY_IGNORED : fromQueue;
         vkBar.dstQueueFamilyIndex = toQueue == InvalidIndex ? VK_QUEUE_FAMILY_IGNORED : toQueue;
 
@@ -607,7 +607,7 @@ CmdBarrier(
         vkBar.srcAccessMask = VkTypes::AsVkAccessFlags(fromStage);
         vkBar.dstAccessMask = VkTypes::AsVkAccessFlags(toStage);
 
-        const ImageSubresourceInfo& subres = nebBar.subres;
+        const TextureSubresourceInfo& subres = nebBar.subres;
         bool isDepth = (subres.aspect & CoreGraphics::ImageAspect::DepthBits) == 1;
         vkBar.subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
         vkBar.subresourceRange.baseMipLevel = subres.mip;

--- a/code/render/coregraphics/vk/vkevent.cc
+++ b/code/render/coregraphics/vk/vkevent.cc
@@ -72,7 +72,7 @@ CreateEvent(const EventCreateInfo& info)
         vkInfo.imageBarriers[vkInfo.numImageBarriers].srcAccessMask = VkTypes::AsVkAccessFlags(info.fromStage);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].dstAccessMask = VkTypes::AsVkAccessFlags(info.toStage);
 
-        const ImageSubresourceInfo& subres = info.textures[i].subres;
+        const TextureSubresourceInfo& subres = info.textures[i].subres;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseMipLevel = subres.mip;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.levelCount = subres.mipCount;
@@ -98,15 +98,15 @@ CreateEvent(const EventCreateInfo& info)
         vkInfo.bufferBarriers[i].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         vkInfo.bufferBarriers[i].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 
-        if (info.buffers[i].size == -1)
+        if (info.buffers[i].subres.size == -1)
         {
             vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = 0;
             vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = VK_WHOLE_SIZE;
         }
         else
         {
-            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = info.buffers[i].offset;
-            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = info.buffers[i].size;
+            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].offset = info.buffers[i].subres.offset;
+            vkInfo.bufferBarriers[vkInfo.numBufferBarriers].size = info.buffers[i].subres.size;
         }
 
         vkInfo.numBufferBarriers++;

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -363,7 +363,7 @@ SetupTexture(const TextureId id)
                         TextureBarrierInfo
                         {
                             id,
-                            CoreGraphics::ImageSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
+                            CoreGraphics::TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
                         }
                     },
                     nullptr);
@@ -379,7 +379,7 @@ SetupTexture(const TextureId id)
                         TextureBarrierInfo
                         {
                             id,
-                            CoreGraphics::ImageSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
+                            CoreGraphics::TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
                         }
                     },
                     nullptr);
@@ -444,7 +444,7 @@ SetupTexture(const TextureId id)
         // use setup submission
         CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockGraphicsSetupCommandBuffer();
 
-        CoreGraphics::ImageSubresourceInfo subres(
+        CoreGraphics::TextureSubresourceInfo subres(
             isDepthFormat ? CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits : CoreGraphics::ImageAspect::ColorBits
             , viewRange.baseMipLevel
             , viewRange.levelCount
@@ -1434,7 +1434,7 @@ TextureSparseUpdate(const CoreGraphics::CmdBufferId cmdBuf, const CoreGraphics::
 /**
 */
 void
-TextureClearColor(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, Math::vec4 color, const CoreGraphics::ImageLayout layout, const CoreGraphics::ImageSubresourceInfo& subres)
+TextureClearColor(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, Math::vec4 color, const CoreGraphics::ImageLayout layout, const CoreGraphics::TextureSubresourceInfo& subres)
 {
     VkClearColorValue clear;
     VkImageSubresourceRange vksubres;
@@ -1458,7 +1458,7 @@ TextureClearColor(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::Textu
 /**
 */
 void
-TextureClearDepthStencil(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, float depth, uint stencil, const CoreGraphics::ImageLayout layout, const CoreGraphics::ImageSubresourceInfo& subres)
+TextureClearDepthStencil(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::TextureId id, float depth, uint stencil, const CoreGraphics::ImageLayout layout, const CoreGraphics::TextureSubresourceInfo& subres)
 {
     VkClearDepthStencilValue clear;
     VkImageSubresourceRange vksubres;

--- a/code/render/fog/volumetricfogcontext.cc
+++ b/code/render/fog/volumetricfogcontext.cc
@@ -216,13 +216,13 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "Fog Volume Texture 0"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     fogCompute->textureDeps.Add(fogState.zBuffer,
                                 {
                                     "ZBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::ImageSubresourceInfo::DepthStencilNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::DepthStencilNoMipNoLayer()
                                 });
     fogCompute->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -242,13 +242,13 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "Fog Volume Texture 0"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     blurX->textureDeps.Add(fogState.fogVolumeTexture1,
                                 {
                                     "Fog Volume Texture 1"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     blurX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -266,13 +266,13 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "Fog Volume Texture 1"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     blurY->textureDeps.Add(fogState.fogVolumeTexture0,
                                 {
                                     "Fog Volume Texture 0"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     blurY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/frame/frameop.h
+++ b/code/render/frame/frameop.h
@@ -58,7 +58,7 @@ public:
 
     CoreGraphics::BarrierDomain domain;
     CoreGraphics::QueueType queue;
-    Util::Dictionary<CoreGraphics::TextureId, Util::Tuple<Util::StringAtom, CoreGraphics::PipelineStage, CoreGraphics::ImageSubresourceInfo>> textureDeps;
+    Util::Dictionary<CoreGraphics::TextureId, Util::Tuple<Util::StringAtom, CoreGraphics::PipelineStage, CoreGraphics::TextureSubresourceInfo>> textureDeps;
     Util::Dictionary<CoreGraphics::BufferId, Util::Tuple<Util::StringAtom, CoreGraphics::PipelineStage, CoreGraphics::BufferSubresourceInfo>> bufferDeps;
 
 protected:
@@ -92,7 +92,7 @@ protected:
     {
         CoreGraphics::PipelineStage stage;
         DependencyIntent intent;
-        CoreGraphics::ImageSubresourceInfo subres;
+        CoreGraphics::TextureSubresourceInfo subres;
         CoreGraphics::QueueType queue;
     };
 
@@ -111,7 +111,7 @@ protected:
         DependencyIntent readOrWrite,
         CoreGraphics::PipelineStage stage,
         CoreGraphics::BarrierDomain domain,
-        const CoreGraphics::ImageSubresourceInfo& subres,
+        const CoreGraphics::TextureSubresourceInfo& subres,
         CoreGraphics::QueueType fromQueue,
         Util::Dictionary<Util::Tuple<CoreGraphics::PipelineStage, CoreGraphics::PipelineStage>, CoreGraphics::BarrierCreateInfo>& barriers,
         Util::Dictionary<Util::Tuple<CoreGraphics::PipelineStage, CoreGraphics::PipelineStage>, CoreGraphics::EventCreateInfo>& waitEvents,

--- a/code/render/frame/framescript.cc
+++ b/code/render/frame/framescript.cc
@@ -210,7 +210,7 @@ FrameScript::Build()
         uint layers = CoreGraphics::TextureGetNumLayers(tex);
         uint mips = CoreGraphics::TextureGetNumMips(tex);
 
-        CoreGraphics::ImageSubresourceInfo subres;
+        CoreGraphics::TextureSubresourceInfo subres;
         subres.aspect = isDepth ? (CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits) : CoreGraphics::ImageAspect::ColorBits;
         subres.layer = 0;
         subres.layerCount = layers;
@@ -237,7 +237,7 @@ FrameScript::Build()
         const Util::Array<FrameOp::TextureDependency>& deps = textures.ValueAtIndex(i);
 
         const FrameOp::TextureDependency& dep = deps.Back();
-        const CoreGraphics::ImageSubresourceInfo& info = dep.subres;
+        const CoreGraphics::TextureSubresourceInfo& info = dep.subres;
 
         // The last thing we do with present is to 
         CoreGraphics::PipelineStage fromStage, toStage;

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -261,7 +261,7 @@ FrameScriptLoader::ParseBlit(const Ptr<Frame::FrameScript>& script, JzonValue* n
     bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(fromTex));
 
     // add implicit barriers
-    ImageSubresourceInfo subres;
+    TextureSubresourceInfo subres;
     subres.aspect = isDepth ? CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits : CoreGraphics::ImageAspect::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
@@ -306,7 +306,7 @@ FrameScriptLoader::ParseCopy(const Ptr<Frame::FrameScript>& script, JzonValue* n
     bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(fromTex));
 
     // add implicit barriers
-    ImageSubresourceInfo subres;
+    TextureSubresourceInfo subres;
     subres.aspect = isDepth ? (CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits) : CoreGraphics::ImageAspect::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
@@ -346,7 +346,7 @@ FrameScriptLoader::ParseMipmap(const Ptr<Frame::FrameScript>& script, JzonValue*
     bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(ttex));
 
     // add implicit barriers
-    ImageSubresourceInfo subres;
+    TextureSubresourceInfo subres;
     subres.aspect = isDepth ? (CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits) : CoreGraphics::ImageAspect::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
@@ -667,7 +667,7 @@ FrameScriptLoader::ParsePass(const Ptr<Frame::FrameScript>& script, JzonValue* n
         }
     }
 
-    ImageSubresourceInfo subres;
+    TextureSubresourceInfo subres;
     subres.aspect = CoreGraphics::ImageAspect::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
@@ -1193,7 +1193,7 @@ FrameScriptLoader::ParseResourceDependencies(const Ptr<Frame::FrameScript>& scri
 
         if (script->texturesByName.Contains(valstr))
         {
-            CoreGraphics::ImageSubresourceInfo subres;
+            CoreGraphics::TextureSubresourceInfo subres;
             JzonValue* nd = nullptr;
 
             TextureId tex = script->texturesByName[valstr];

--- a/code/render/lighting/lightcontext.cc
+++ b/code/render/lighting/lightcontext.cc
@@ -335,25 +335,25 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "LightBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     lightsCombine->textureDeps.Add(textureState.aoTexture,
                                {
                                    "SSAOBuffer"
                                    , CoreGraphics::PipelineStage::ComputeShaderRead
-                                   , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                   , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                });
     lightsCombine->textureDeps.Add(textureState.fogTexture,
                                 {
                                     "VolumeFogBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     lightsCombine->textureDeps.Add(textureState.reflectionTexture,
                                 {
                                     "ReflectionBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
     lightsCombine->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/posteffects/bloomcontext.cc
+++ b/code/render/posteffects/bloomcontext.cc
@@ -131,7 +131,7 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
                                {
                                    "LightBuffer"
                                    , CoreGraphics::PipelineStage::PixelShaderRead
-                                   , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                   , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                });
 
     lowpassOp->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
@@ -178,13 +178,13 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
                     {
                         "BloomBuffer",
                         CoreGraphics::PipelineStage::TransferRead,
-                        CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                        CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                     });
     blit->textureDeps.Add(bloomState.blurredBloom,
                     {
                         "BloomBufferBlurred",
                         CoreGraphics::PipelineStage::TransferWrite,
-                        CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                        CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                     });
     blit->from = bloomState.bloomBuffer;
     blit->to = bloomState.blurredBloom;
@@ -199,14 +199,14 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
                             {
                                 "Bloom-Internal0"
                                 , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
 
         blurX->textureDeps.Add(bloomState.blurredBloom,
                             {
                                 "Bloom-BlurredBloom"
                                 , CoreGraphics::PipelineStage::ComputeShaderRead
-                                , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
 
         blurX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
@@ -229,13 +229,13 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
                               {
                                   "Bloom-Internal0"
                                   , CoreGraphics::PipelineStage::ComputeShaderRead
-                                  , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                  , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                               });
         blurY->textureDeps.Add(bloomState.blurredBloom,
                               {
                                   "Bloom-Output"
                                   , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                  , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                  , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                               });
 
         blurY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)

--- a/code/render/posteffects/histogramcontext.cc
+++ b/code/render/posteffects/histogramcontext.cc
@@ -283,7 +283,7 @@ HistogramContext::Setup(const Ptr<Frame::FrameScript>& script)
                                 {
                                     "Histogram Downsample"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                 });
 
     downsample->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
@@ -331,7 +331,7 @@ HistogramContext::Setup(const Ptr<Frame::FrameScript>& script)
             CoreGraphics::BufferBarrierInfo
             {
                 histogramState.histogramReadback[bufferIndex],
-                0, NEBULA_WHOLE_BUFFER_SIZE
+                CoreGraphics::BufferSubresourceInfo()
             },
         });
 

--- a/code/render/posteffects/ssaocontext.cc
+++ b/code/render/posteffects/ssaocontext.cc
@@ -124,7 +124,7 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
     ssaoState.internalTargets[0] = CreateTexture(tinfo);
     tinfo.name = "HBAO-Internal1";
     ssaoState.internalTargets[1] = CreateTexture(tinfo);
-    ImageSubresourceInfo subres = ImageSubresourceInfo::ColorNoMipNoLayer();
+    TextureSubresourceInfo subres = TextureSubresourceInfo::ColorNoMipNoLayer();
 
     // setup shaders
     ssaoState.hbaoShader = ShaderGet("shd:hbao_cs.fxb");
@@ -200,13 +200,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "ZBuffer"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::ImageSubresourceInfo::DepthStencilNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::DepthStencilNoMipNoLayer()
                          });
     aoX->textureDeps.Add(ssaoState.internalTargets[0],
                          {
                             "SSAOBuffer0"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     aoX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -226,13 +226,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "SSAOBuffer0"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     aoY->textureDeps.Add(ssaoState.internalTargets[1],
                          {
                             "SSAOBuffer1"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     aoY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -252,13 +252,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "SSAOBuffer1"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     blurX->textureDeps.Add(ssaoState.internalTargets[0],
                          {
                             "SSAOBuffer0"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     blurX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -278,13 +278,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "SSAOBuffer1"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     blurY->textureDeps.Add(ssaoState.ssaoOutput,
                          {
                             "SSAOOutput"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::ImageSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                          });
     blurY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -629,13 +629,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                                 {
                                     "Indirection Texture",
                                     CoreGraphics::PipelineStage::TransferWrite,
-                                    CoreGraphics::ImageSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
+                                    CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
                                 });
     terrainPrepare->textureDeps.Add(terrainVirtualTileState.indirectionTextureCopy,
                                 {
                                     "Indirection Texture Copy",
                                     CoreGraphics::PipelineStage::TransferRead,
-                                    CoreGraphics::ImageSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
+                                    CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
                                 });
     terrainPrepare->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -652,7 +652,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                     BufferBarrierInfo
                     {
                         CoreGraphics::GetUploadBuffer(),
-                        0, NEBULA_WHOLE_BUFFER_SIZE
+                        CoreGraphics::BufferSubresourceInfo()
                     },
                 });
 
@@ -691,7 +691,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                     BufferBarrierInfo
                     {
                         CoreGraphics::GetUploadBuffer(),
-                        0, NEBULA_WHOLE_BUFFER_SIZE
+                        CoreGraphics::BufferSubresourceInfo()
                     },
                 });
 
@@ -718,7 +718,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                     BufferBarrierInfo
                     {
                         terrainVirtualTileState.subtextureStagingBuffers[bufferIndex],
-                        0, NEBULA_WHOLE_BUFFER_SIZE
+                        CoreGraphics::BufferSubresourceInfo()
                     },
                 });
 
@@ -739,7 +739,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                     BufferBarrierInfo
                     {
                         terrainVirtualTileState.subtextureStagingBuffers[bufferIndex],
-                        0, NEBULA_WHOLE_BUFFER_SIZE
+                        CoreGraphics::BufferSubresourceInfo()
                     },
                 });
 
@@ -753,13 +753,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Indirection Texture",
                                 CoreGraphics::PipelineStage::TransferRead,
-                                CoreGraphics::ImageSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
+                                CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
                             });
     indirectionCopy->textureDeps.Add(terrainVirtualTileState.indirectionTextureCopy,
                             {
                                 "Indirection Texture Copy",
                                 CoreGraphics::PipelineStage::TransferWrite,
-                                CoreGraphics::ImageSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
+                                CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
                             });
     indirectionCopy->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -897,19 +897,19 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::ColorWrite,
-                                ImageSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
     cacheUpdate->textureDeps.Add(terrainVirtualTileState.physicalMaterialCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::ColorWrite,
-                                ImageSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
     cacheUpdate->textureDeps.Add(terrainVirtualTileState.physicalNormalCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::ColorWrite,
-                                ImageSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
     cacheUpdate->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -1003,25 +1003,25 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::PixelShaderRead,
-                                ImageSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
     screenSpace->textureDeps.Add(terrainVirtualTileState.physicalMaterialCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::PixelShaderRead,
-                                ImageSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
     screenSpace->textureDeps.Add(terrainVirtualTileState.physicalNormalCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::PixelShaderRead,
-                                ImageSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::ColorNoMipNoLayer()
                             });
     screenSpace->textureDeps.Add(terrainVirtualTileState.indirectionTexture,
                         {
                             "Indirection Texture",
                             CoreGraphics::PipelineStage::PixelShaderRead,
-                            ImageSubresourceInfo::ColorNoLayer(CoreGraphics::TextureGetNumMips(terrainVirtualTileState.indirectionTexture))
+                            TextureSubresourceInfo::ColorNoLayer(CoreGraphics::TextureGetNumMips(terrainVirtualTileState.indirectionTexture))
                         });
     screenSpace->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/vegetation/vegetationcontext.cc
+++ b/code/render/vegetation/vegetationcontext.cc
@@ -498,7 +498,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
                 BufferBarrierInfo
                 {
                     vegetationState.indirectDrawCountBuffer[bufferIndex],
-                    0, NEBULA_WHOLE_BUFFER_SIZE
+                    CoreGraphics::BufferSubresourceInfo()
                 },
             });
 
@@ -516,7 +516,7 @@ VegetationContext::Create(const VegetationSetupSettings& settings)
                 BufferBarrierInfo
                 {
                     vegetationState.indirectDrawCountBuffer[bufferIndex],
-                    0, NEBULA_WHOLE_BUFFER_SIZE
+                    CoreGraphics::BufferSubresourceInfo()
                 },
             });
     };


### PR DESCRIPTION
ImageSubresourceInfo has been renamed to TextureSubresourceInfo to be more consistent.

Also, BufferSubresourceInfo is used to define buffer barriers, instead of passing the size and offset separately. 