### PR TITLE
Use image bits for texture copies

### DIFF
--- a/code/render/coregraphics/barrier.h
+++ b/code/render/coregraphics/barrier.h
@@ -22,18 +22,18 @@ ID_24_8_TYPE(BarrierId);
 struct CmdBufferId;
 struct TextureSubresourceInfo
 {
-    CoreGraphics::ImageAspect aspect;
+    CoreGraphics::ImageBits aspect;
     uint mip, mipCount, layer, layerCount;
 
     TextureSubresourceInfo() :
-        aspect(CoreGraphics::ImageAspect::ColorBits),
+        aspect(CoreGraphics::ImageBits::ColorBits),
         mip(0),
         mipCount(1),
         layer(0),
         layerCount(1)
     {}
 
-    TextureSubresourceInfo(CoreGraphics::ImageAspect aspect, uint mip, uint mipCount, uint layer, uint layerCount) :
+    TextureSubresourceInfo(CoreGraphics::ImageBits aspect, uint mip, uint mipCount, uint layer, uint layerCount) :
         aspect(aspect),
         mip(mip),
         mipCount(mipCount),
@@ -43,32 +43,32 @@ struct TextureSubresourceInfo
 
     static TextureSubresourceInfo ColorNoMipNoLayer()
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, 1, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, 0, 1, 0, 1);
     }
 
     static TextureSubresourceInfo ColorNoMip(uint layerCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, 1, 0, layerCount);
+        return TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, 0, 1, 0, layerCount);
     }
 
     static TextureSubresourceInfo ColorNoLayer(uint mipCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, 0, mipCount, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, 0, mipCount, 0, 1);
     }
 
     static TextureSubresourceInfo DepthStencilNoMipNoLayer()
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, 1, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits, 0, 1, 0, 1);
     }
 
     static TextureSubresourceInfo DepthStencilNoMip(uint layerCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, 1, 0, layerCount);
+        return TextureSubresourceInfo(CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits, 0, 1, 0, layerCount);
     }
 
     static TextureSubresourceInfo DepthStencilNoLayer(uint mipCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits, 0, mipCount, 0, 1);
+        return TextureSubresourceInfo(CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits, 0, mipCount, 0, 1);
     }
 
     const bool Overlaps(const TextureSubresourceInfo& rhs) const
@@ -177,24 +177,24 @@ void BarrierRepeat(const CoreGraphics::CmdBufferId buf);
 //------------------------------------------------------------------------------
 /**
 */
-inline CoreGraphics::ImageAspect
+inline CoreGraphics::ImageBits
 ImageAspectFromString(const Util::String& str)
 {
     Util::Array<Util::String> comps = str.Tokenize("|");
-    CoreGraphics::ImageAspect aspect = CoreGraphics::ImageAspect(0x0);
+    CoreGraphics::ImageBits aspect = CoreGraphics::ImageBits(0x0);
     for (IndexT i = 0; i < comps.Size(); i++)
     {
-        if (comps[i] == "Color")            aspect |= CoreGraphics::ImageAspect::ColorBits;
-        else if (comps[i] == "Depth")       aspect |= CoreGraphics::ImageAspect::DepthBits;
-        else if (comps[i] == "Stencil")     aspect |= CoreGraphics::ImageAspect::StencilBits;
-        else if (comps[i] == "Metadata")    aspect |= CoreGraphics::ImageAspect::MetaBits;
-        else if (comps[i] == "Plane0")      aspect |= CoreGraphics::ImageAspect::Plane0Bits;
-        else if (comps[i] == "Plane1")      aspect |= CoreGraphics::ImageAspect::Plane1Bits;
-        else if (comps[i] == "Plane2")      aspect |= CoreGraphics::ImageAspect::Plane2Bits;
+        if (comps[i] == "Color")            aspect |= CoreGraphics::ImageBits::ColorBits;
+        else if (comps[i] == "Depth")       aspect |= CoreGraphics::ImageBits::DepthBits;
+        else if (comps[i] == "Stencil")     aspect |= CoreGraphics::ImageBits::StencilBits;
+        else if (comps[i] == "Metadata")    aspect |= CoreGraphics::ImageBits::MetaBits;
+        else if (comps[i] == "Plane0")      aspect |= CoreGraphics::ImageBits::Plane0Bits;
+        else if (comps[i] == "Plane1")      aspect |= CoreGraphics::ImageBits::Plane1Bits;
+        else if (comps[i] == "Plane2")      aspect |= CoreGraphics::ImageBits::Plane2Bits;
         else
         {
             n_error("Invalid access string '%s'\n", comps[i].AsCharPtr());
-            return CoreGraphics::ImageAspect::ColorBits;
+            return CoreGraphics::ImageBits::ColorBits;
         }
     }
     return aspect;

--- a/code/render/coregraphics/barrier.h
+++ b/code/render/coregraphics/barrier.h
@@ -178,7 +178,7 @@ void BarrierRepeat(const CoreGraphics::CmdBufferId buf);
 /**
 */
 inline CoreGraphics::ImageBits
-ImageAspectFromString(const Util::String& str)
+ImageBitsFromString(const Util::String& str)
 {
     Util::Array<Util::String> comps = str.Tokenize("|");
     CoreGraphics::ImageBits aspect = CoreGraphics::ImageBits(0x0);

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -65,6 +65,7 @@ struct TextureCopy
     Math::rectangle<SizeT> region;
     uint mip;
     uint layer;
+    ImageBits bits = ImageBits::ColorBits;
 };
 
 struct BufferCopy

--- a/code/render/coregraphics/config.h
+++ b/code/render/coregraphics/config.h
@@ -100,8 +100,9 @@ enum ShaderVisibility
 };
 __ImplementEnumBitOperators(CoreGraphics::ShaderVisibility);
 
-enum class ImageAspect
+enum class ImageBits
 {
+    Auto = 0,
     ColorBits = (1 << 0),
     DepthBits = (1 << 1),
     StencilBits = (1 << 2),
@@ -110,8 +111,8 @@ enum class ImageAspect
     Plane1Bits = (1 << 5),
     Plane2Bits = (1 << 6)
 };
-__ImplementEnumBitOperators(CoreGraphics::ImageAspect);
-__ImplementEnumComparisonOperators(CoreGraphics::ImageAspect);
+__ImplementEnumBitOperators(CoreGraphics::ImageBits);
+__ImplementEnumComparisonOperators(CoreGraphics::ImageBits);
 
 enum class ImageLayout
 {

--- a/code/render/coregraphics/texture.cc
+++ b/code/render/coregraphics/texture.cc
@@ -41,7 +41,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
         {
             {
                 id,
-                CoreGraphics::TextureSubresourceInfo{ ImageAspect::ColorBits, 0, (uint)numMips, 0, 1 },
+                CoreGraphics::TextureSubresourceInfo{ ImageBits::ColorBits, 0, (uint)numMips, 0, 1 },
             },
         });
 
@@ -78,7 +78,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             {
                 {
                     id,
-                    CoreGraphics::TextureSubresourceInfo{ CoreGraphics::ImageAspect::ColorBits, (uint)mip, 1, 0, 1 },
+                    CoreGraphics::TextureSubresourceInfo{ CoreGraphics::ImageBits::ColorBits, (uint)mip, 1, 0, 1 },
                 }
             },
             nullptr);
@@ -91,7 +91,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             {
                 {
                     id,
-                    CoreGraphics::TextureSubresourceInfo{ CoreGraphics::ImageAspect::ColorBits, (uint)mip + 1, 1, 0, 1 },
+                    CoreGraphics::TextureSubresourceInfo{ CoreGraphics::ImageBits::ColorBits, (uint)mip + 1, 1, 0, 1 },
                 }
             },
             nullptr);
@@ -111,7 +111,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             CoreGraphics::TextureBarrierInfo
             {
                 id,
-                CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, mip, 1, 0, 1),
+                CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, mip, 1, 0, 1),
             }
         },
         nullptr);

--- a/code/render/coregraphics/textureloader.cc
+++ b/code/render/coregraphics/textureloader.cc
@@ -95,7 +95,7 @@ TextureLoader::LoadFromStream(Ids::Id32 entry, const Util::StringAtom& tag, cons
         textureInfo.format = format;
         CoreGraphics::TextureId texture = CoreGraphics::CreateTexture(textureInfo);
 
-        CoreGraphics::TextureSubresourceInfo subres(CoreGraphics::ImageAspect::ColorBits, streamData->lowestLod, mipsToLoad, 0, textureInfo.layers);
+        CoreGraphics::TextureSubresourceInfo subres(CoreGraphics::ImageBits::ColorBits, streamData->lowestLod, mipsToLoad, 0, textureInfo.layers);
 
         // use resource submission
         CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockTransferSetupCommandBuffer();
@@ -231,7 +231,7 @@ TextureLoader::StreamMaxLOD(const Resources::ResourceId& id, const float lod, bo
     texture.resourceType = id.resourceType;
 
     const gliml::context& ctx = streamData->ctx;
-    CoreGraphics::TextureSubresourceInfo subres(CoreGraphics::ImageAspect::ColorBits, adjustedLod, streamData->lowestLod, 0, ctx.num_faces());
+    CoreGraphics::TextureSubresourceInfo subres(CoreGraphics::ImageBits::ColorBits, adjustedLod, streamData->lowestLod, 0, ctx.num_faces());
 
     // use resource submission
     CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockTransferSetupCommandBuffer();

--- a/code/render/coregraphics/textureview.h
+++ b/code/render/coregraphics/textureview.h
@@ -24,6 +24,7 @@ struct TextureViewCreateInfo
     IndexT startLayer = 0;
     SizeT numLayers = 1;
     PixelFormat::Code format = PixelFormat::InvalidPixelFormat;
+    ImageBits aspect = ImageBits::Auto;
     CoreGraphics::TextureSwizzle swizzle = { TextureChannelMapping::None, TextureChannelMapping::None, TextureChannelMapping::None, TextureChannelMapping::None };
 };
 

--- a/code/render/coregraphics/vk/vkbarrier.cc
+++ b/code/render/coregraphics/vk/vkbarrier.cc
@@ -67,7 +67,7 @@ CreateBarrier(const BarrierCreateInfo& info)
         vkInfo.imageBarriers[vkInfo.numImageBarriers].dstAccessMask = VkTypes::AsVkAccessFlags(info.toStage);
 
         const TextureSubresourceInfo& subres = info.textures[i].subres;
-        bool isDepth = (subres.aspect & CoreGraphics::ImageAspect::DepthBits) == CoreGraphics::ImageAspect::DepthBits;
+        bool isDepth = (subres.aspect & CoreGraphics::ImageBits::DepthBits) == CoreGraphics::ImageBits::DepthBits;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseMipLevel = subres.mip;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.levelCount = subres.mipCount;

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -610,7 +610,7 @@ CmdBarrier(
         vkBar.dstAccessMask = VkTypes::AsVkAccessFlags(toStage);
 
         const TextureSubresourceInfo& subres = nebBar.subres;
-        bool isDepth = (subres.aspect & CoreGraphics::ImageAspect::DepthBits) == 1;
+        bool isDepth = (subres.aspect & CoreGraphics::ImageBits::DepthBits) == 1;
         vkBar.subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
         vkBar.subresourceRange.baseMipLevel = subres.mip;
         vkBar.subresourceRange.levelCount = subres.mipCount;
@@ -848,17 +848,15 @@ CmdCopy(
     n_assert(from.Size() > 0);
     n_assert(from.Size() == to.Size());
 
-    bool isDepth = PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(fromTexture));
-    VkImageAspectFlags aspect = isDepth ? (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT) : VK_IMAGE_ASPECT_COLOR_BIT;
     Util::FixedArray<VkImageCopy> copies(from.Size());
     for (IndexT i = 0; i < copies.Size(); i++)
     {
         VkImageCopy& copy = copies[i];
         copy.dstOffset = { to[i].region.left, to[i].region.top, 0 };
-        copy.dstSubresource = { aspect, (uint32_t)to[i].mip, (uint32_t)to[i].layer, 1 };
+        copy.dstSubresource = { VkTypes::AsVkImageAspectFlags(to[i].bits), (uint32_t)to[i].mip, (uint32_t)to[i].layer, 1 };
         copy.extent = { (uint32_t)to[i].region.width(), (uint32_t)to[i].region.height(), 1 };
         copy.srcOffset = { from[i].region.left, from[i].region.top, 0 };
-        copy.srcSubresource = { aspect, (uint32_t)from[i].mip, (uint32_t)from[i].layer, 1 };
+        copy.srcSubresource = { VkTypes::AsVkImageAspectFlags(from[i].bits), (uint32_t)from[i].mip, (uint32_t)from[i].layer, 1 };
     }
 
     VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -362,7 +362,7 @@ SetupTexture(const TextureId id)
                         TextureBarrierInfo
                         {
                             id,
-                            CoreGraphics::TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
+                            CoreGraphics::TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
                         }
                     },
                     nullptr);
@@ -378,7 +378,7 @@ SetupTexture(const TextureId id)
                         TextureBarrierInfo
                         {
                             id,
-                            CoreGraphics::TextureSubresourceInfo(CoreGraphics::ImageAspect::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
+                            CoreGraphics::TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, viewRange.baseMipLevel, viewRange.levelCount, 0, viewRange.layerCount)
                         }
                     },
                     nullptr);
@@ -433,6 +433,7 @@ SetupTexture(const TextureId id)
             viewCreate.startLayer = 0;
             viewCreate.startMip = viewRange.baseMipLevel;
             viewCreate.tex = id;
+            viewCreate.aspect = ImageBits::StencilBits;
             TextureViewId stencilView = CreateTextureView(viewCreate);
 
             loadInfo.stencilExtension = textureStencilExtensionAllocator.Alloc();
@@ -444,7 +445,7 @@ SetupTexture(const TextureId id)
         CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockGraphicsSetupCommandBuffer();
 
         CoreGraphics::TextureSubresourceInfo subres(
-            isDepthFormat ? CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits : CoreGraphics::ImageAspect::ColorBits
+            isDepthFormat ? CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits : CoreGraphics::ImageBits::ColorBits
             , viewRange.baseMipLevel
             , viewRange.levelCount
             , viewRange.baseArrayLayer
@@ -537,7 +538,7 @@ SetupTexture(const TextureId id)
             {
                 __Lock(textureStencilExtensionAllocator, Util::ArrayAllocatorAccess::Write);
                 IndexT& bind = textureStencilExtensionAllocator.Get<TextureExtension_StencilBind>(loadInfo.stencilExtension);
-                bind = Graphics::RegisterTexture(id, runtimeInfo.type, true, true);
+                bind = Graphics::RegisterTexture(id, runtimeInfo.type, false, true);
             }
         }
         else

--- a/code/render/coregraphics/vk/vktextureview.cc
+++ b/code/render/coregraphics/vk/vktextureview.cc
@@ -63,7 +63,10 @@ CreateTextureView(const TextureViewCreateInfo& info)
 
     bool isDepthFormat = VkTypes::IsDepthFormat(info.format);
     VkImageSubresourceRange viewRange;
-    viewRange.aspectMask = isDepthFormat ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT; // view only supports reading depth in shader
+    if (info.aspect == ImageBits::Auto)
+        viewRange.aspectMask = isDepthFormat ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT; // view only supports reading depth in shader
+    else
+        viewRange.aspectMask = VkTypes::AsVkImageAspectFlags(info.aspect);
     viewRange.baseMipLevel = info.startMip;
     viewRange.levelCount = info.numMips;
     viewRange.baseArrayLayer = info.startLayer;

--- a/code/render/coregraphics/vk/vktypes.cc
+++ b/code/render/coregraphics/vk/vktypes.cc
@@ -437,33 +437,33 @@ VkTypes::AsNebulaPixelFormat(VkFormat f)
 /**
 */
 VkImageAspectFlags
-VkTypes::AsVkImageAspectFlags(const CoreGraphics::ImageAspect aspect)
+VkTypes::AsVkImageAspectFlags(const CoreGraphics::ImageBits aspect)
 {
     VkImageAspectFlags flags = 0;
     uint32_t bit;
     for (bit = 1; aspect >= bit; bit *= 2)
     {
-        if ((aspect & bit) == bit) switch ((CoreGraphics::ImageAspect)bit)
+        if ((aspect & bit) == bit) switch ((CoreGraphics::ImageBits)bit)
         {
-        case CoreGraphics::ImageAspect::ColorBits:
+        case CoreGraphics::ImageBits::ColorBits:
             flags |= VK_IMAGE_ASPECT_COLOR_BIT;
             break;
-        case CoreGraphics::ImageAspect::DepthBits:
+        case CoreGraphics::ImageBits::DepthBits:
             flags |= VK_IMAGE_ASPECT_DEPTH_BIT;
             break;
-        case CoreGraphics::ImageAspect::StencilBits:
+        case CoreGraphics::ImageBits::StencilBits:
             flags |= VK_IMAGE_ASPECT_STENCIL_BIT;
             break;
-        case CoreGraphics::ImageAspect::MetaBits:
+        case CoreGraphics::ImageBits::MetaBits:
             flags |= VK_IMAGE_ASPECT_METADATA_BIT;
             break;
-        case CoreGraphics::ImageAspect::Plane0Bits:
+        case CoreGraphics::ImageBits::Plane0Bits:
             flags |= VK_IMAGE_ASPECT_PLANE_0_BIT;
             break;
-        case CoreGraphics::ImageAspect::Plane1Bits:
+        case CoreGraphics::ImageBits::Plane1Bits:
             flags |= VK_IMAGE_ASPECT_PLANE_1_BIT;
             break;
-        case CoreGraphics::ImageAspect::Plane2Bits:
+        case CoreGraphics::ImageBits::Plane2Bits:
             flags |= VK_IMAGE_ASPECT_PLANE_2_BIT;
             break;
         }

--- a/code/render/coregraphics/vk/vktypes.h
+++ b/code/render/coregraphics/vk/vktypes.h
@@ -69,7 +69,7 @@ public:
     /// convert vulkan format back to nebula format
     static CoreGraphics::PixelFormat::Code AsNebulaPixelFormat(VkFormat f);
     /// convert image aspects to Vulkan
-    static VkImageAspectFlags AsVkImageAspectFlags(const CoreGraphics::ImageAspect aspect);
+    static VkImageAspectFlags AsVkImageAspectFlags(const CoreGraphics::ImageBits aspect);
     /// convert shader visibility to vulkan
     static VkShaderStageFlags AsVkShaderVisibility(const CoreGraphics::ShaderVisibility vis);
     /// convert image layout to vulkan

--- a/code/render/frame/framecopy.cc
+++ b/code/render/frame/framecopy.cc
@@ -38,6 +38,8 @@ FrameCopy::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
     ret->name = this->name;
 #endif
 
+    ret->fromBits = this->fromBits;
+    ret->toBits = this->toBits;
     ret->from = this->from;
     ret->to = this->to;
     return ret;
@@ -54,16 +56,8 @@ FrameCopy::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const Index
     CoreGraphics::TextureDimensions toDims = TextureGetDimensions(this->to);
 
     // setup regions
-    Math::rectangle<SizeT> fromRegion;
-    fromRegion.left = 0;
-    fromRegion.top = 0;
-    fromRegion.right = fromDims.width;
-    fromRegion.bottom = fromDims.height;
-    Math::rectangle<SizeT> toRegion;
-    toRegion.left = 0;
-    toRegion.top = 0;
-    toRegion.right = toDims.width;
-    toRegion.bottom = toDims.height;
+    Math::rectangle<SizeT> fromRegion(0, 0, fromDims.width, fromDims.height);
+    Math::rectangle<SizeT> toRegion(0, 0, toDims.width, toDims.height);
 
     N_CMD_SCOPE(cmdBuf, NEBULA_MARKER_TRANSFER, this->name.Value());
 
@@ -71,11 +65,12 @@ FrameCopy::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const Index
     from.region = fromRegion;
     from.mip = 0;
     from.layer = 0;
+    from.bits = this->fromBits;
     to.region = toRegion;
     to.mip = 0;
     to.layer = 0;
+    to.bits = this->toBits;
     CoreGraphics::CmdCopy(cmdBuf, this->from, { from }, this->to, { to });
-
 }
 
 } // namespace Frame2

--- a/code/render/frame/framecopy.h
+++ b/code/render/frame/framecopy.h
@@ -26,11 +26,13 @@ public:
         Util::StringAtom name;
 #endif
 
+        CoreGraphics::ImageBits fromBits, toBits;
         CoreGraphics::TextureId from, to;
     };
 
     FrameOp::Compiled* AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator);
 
+    CoreGraphics::ImageBits fromBits, toBits;
     CoreGraphics::TextureId from, to;
 };
 

--- a/code/render/frame/framescript.cc
+++ b/code/render/frame/framescript.cc
@@ -211,7 +211,7 @@ FrameScript::Build()
         uint mips = CoreGraphics::TextureGetNumMips(tex);
 
         CoreGraphics::TextureSubresourceInfo subres;
-        subres.aspect = isDepth ? (CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits) : CoreGraphics::ImageAspect::ColorBits;
+        subres.aspect = isDepth ? (CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits) : CoreGraphics::ImageBits::ColorBits;
         subres.layer = 0;
         subres.layerCount = layers;
         subres.mip = 0;

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -1236,7 +1236,7 @@ FrameScriptLoader::ParseResourceDependencies(const Ptr<Frame::FrameScript>& scri
             JzonValue* nd = nullptr;
 
             TextureId tex = script->texturesByName[valstr];
-            if ((nd = jzon_get(dep, "aspect")) != nullptr) subres.aspect = ImageAspectFromString(nd->string_value);
+            if ((nd = jzon_get(dep, "aspect")) != nullptr) subres.aspect = ImageBitsFromString(nd->string_value);
             else
             {
                 bool isDepth = PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(tex));

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -262,7 +262,7 @@ FrameScriptLoader::ParseBlit(const Ptr<Frame::FrameScript>& script, JzonValue* n
 
     // add implicit barriers
     TextureSubresourceInfo subres;
-    subres.aspect = isDepth ? CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits : CoreGraphics::ImageAspect::ColorBits;
+    subres.aspect = isDepth ? CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits : CoreGraphics::ImageBits::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
     subres.mip = 0;
@@ -297,25 +297,46 @@ FrameScriptLoader::ParseCopy(const Ptr<Frame::FrameScript>& script, JzonValue* n
 
     JzonValue* from = jzon_get(node, "from");
     n_assert(from != nullptr);
-    const CoreGraphics::TextureId& fromTex = script->GetTexture(from->string_value);
 
     JzonValue* to = jzon_get(node, "to");
     n_assert(to != nullptr);
-    const CoreGraphics::TextureId& toTex = script->GetTexture(to->string_value);
 
-    bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(fromTex));
+    CoreGraphics::TextureId fromTex, toTex;
+    CoreGraphics::ImageBits fromBits = CoreGraphics::ImageBits::Auto, toBits = CoreGraphics::ImageBits::Auto;
+
+    JzonValue* from_tex = jzon_get(from, "tex");
+    n_assert(from_tex != nullptr);
+    fromTex = script->GetTexture(from_tex->string_value);
+
+    JzonValue* from_bits = jzon_get(from, "bits");
+    if (from_bits != nullptr)
+        fromBits = ImageAspectFromString(from_bits->string_value);
+
+    JzonValue* to_tex = jzon_get(to, "tex");
+    n_assert(to_tex != nullptr);
+    toTex = script->GetTexture(to_tex->string_value);
+
+    JzonValue* to_bits = jzon_get(to, "bits");
+    if (to_bits != nullptr)
+        toBits = ImageAspectFromString(to_bits->string_value);
 
     // add implicit barriers
-    TextureSubresourceInfo subres;
-    subres.aspect = isDepth ? (CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits) : CoreGraphics::ImageAspect::ColorBits;
-    subres.layer = 0;
-    subres.layerCount = 1;
-    subres.mip = 0;
-    subres.mipCount = 1;
-    op->textureDeps.Add(fromTex, Util::MakeTuple(from->string_value, CoreGraphics::PipelineStage::TransferRead, subres));
-    op->textureDeps.Add(toTex, Util::MakeTuple(to->string_value, CoreGraphics::PipelineStage::TransferWrite, subres));
+    TextureSubresourceInfo subresFrom, subresTo;
+    subresFrom.aspect = fromBits;
+    subresFrom.layer = 0;
+    subresFrom.layerCount = 1;
+    subresFrom.mip = 0;
+    subresFrom.mipCount = 1;
+
+    subresTo = subresFrom;
+    subresTo.aspect = toBits;
+
+    op->textureDeps.Add(fromTex, Util::MakeTuple(from->string_value, CoreGraphics::PipelineStage::TransferRead, subresFrom));
+    op->textureDeps.Add(toTex, Util::MakeTuple(to->string_value, CoreGraphics::PipelineStage::TransferWrite, subresTo));
 
     // setup copy operation
+    op->fromBits = fromBits;
+    op->toBits = toBits;
     op->from = fromTex;
     op->to = toTex;
     return op;
@@ -347,7 +368,7 @@ FrameScriptLoader::ParseMipmap(const Ptr<Frame::FrameScript>& script, JzonValue*
 
     // add implicit barriers
     TextureSubresourceInfo subres;
-    subres.aspect = isDepth ? (CoreGraphics::ImageAspect::DepthBits | CoreGraphics::ImageAspect::StencilBits) : CoreGraphics::ImageAspect::ColorBits;
+    subres.aspect = isDepth ? (CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits) : CoreGraphics::ImageBits::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
     subres.mip = 0;
@@ -685,7 +706,7 @@ FrameScriptLoader::ParsePass(const Ptr<Frame::FrameScript>& script, JzonValue* n
     }
 
     TextureSubresourceInfo subres;
-    subres.aspect = CoreGraphics::ImageAspect::ColorBits;
+    subres.aspect = CoreGraphics::ImageBits::ColorBits;
     subres.layer = 0;
     subres.layerCount = 1;
     subres.mip = 0;
@@ -695,7 +716,7 @@ FrameScriptLoader::ParsePass(const Ptr<Frame::FrameScript>& script, JzonValue* n
         op->textureDeps.Add(TextureViewGetTexture(info.colorAttachments[i]), Util::MakeTuple(attachmentNames[i], CoreGraphics::PipelineStage::ColorWrite, subres));
     }
 
-    subres.aspect = CoreGraphics::ImageAspect::StencilBits | CoreGraphics::ImageAspect::DepthBits;
+    subres.aspect = CoreGraphics::ImageBits::StencilBits | CoreGraphics::ImageBits::DepthBits;
     if (info.depthStencilAttachment != InvalidTextureViewId)
     {
         op->textureDeps.Add(TextureViewGetTexture(info.depthStencilAttachment), Util::MakeTuple(dsName, CoreGraphics::PipelineStage::DepthStencilWrite, subres));
@@ -1219,7 +1240,7 @@ FrameScriptLoader::ParseResourceDependencies(const Ptr<Frame::FrameScript>& scri
             else
             {
                 bool isDepth = PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(tex));
-                subres.aspect = isDepth ? (ImageAspect::DepthBits | ImageAspect::StencilBits) : ImageAspect::ColorBits;
+                subres.aspect = isDepth ? (ImageBits::DepthBits | ImageBits::StencilBits) : ImageBits::ColorBits;
             }
             if ((nd = jzon_get(dep, "mip")) != nullptr) subres.mip = nd->int_value;
             if ((nd = jzon_get(dep, "mip_count")) != nullptr) subres.mipCount = nd->int_value;

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -310,7 +310,7 @@ FrameScriptLoader::ParseCopy(const Ptr<Frame::FrameScript>& script, JzonValue* n
 
     JzonValue* from_bits = jzon_get(from, "bits");
     if (from_bits != nullptr)
-        fromBits = ImageAspectFromString(from_bits->string_value);
+        fromBits = ImageBitsFromString(from_bits->string_value);
 
     JzonValue* to_tex = jzon_get(to, "tex");
     n_assert(to_tex != nullptr);
@@ -318,7 +318,7 @@ FrameScriptLoader::ParseCopy(const Ptr<Frame::FrameScript>& script, JzonValue* n
 
     JzonValue* to_bits = jzon_get(to, "bits");
     if (to_bits != nullptr)
-        toBits = ImageAspectFromString(to_bits->string_value);
+        toBits = ImageBitsFromString(to_bits->string_value);
 
     // add implicit barriers
     TextureSubresourceInfo subresFrom, subresTo;

--- a/code/render/graphics/globalconstants.cc
+++ b/code/render/graphics/globalconstants.cc
@@ -151,35 +151,86 @@ FlushUpdates(const CoreGraphics::CmdBufferId buf, const CoreGraphics::QueueType 
         case CoreGraphics::QueueType::GraphicsQueueType:
             if (state.tickParamsDirty.graphicsDirty)
             {
-                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetGraphicsConstantBuffer(), state.tickCboOffset, sizeof(Shared::PerTickParams), &state.tickParams);
-                //state.tickParamsDirty.graphicsDirty = false;
+                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetGraphicsConstantBuffer(), state.tickCboOffset, sizeof(state.tickParams), &state.tickParams);
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::PipelineStage::AllShadersRead, CoreGraphics::BarrierDomain::Global,
+                {
+                    {
+                        CoreGraphics::GetGraphicsConstantBuffer(),
+                        CoreGraphics::BufferSubresourceInfo(state.tickCboOffset, sizeof(state.tickParams))
+                        
+                    }
+                });
+                state.tickParamsDirty.graphicsDirty = false;
             }
             if (state.viewConstantsDirty.graphicsDirty)
             {
-                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetGraphicsConstantBuffer(), state.viewCboOffset, sizeof(Shared::ViewConstants), &state.viewConstants);
-                //state.viewConstantsDirty.graphicsDirty = false;
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::AllShadersRead, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::BarrierDomain::Global,
+                {
+                    {
+                        CoreGraphics::GetGraphicsConstantBuffer(),
+                        CoreGraphics::BufferSubresourceInfo(state.viewCboOffset, sizeof(state.viewConstants))
+                    }
+                });
+                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetGraphicsConstantBuffer(), state.viewCboOffset, sizeof(state.viewConstants), &state.viewConstants);
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::PipelineStage::AllShadersRead, CoreGraphics::BarrierDomain::Global,
+                {
+                    {
+                        CoreGraphics::GetGraphicsConstantBuffer(),
+                        CoreGraphics::BufferSubresourceInfo(state.viewCboOffset, sizeof(state.viewConstants))
+                    }
+                });
+                state.viewConstantsDirty.graphicsDirty = false;
             }
             if (state.shadowViewConstantsDirty.graphicsDirty)
             {
-                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetGraphicsConstantBuffer(), state.shadowViewCboOffset, sizeof(Shared::ShadowViewConstants), &state.shadowViewConstants);
-                //state.shadowViewConstantsDirty.graphicsDirty = false;
+                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetGraphicsConstantBuffer(), state.shadowViewCboOffset, sizeof(state.shadowViewConstants), &state.shadowViewConstants);
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::PipelineStage::AllShadersRead, CoreGraphics::BarrierDomain::Global,
+                {
+                    {
+                        CoreGraphics::GetGraphicsConstantBuffer(),
+                        CoreGraphics::BufferSubresourceInfo(state.shadowViewCboOffset, sizeof(state.shadowViewConstants))
+                    }
+                });
+                state.shadowViewConstantsDirty.graphicsDirty = false;
             }
             break;
         case CoreGraphics::QueueType::ComputeQueueType:
             if (state.tickParamsDirty.computeDirty)
             {
-                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetComputeConstantBuffer(), state.tickCboOffset, sizeof(Shared::PerTickParams), &state.tickParams);
-                //state.tickParamsDirty.computeDirty = false;
+                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetComputeConstantBuffer(), state.tickCboOffset, sizeof(state.tickParams), &state.tickParams);
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::PipelineStage::ComputeShaderRead, CoreGraphics::BarrierDomain::Global,
+                         {
+                             {
+                                 CoreGraphics::GetComputeConstantBuffer(),
+                                 CoreGraphics::BufferSubresourceInfo(state.tickCboOffset, sizeof(state.tickParams))
+
+                             }
+                         });
+                state.tickParamsDirty.computeDirty = false;
             }
             if (state.viewConstantsDirty.computeDirty)
             {
-                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetComputeConstantBuffer(), state.viewCboOffset, sizeof(Shared::ViewConstants), &state.viewConstants);
-                //state.viewConstantsDirty.computeDirty = false;
+                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetComputeConstantBuffer(), state.viewCboOffset, sizeof(state.viewConstants), &state.viewConstants);
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::PipelineStage::ComputeShaderRead, CoreGraphics::BarrierDomain::Global,
+                        {
+                            {
+                                CoreGraphics::GetComputeConstantBuffer(),
+                                CoreGraphics::BufferSubresourceInfo(state.viewCboOffset, sizeof(state.viewConstants))
+                            }
+                        });
+                state.viewConstantsDirty.computeDirty = false;
             }
             if (state.shadowViewConstantsDirty.computeDirty)
             {
-                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetComputeConstantBuffer(), state.shadowViewCboOffset, sizeof(Shared::ShadowViewConstants), &state.shadowViewConstants);
-                //state.shadowViewConstantsDirty.computeDirty = false;
+                CoreGraphics::CmdUpdateBuffer(buf, CoreGraphics::GetComputeConstantBuffer(), state.shadowViewCboOffset, sizeof(state.shadowViewConstants), &state.shadowViewConstants);
+                CoreGraphics::CmdBarrier(buf, CoreGraphics::PipelineStage::TransferWrite, CoreGraphics::PipelineStage::ComputeShaderRead, CoreGraphics::BarrierDomain::Global,
+                        {
+                            {
+                                CoreGraphics::GetComputeConstantBuffer(),
+                                CoreGraphics::BufferSubresourceInfo(state.tickCboOffset, sizeof(state.shadowViewConstants))
+                            }
+                        });
+                state.shadowViewConstantsDirty.computeDirty = false;
             }
             break;
     }

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -629,13 +629,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                                 {
                                     "Indirection Texture",
                                     CoreGraphics::PipelineStage::TransferWrite,
-                                    CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
+                                    CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
                                 });
     terrainPrepare->textureDeps.Add(terrainVirtualTileState.indirectionTextureCopy,
                                 {
                                     "Indirection Texture Copy",
                                     CoreGraphics::PipelineStage::TransferRead,
-                                    CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
+                                    CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
                                 });
     terrainPrepare->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -753,13 +753,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Indirection Texture",
                                 CoreGraphics::PipelineStage::TransferRead,
-                                CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
+                                CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
                             });
     indirectionCopy->textureDeps.Add(terrainVirtualTileState.indirectionTextureCopy,
                             {
                                 "Indirection Texture Copy",
                                 CoreGraphics::PipelineStage::TransferWrite,
-                                CoreGraphics::TextureSubresourceInfo(ImageAspect::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
+                                CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
                             });
     indirectionCopy->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {


### PR DESCRIPTION
Texture copies need to specify the image bits, but it can also be set to auto which will pick the color bits for typical textures, or depth for depth/depth-stencil textures. To copy stencil, one would need to specify that set of bits in the copy. 

This PR also renames ImageAspect (which is a very Vulkan-centric name) to ImageBits, which describes it a bit more generically. 