### PR TITLE
Fix lights blink

### DIFF
--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -71,6 +71,7 @@ struct SubmissionWaitEvent
 #if __VULKAN__
     uint64_t timelineIndex;
 #endif
+    CoreGraphics::QueueType queue;
 };
 
 struct GraphicsDeviceState
@@ -169,25 +170,8 @@ void UnlockGraphicsSetupCommandBuffer();
 SubmissionWaitEvent SubmitCommandBuffer(const CoreGraphics::CmdBufferId cmds, CoreGraphics::QueueType type);
 /// Wait for a submission
 void WaitForSubmission(SubmissionWaitEvent index, CoreGraphics::QueueType type, CoreGraphics::QueueType waitType);
-
-/// Set the resource table to be used for the NEBULA_TICK_GROUP, returns the currently used resource table
-void SetTickResourceTableGraphics(const CoreGraphics::ResourceTableId table);
-/// Get tick resoure table
-CoreGraphics::ResourceTableId GetTickResourceTableGraphics();
-/// Set the resource table to be used for the NEBULA_TICK_GROUP, returns the currently used resource table
-void SetTickResourceTableCompute(const CoreGraphics::ResourceTableId table);
-/// Get tick resoure table
-CoreGraphics::ResourceTableId GetTickResourceTableCompute();
-
-
-/// Set the resource table to be used for the NEBULA_FRAME_GROUP, returns the currently used resource table
-void SetFrameResourceTableGraphics(const CoreGraphics::ResourceTableId table);
-/// Get frame resoure table
-CoreGraphics::ResourceTableId GetFrameResourceTableGraphics();
-/// Set the resource table to be used for the NEBULA_FRAME_GROUP, returns the currently used resource table
-void SetFrameResourceTableCompute(const CoreGraphics::ResourceTableId table);
-/// Get frame resoure table
-CoreGraphics::ResourceTableId GetFrameResourceTableCompute();
+/// Have a queue wait for another queue
+void WaitForLastSubmission(CoreGraphics::QueueType type, CoreGraphics::QueueType waitType);
 
 /// Unlock constants
 void UnlockConstantUpdates();

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -393,6 +393,7 @@ CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pr
     VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
     VkShaderProgramRuntimeInfo& info = shaderAlloc.Get<Shader_ProgramAllocator>(pro.shaderId).Get<ShaderProgram_RuntimeInfo>(pro.programId);
 
+    IndexT buffer = CoreGraphics::GetBufferedFrameIndex();
     pipelineBundle.program = pro;
     if (info.type == ShaderPipeline::ComputePipeline)
     {

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -16,6 +16,7 @@
 #include "vkresourcetable.h"
 #include "vkevent.h"
 #include "vkpass.h"
+#include "graphics/globalconstants.h"
 
 namespace Vulkan
 {

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -403,13 +403,13 @@ CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pr
             QueueType queue = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
             if (queue == GraphicsQueueType)
             {
-                CoreGraphics::CmdSetResourceTable(id, CoreGraphics::GetTickResourceTableGraphics(), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
-                CoreGraphics::CmdSetResourceTable(id, CoreGraphics::GetFrameResourceTableGraphics(), NEBULA_FRAME_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
+                CoreGraphics::CmdSetResourceTable(id, Graphics::GetTickResourceTableGraphics(buffer), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
+                CoreGraphics::CmdSetResourceTable(id, Graphics::GetFrameResourceTableGraphics(buffer), NEBULA_FRAME_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
             }
             else
             {
-                CoreGraphics::CmdSetResourceTable(id, CoreGraphics::GetTickResourceTableCompute(), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
-                CoreGraphics::CmdSetResourceTable(id, CoreGraphics::GetFrameResourceTableCompute(), NEBULA_FRAME_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
+                CoreGraphics::CmdSetResourceTable(id, Graphics::GetTickResourceTableCompute(buffer), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
+                CoreGraphics::CmdSetResourceTable(id, Graphics::GetFrameResourceTableCompute(buffer), NEBULA_FRAME_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
             }
         }
     }
@@ -443,8 +443,8 @@ CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pr
         pipelineBundle.graphicsLayout = info.layout;
         if (bindGlobals && pipelineChange)
         {
-            CoreGraphics::CmdSetResourceTable(id, CoreGraphics::GetTickResourceTableGraphics(), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::GraphicsPipeline, nullptr);
-            CoreGraphics::CmdSetResourceTable(id, CoreGraphics::GetFrameResourceTableGraphics(), NEBULA_FRAME_GROUP, CoreGraphics::ShaderPipeline::GraphicsPipeline, nullptr);
+            CoreGraphics::CmdSetResourceTable(id, Graphics::GetTickResourceTableGraphics(buffer), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::GraphicsPipeline, nullptr);
+            CoreGraphics::CmdSetResourceTable(id, Graphics::GetFrameResourceTableGraphics(buffer), NEBULA_FRAME_GROUP, CoreGraphics::ShaderPipeline::GraphicsPipeline, nullptr);
             CoreGraphics::CmdSetResourceTable(id, PassGetResourceTable(pipelineBundle.pass), NEBULA_PASS_GROUP, CoreGraphics::ShaderPipeline::GraphicsPipeline, nullptr);
         }
     }

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -37,7 +37,9 @@
 
 namespace Vulkan
 {
-Threading::CriticalSection delayedDeleteSection;
+static Threading::CriticalSection delayedDeleteSection;
+static Threading::CriticalSection transferLock;
+static Threading::CriticalSection setupLock;
 
 struct GraphicsDeviceState : CoreGraphics::GraphicsDeviceState
 {
@@ -86,7 +88,8 @@ struct GraphicsDeviceState : CoreGraphics::GraphicsDeviceState
         Util::Array<Util::Tuple<CoreGraphics::Alloc>> allocs;
     };
     Util::FixedArray<PendingDeletes> pendingDeletes;
-    Util::FixedArray<Util::Array<Util::Pair<CoreGraphics::QueueType, CoreGraphics::SubmissionWaitEvent>>> waitEvents;
+    Util::FixedArray<Util::Array<CoreGraphics::SubmissionWaitEvent>> waitEvents;
+    CoreGraphics::SubmissionWaitEvent mostRecentEvents[CoreGraphics::QueueType::NumQueueTypes];
 
     struct PendingMarkers
     {
@@ -410,12 +413,8 @@ VkPipeline
 GetOrCreatePipeline(CoreGraphics::PassId pass, uint subpass, CoreGraphics::ShaderProgramId program, CoreGraphics::InputAssemblyKey inputAssembly, const VkGraphicsPipelineCreateInfo& info)
 {
     Threading::CriticalScope scope(&pipelineMutex);
-    N_MARKER_BEGIN(GetOrCreateGraphicsPipeline, Graphics);
-
     VkPipeline pipeline = state.database.GetCompiledPipeline(pass, subpass, program, inputAssembly, info);
     _incr_counter(state.NumPipelinesBuilt, 1);
-
-    N_MARKER_END();
     return pipeline;
 }
 
@@ -435,8 +434,6 @@ SparseTextureBind(const VkImage img, const Util::Array<VkSparseMemoryBind>& opaq
 void
 ClearPending()
 {
-    Threading::CriticalScope scope(&delayedDeleteSection);
-
     // Clear up any pending deletes
     for (const auto& tuple : state.pendingDeletes[state.currentBufferedFrameIndex].commandBuffers)
     {
@@ -1154,12 +1151,10 @@ DestroyGraphicsDevice()
 
     state.database.Discard();
 
-    // destroy pipeline
-    vkDestroyPipelineCache(state.devices[state.currentDevice], state.cache, nullptr);
-
     IndexT i;
     for (i = 0; i < state.renderingFinishedSemaphores.Size(); i++)
     {
+        FenceWait(state.presentFences[i], UINT64_MAX);
         DestroyFence(state.presentFences[i]);
         DestroySemaphore(state.renderingFinishedSemaphores[i]);
     }
@@ -1255,7 +1250,6 @@ RemoveBackBufferTexture(const CoreGraphics::TextureId tex)
     state.backBuffers.EraseIndex(i);
 }
 
-static Threading::CriticalSection transferLock;
 //------------------------------------------------------------------------------
 /**
 */
@@ -1286,14 +1280,13 @@ UnlockTransferSetupCommandBuffer()
     transferLock.Leave();
 }
 
-static Threading::CriticalSection graphicsLock;
 //------------------------------------------------------------------------------
 /**
 */
 const CoreGraphics::CmdBufferId
 LockGraphicsSetupCommandBuffer()
 {
-    graphicsLock.Enter();
+    setupLock.Enter();
     if (state.setupGraphicsCommandBuffer == CoreGraphics::InvalidCmdBufferId)
     {
         CoreGraphics::CmdBufferCreateInfo cmdCreateInfo;
@@ -1314,16 +1307,17 @@ LockGraphicsSetupCommandBuffer()
 void
 UnlockGraphicsSetupCommandBuffer()
 {
-    graphicsLock.Leave();
+    setupLock.Leave();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 void 
-SetSubmissionEvent(const CoreGraphics::QueueType queue, const CoreGraphics::SubmissionWaitEvent& event)
+AddSubmissionEvent(const CoreGraphics::SubmissionWaitEvent& event)
 {
-    state.waitEvents[state.currentBufferedFrameIndex].Append(Util::MakePair(queue, event));
+    state.waitEvents[state.currentBufferedFrameIndex].Append(event);
+    state.mostRecentEvents[event.queue] = event;
 }
 
 //------------------------------------------------------------------------------
@@ -1339,10 +1333,11 @@ SubmitCommandBuffer(const CoreGraphics::CmdBufferId cmds, CoreGraphics::QueueTyp
     {
         CmdEndMarker(state.setupTransferCommandBuffer);
         CmdEndRecord(state.setupTransferCommandBuffer);
-        transferWait.timelineIndex = state.queueHandler.AppendSubmissionTimeline(CoreGraphics::TransferQueueType, CmdBufferGetVk(state.setupTransferCommandBuffer), true);
+        transferWait.timelineIndex = state.queueHandler.AppendSubmissionTimeline(CoreGraphics::TransferQueueType, CmdBufferGetVk(state.setupTransferCommandBuffer));
+        transferWait.queue = CoreGraphics::TransferQueueType;
 
         // Set wait events in graphics device
-        SetSubmissionEvent(CoreGraphics::TransferQueueType, transferWait);
+        AddSubmissionEvent(transferWait);
 
         // Delete command buffer
         CoreGraphics::DelayedDeleteCommandBuffer(state.setupTransferCommandBuffer);
@@ -1352,19 +1347,21 @@ SubmitCommandBuffer(const CoreGraphics::CmdBufferId cmds, CoreGraphics::QueueTyp
     }
     transferLock.Leave();
 
-    graphicsLock.Enter();
+    setupLock.Enter();
     if (state.setupGraphicsCommandBuffer != CoreGraphics::InvalidCmdBufferId)
     {
         CmdEndMarker(state.setupGraphicsCommandBuffer);
         CmdEndRecord(state.setupGraphicsCommandBuffer);
         
-        graphicsWait.timelineIndex = state.queueHandler.AppendSubmissionTimeline(CoreGraphics::GraphicsQueueType, CmdBufferGetVk(state.setupGraphicsCommandBuffer), false);
+        graphicsWait.timelineIndex = state.queueHandler.AppendSubmissionTimeline(CoreGraphics::GraphicsQueueType, CmdBufferGetVk(state.setupGraphicsCommandBuffer));
+        graphicsWait.queue = CoreGraphics::GraphicsQueueType;
 
+        // This command buffer will have handover commands, so wait for the previous transfer buffer
         if (transferWait != nullptr)
             state.queueHandler.AppendWaitTimeline(transferWait.timelineIndex, CoreGraphics::GraphicsQueueType, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, CoreGraphics::TransferQueueType);
 
-        // Set wait events in graphics device
-        SetSubmissionEvent(CoreGraphics::GraphicsQueueType, graphicsWait);
+        // Add wait event
+        AddSubmissionEvent(graphicsWait);
 
         // Delete command buffer
         CoreGraphics::DelayedDeleteCommandBuffer(state.setupGraphicsCommandBuffer);
@@ -1372,16 +1369,15 @@ SubmitCommandBuffer(const CoreGraphics::CmdBufferId cmds, CoreGraphics::QueueTyp
         // Reset command buffer id for the next frame
         state.setupGraphicsCommandBuffer = CoreGraphics::InvalidCmdBufferId;
     }
-    graphicsLock.Leave();
+    setupLock.Leave();
 
     // Append submission
     CoreGraphics::SubmissionWaitEvent ret;
     ret.timelineIndex = state.queueHandler.AppendSubmissionTimeline(type, CmdBufferGetVk(cmds));
-    //if (state.waitEvents[state.currentBufferedFrameIndex].events[CoreGraphics::GraphicsQueueType] != nullptr)
-        //state.queueHandler.AppendWaitTimeline(state.waitEvents[state.currentBufferedFrameIndex].events[CoreGraphics::GraphicsQueueType].timelineIndex, type, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, CoreGraphics::QueueType::GraphicsQueueType);
+    ret.queue = type;
 
-    // Set wait events in graphics device
-    SetSubmissionEvent(type, ret);
+    // Add wait event
+    AddSubmissionEvent(ret);
 
     Util::Array<CoreGraphics::FrameProfilingMarker> markers = CmdCopyProfilingMarkers(cmds);
     state.pendingMarkers[state.currentBufferedFrameIndex].markers.Append(markers);
@@ -1402,80 +1398,9 @@ WaitForSubmission(SubmissionWaitEvent index, CoreGraphics::QueueType type, CoreG
 /**
 */
 void
-SetTickResourceTableGraphics(const CoreGraphics::ResourceTableId table)
+WaitForLastSubmission(CoreGraphics::QueueType type, CoreGraphics::QueueType waitType)
 {
-    n_assert(table != CoreGraphics::InvalidResourceTableId);
-    CoreGraphics::ResourceTableId ret = state.tickResourceTableGraphics;
-    state.tickResourceTableGraphics = table;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-CoreGraphics::ResourceTableId
-GetTickResourceTableGraphics()
-{
-    return state.tickResourceTableGraphics;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-void
-SetTickResourceTableCompute(const CoreGraphics::ResourceTableId table)
-{
-    n_assert(table != CoreGraphics::InvalidResourceTableId);
-    CoreGraphics::ResourceTableId ret = state.tickResourceTableCompute;
-    state.tickResourceTableCompute = table;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-CoreGraphics::ResourceTableId
-GetTickResourceTableCompute()
-{
-    return state.tickResourceTableCompute;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-void
-SetFrameResourceTableGraphics(const CoreGraphics::ResourceTableId table)
-{
-    n_assert(table != CoreGraphics::InvalidResourceTableId);
-    CoreGraphics::ResourceTableId ret = state.frameResourceTableGraphics;
-    state.frameResourceTableGraphics = table;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-CoreGraphics::ResourceTableId
-GetFrameResourceTableGraphics()
-{
-    return state.frameResourceTableGraphics;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-void
-SetFrameResourceTableCompute(const CoreGraphics::ResourceTableId table)
-{
-    n_assert(table != CoreGraphics::InvalidResourceTableId);
-    CoreGraphics::ResourceTableId ret = state.frameResourceTableCompute;
-    state.frameResourceTableCompute = table;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-CoreGraphics::ResourceTableId
-GetFrameResourceTableCompute()
-{
-    return state.frameResourceTableCompute;
+    state.queueHandler.AppendWaitTimeline(state.mostRecentEvents[waitType].timelineIndex, type, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, waitType);
 }
 
 //------------------------------------------------------------------------------
@@ -1977,7 +1902,9 @@ NewFrame()
 {
     // We need to lock here so that we don't accidentally insert a delete resource inbetween updating
     // the current buffer index and deleting pending resources
-    Threading::CriticalScope scope(&delayedDeleteSection);
+    Threading::CriticalScope transferScope(&transferLock);
+    Threading::CriticalScope setupScope(&setupLock);
+    Threading::CriticalScope deleteScope(&delayedDeleteSection);
 
     // Progress to next frame and wait for that buffer
     state.currentBufferedFrameIndex = (state.currentBufferedFrameIndex + 1) % state.maxNumBufferedFrames;
@@ -1987,7 +1914,7 @@ NewFrame()
     auto& waitEventsThisFrame = state.waitEvents[state.currentBufferedFrameIndex];
     for (const auto& waitEvent : waitEventsThisFrame)
     {
-        state.queueHandler.Wait(Util::Get<0>(waitEvent), Util::Get<1>(waitEvent).timelineIndex);
+        state.queueHandler.Wait(waitEvent.queue, waitEvent.timelineIndex);
     }
     waitEventsThisFrame.Clear();
 

--- a/code/render/coregraphics/vk/vksubcontexthandler.h
+++ b/code/render/coregraphics/vk/vksubcontexthandler.h
@@ -73,7 +73,7 @@ public:
     void SetToNextContext(const CoreGraphics::QueueType type);
 
     /// append submission to context to execute later, supports waiting for a queue
-    uint64 AppendSubmissionTimeline(CoreGraphics::QueueType type, VkCommandBuffer cmds, bool semaphore = true);
+    uint64 AppendSubmissionTimeline(CoreGraphics::QueueType type, VkCommandBuffer cmds);
     /// Append a wait for a submission timeline index
     void AppendWaitTimeline(uint64 index, CoreGraphics::QueueType type, VkPipelineStageFlags waitFlags, CoreGraphics::QueueType waitType);
     /// append a sparse bind timeline operation

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -518,10 +518,26 @@ FrameScriptLoader::ParseFrameSubmission(const Ptr<Frame::FrameScript>& script, J
     {
         for (int i = 0; i < waitSubmissions->size; i++)
         {
-            Frame::FrameOp* dependence = script->GetOp(waitSubmissions->array_values[i]->string_value);
-            n_assert(dependence != nullptr);
-            submission->waitSubmissions.Append(static_cast<Frame::FrameSubmission*>(dependence));
+            Frame::FrameOp* dependency = script->GetOp(waitSubmissions->array_values[i]->string_value);
+            n_assert(dependency != nullptr);
+            submission->waitSubmissions.Append(static_cast<Frame::FrameSubmission*>(dependency));
         }
+    }
+
+    JzonValue* waitQueue = jzon_get(node, "wait_for_queue");
+    if (waitQueue != nullptr)
+    {
+        CoreGraphics::QueueType queue;
+        Util::String q(waitQueue->string_value);
+        if (q == "Graphics") queue = CoreGraphics::QueueType::GraphicsQueueType;
+        else if (q == "Compute") queue = CoreGraphics::QueueType::ComputeQueueType;
+        else if (q == "Transfer") queue = CoreGraphics::QueueType::TransferQueueType;
+        else if (q == "Sparse") queue = CoreGraphics::QueueType::SparseQueueType;
+        else
+        {
+            n_error("Unknown queue type '%s'\n", q.AsCharPtr());
+        }
+        submission->waitQueues.Append(queue);
     }
 
     JzonValue* ops = jzon_get(node, "ops");

--- a/code/render/frame/framesubmission.cc
+++ b/code/render/frame/framesubmission.cc
@@ -107,6 +107,9 @@ FrameSubmission::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const
     for (IndexT i = 0; i < this->waitSubmissions.Size(); i++)
         CoreGraphics::WaitForSubmission(this->waitSubmissions[i]->submissionId, this->queue, this->waitSubmissions[i]->queue);
 
+    for (IndexT i = 0; i < this->waitQueues.Size(); i++)
+        CoreGraphics::WaitForLastSubmission(this->queue, this->waitQueues[i]);
+
     // Delete command buffer
     CoreGraphics::DestroyCmdBuffer(submissionBuffer);
 }
@@ -133,6 +136,7 @@ FrameSubmission::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
     ret->compiled = {};
     ret->name = this->name;
     ret->queue = this->queue;
+    ret->waitQueues = this->waitQueues;
     ret->resourceResetBarriers = this->resourceResetBarriers;
     return ret;
 }

--- a/code/render/frame/framesubmission.h
+++ b/code/render/frame/framesubmission.h
@@ -30,6 +30,7 @@ public:
         void Discard() override;
 
         Util::Array<FrameSubmission::CompiledImpl*> waitSubmissions;
+        Util::Array<CoreGraphics::QueueType> waitQueues;
         CoreGraphics::CmdBufferPoolId commandBufferPool;
         CoreGraphics::QueueType queue;
         Util::Array<CoreGraphics::BarrierId>* resourceResetBarriers;
@@ -53,6 +54,7 @@ public:
         Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures);
 
     Util::Array<FrameSubmission*> waitSubmissions;
+    Util::Array<CoreGraphics::QueueType> waitQueues;
     CoreGraphics::CmdBufferPoolId commandBufferPool;
     CoreGraphics::QueueType queue;
     Util::Array<CoreGraphics::BarrierId>* resourceResetBarriers;

--- a/code/render/graphics/globalconstants.cc
+++ b/code/render/graphics/globalconstants.cc
@@ -103,19 +103,11 @@ AllocateGlobalConstants()
     ResourceTableSetConstantBuffer(state.frameResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::ShadowViewConstants::SLOT, 0, Shared::Table_Frame::ShadowViewConstants::SIZE, (SizeT)state.shadowViewCboOffset });
     ResourceTableCommitChanges(state.frameResourceTablesCompute[bufferedFrameIndex]);
 
-    // Set frame tables
-    CoreGraphics::SetFrameResourceTableGraphics(state.frameResourceTablesGraphics[bufferedFrameIndex]);
-    CoreGraphics::SetFrameResourceTableCompute(state.frameResourceTablesCompute[bufferedFrameIndex]);
-
     // Update tick resource tables
     ResourceTableSetConstantBuffer(state.tickResourceTablesGraphics[bufferedFrameIndex], { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Tick::PerTickParams::SLOT, 0, Shared::Table_Tick::PerTickParams::SIZE, (SizeT)state.tickCboOffset });
     ResourceTableCommitChanges(state.tickResourceTablesGraphics[bufferedFrameIndex]);
     ResourceTableSetConstantBuffer(state.tickResourceTablesCompute[bufferedFrameIndex], { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Tick::PerTickParams::SLOT, 0, Shared::Table_Tick::PerTickParams::SIZE, (SizeT)state.tickCboOffset });
     ResourceTableCommitChanges(state.tickResourceTablesCompute[bufferedFrameIndex]);
-
-    // Set tick tables
-    CoreGraphics::SetTickResourceTableGraphics(state.tickResourceTablesGraphics[bufferedFrameIndex]);
-    CoreGraphics::SetTickResourceTableCompute(state.tickResourceTablesCompute[bufferedFrameIndex]);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/graphics/view.h
+++ b/code/render/graphics/view.h
@@ -137,5 +137,4 @@ View::GetFrameScript() const
     return this->script;
 }
 
-
 } // namespace Graphics

--- a/work/frame/win32/vkdefault.json
+++ b/work/frame/win32/vkdefault.json
@@ -177,6 +177,7 @@
         "submission": {
             "name": "Compute Prepass",
             "queue": "Compute",
+            "wait_for_queue": "Graphics",
             "_comment": "Perform clustering AABB generation and run culling for clustering systems",
             "ops": {
                 "subgraph": {


### PR DESCRIPTION
Turns out, we don't wait on the compute queue for the graphics to finish. This causes the copy on the compute queue to stomp the memory used by the graphics queue in case we have a very high frame rate. 

Fixes #83 