### PR TITLE
Adding a few overloads to CmdBarrier

### DIFF
--- a/code/render/CMakeLists.txt
+++ b/code/render/CMakeLists.txt
@@ -121,6 +121,7 @@ ENDIF()
                 batchgroup.h
                 buffer.h
                 gpubuffertypes.h
+                commandbuffer.cc
                 commandbuffer.h
                 config.h
                 displaydevice.cc

--- a/code/render/coregraphics/commandbuffer.cc
+++ b/code/render/coregraphics/commandbuffer.cc
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+//  @file commandbuffer.cc
+//  @copyright (C) 2022 Individual contributors, see AUTHORS file
+//------------------------------------------------------------------------------
+#include "foundation/stdneb.h"
+#include "commandbuffer.h"
+#include "barrier.h"
+namespace CoreGraphics
+{
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+CoreGraphics::CmdBarrier(const CmdBufferId id
+                         , CoreGraphics::PipelineStage fromStage
+                         , CoreGraphics::PipelineStage toStage
+                         , CoreGraphics::BarrierDomain domain
+                         , const Util::FixedArray<TextureBarrierInfo>& textures
+                         , const IndexT fromQueue
+                         , const IndexT toQueue
+                         , const char* name)
+{
+    CmdBarrier(id, fromStage, toStage, domain, textures, nullptr, fromQueue, toQueue, name);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+CoreGraphics::CmdBarrier(const CmdBufferId id
+                         , CoreGraphics::PipelineStage fromStage
+                         , CoreGraphics::PipelineStage toStage
+                         , CoreGraphics::BarrierDomain domain
+                         , const Util::FixedArray<BufferBarrierInfo>& buffers
+                         , const IndexT fromQueue
+                         , const IndexT toQueue
+                         , const char* name)
+{
+    CmdBarrier(id, fromStage, toStage, domain, nullptr, buffers, fromQueue, toQueue, name);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+CoreGraphics::CmdBarrier(const CmdBufferId id
+                         , CoreGraphics::PipelineStage fromStage
+                         , CoreGraphics::PipelineStage toStage
+                         , CoreGraphics::BarrierDomain domain
+                         , const IndexT fromQueue
+                         , const IndexT toQueue
+                         , const char* name)
+{
+    CmdBarrier(id, fromStage, toStage, domain, nullptr, nullptr, fromQueue, toQueue, name);
+}
+
+} // namespace CoreGraphics

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -15,6 +15,7 @@
 #include "coregraphics/config.h"
 #include "math/rectangle.h"
 #include "coregraphics/indextype.h"
+
 namespace CoreGraphics
 {
 
@@ -180,12 +181,44 @@ void CmdSetGraphicsPipeline(const CmdBufferId id);
 
 /// Insert pipeline barrier
 void CmdBarrier(
+            const CmdBufferId id,
+            CoreGraphics::PipelineStage fromStage,
+            CoreGraphics::PipelineStage toStage,
+            CoreGraphics::BarrierDomain domain,
+            const IndexT fromQueue = InvalidIndex,
+            const IndexT toQueue = InvalidIndex,
+            const char* name = nullptr
+);
+/// Insert pipeline barrier
+void CmdBarrier(
+            const CmdBufferId id,
+            CoreGraphics::PipelineStage fromStage,
+            CoreGraphics::PipelineStage toStage,
+            CoreGraphics::BarrierDomain domain,
+            const Util::FixedArray<TextureBarrierInfo>& textures,
+            const IndexT fromQueue = InvalidIndex,
+            const IndexT toQueue = InvalidIndex,
+            const char* name = nullptr
+);
+/// Insert pipeline barrier
+void CmdBarrier(
+            const CmdBufferId id,
+            CoreGraphics::PipelineStage fromStage,
+            CoreGraphics::PipelineStage toStage,
+            CoreGraphics::BarrierDomain domain,
+            const Util::FixedArray<BufferBarrierInfo>& buffers,
+            const IndexT fromQueue = InvalidIndex,
+            const IndexT toQueue = InvalidIndex,
+            const char* name = nullptr
+);
+/// Insert pipeline barrier
+void CmdBarrier(
             const CmdBufferId id, 
             CoreGraphics::PipelineStage fromStage,
             CoreGraphics::PipelineStage toStage,
             CoreGraphics::BarrierDomain domain,
-            const Util::FixedArray<TextureBarrierInfo>& textures = nullptr,
-            const Util::FixedArray<BufferBarrierInfo>& buffers = nullptr,
+            const Util::FixedArray<TextureBarrierInfo>& textures,
+            const Util::FixedArray<BufferBarrierInfo>& buffers,
             const IndexT fromQueue = InvalidIndex,
             const IndexT toQueue = InvalidIndex,
             const char* name = nullptr


### PR DESCRIPTION
It's annoying to always have to specify nullptr for either buffer or texture barriers, since most barriers either block a single texture or buffer.