### PR TITLE
Fix missing GPU markers

### DIFF
--- a/code/addons/dynui/profiler/imguiprofiler.h
+++ b/code/addons/dynui/profiler/imguiprofiler.h
@@ -27,6 +27,9 @@ public:
     /// Destructor
     ~ImguiProfiler();
 
+    /// Capture the frame
+    void Capture();
+
     /// Render, call this per-frame
     void Render(Timing::Time frameTime, IndexT frameIndex);
 

--- a/tests/testviewer/viewerapp.cc
+++ b/tests/testviewer/viewerapp.cc
@@ -354,23 +354,35 @@ SimpleViewerApplication::Run()
         */
 
         Jobs2::JobNewFrame();
-        
+
+#if NEBULA_ENABLE_PROFILING
+        this->profiler->Capture();
+        Profiling::ProfilingNewFrame();
+#endif
+
         N_MARKER_BEGIN(Input, App);
         this->inputServer->BeginFrame();
         CoreGraphics::WindowPollEvents();
         this->inputServer->OnFrame();
         N_MARKER_END();
-        CoreGraphics::WindowPollEvents();
         this->resMgr->Update(this->frameIndex);
+
+        if (keyboard->KeyPressed(Input::Key::Escape)) run = false;
+
+        if (keyboard->KeyPressed(Input::Key::LeftMenu) && this->cameraMode == 0
+            || this->cameraMode == 1)
+            this->UpdateCamera();
+
+        if (keyboard->KeyPressed(Input::Key::F8))
+            Terrain::TerrainContext::ClearCache();
+
+        if (keyboard->KeyDown(Input::Key::F3))
+            this->profiler->TogglePause();
 
         // Run pre-game logic render code
         this->gfxServer->RunPreLogic();
-        
-        this->RenderUI();
 
-#if NEBULA_ENABLE_PROFILING
-        Profiling::ProfilingNewFrame();
-#endif
+        this->RenderUI();
 
         if (this->renderDebug)
         {
@@ -396,17 +408,6 @@ SimpleViewerApplication::Run()
         // Begin a new frame
         this->gfxServer->NewFrame();
 
-        if (keyboard->KeyPressed(Input::Key::Escape)) run = false;
-                
-        if (keyboard->KeyPressed(Input::Key::LeftMenu) && this->cameraMode == 0
-            || this->cameraMode == 1)
-            this->UpdateCamera();
-        
-        if (keyboard->KeyPressed(Input::Key::F8))
-            Terrain::TerrainContext::ClearCache();
-
-        if (keyboard->KeyDown(Input::Key::F3))
-            this->profiler->TogglePause();
 
         frameIndex++;             
         this->inputServer->EndFrame();


### PR DESCRIPTION
Because we copied the markers from the GPU on the Render call, we obviously missed a bunch of markers. To fix that, the profiler has two calls, capture and render. Capture is to be run after the frame is done (or before a new profiler frame is initiated) and the render should be called like before. 