### PR TITLE
Add resolve to frame script and pass

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -276,12 +276,11 @@ UltralightRenderer::CreateRenderBuffer(uint32_t render_buffer_id, const ultralig
 
     CoreGraphics::PassCreateInfo passInfo;
     passInfo.name = Util::String::Sprintf("Ultralight Pass %d", render_buffer_id);
-    passInfo.colorAttachments.Append(texView);
-    passInfo.colorAttachmentClears.Append(Math::vec4(0));
-    passInfo.colorAttachmentFlags.Append(CoreGraphics::AttachmentFlagBits::Clear | CoreGraphics::AttachmentFlagBits::Store);
-    passInfo.depthStencilFlags = CoreGraphics::AttachmentFlagBits::NoFlags;
+    passInfo.attachments.Append(texView);
+    passInfo.attachmentClears.Append(Math::vec4(0));
+    passInfo.attachmentFlags.Append(CoreGraphics::AttachmentFlagBits::Clear | CoreGraphics::AttachmentFlagBits::Store);
+    passInfo.attachmentDepthStencil.Append(false);
     CoreGraphics::Subpass subpass;
-    subpass.bindDepth = false;
     subpass.attachments.Append(0);
     subpass.numScissors = 1;
     subpass.numViewports = 1;

--- a/code/foundation/core/debug.h
+++ b/code/foundation/core/debug.h
@@ -35,6 +35,7 @@ void n_break();
 #if __NEBULA_NO_ASSERT__
 #define n_assert(exp) if(!(exp)){}
 #define n_assert2(exp, msg) if(!(exp)){}
+#define n_assert_msg(exp, msg) n_assert2(exp, msg)
 #define n_assert_fmt(exp, msg, ...) if(!(exp)){}
 #define n_verify(exp) (exp)
 #define n_verify2(exp,imsg) (exp)
@@ -48,6 +49,7 @@ void n_break();
 #else
 #define n_assert(exp) { if (!(exp)) n_barf(#exp, __FILE__, __LINE__); }
 #define n_assert2(exp, msg) { if (!(exp)) n_barf2(#exp, msg, __FILE__, __LINE__); }
+#define n_assert_msg(exp, msg) n_assert2(exp, msg)
 #define n_assert_fmt(exp, msg, ...) { if (!(exp)) n_barf_fmt(#exp, msg, __FILE__, __LINE__, __VA_ARGS__); }
 #define n_warn(exp) { if (!(exp)) n_cough(#exp, __FILE__, __LINE__); }
 #define n_warn2(exp, msg) { if (!(exp)) n_cough2(#exp, msg, __FILE__, __LINE__); }

--- a/code/render/CMakeLists.txt
+++ b/code/render/CMakeLists.txt
@@ -350,6 +350,8 @@ ENDIF()
                 framecompute.h
                 frameplugin.cc
                 frameplugin.h
+                frameresolve.cc
+                frameresolve.h
                 framecopy.cc
                 framecopy.h
                 #frameevent.cc

--- a/code/render/coregraphics/pass.h
+++ b/code/render/coregraphics/pass.h
@@ -38,37 +38,29 @@ __ImplementEnumComparisonOperators(AttachmentFlagBits);
 struct Subpass
 {
     Util::Array<IndexT> attachments;
+    Util::Array<IndexT> resolves;
     Util::Array<IndexT> dependencies;
     Util::Array<IndexT> inputs;
+    IndexT depthResolve;
+    IndexT depth;
     SizeT numViewports;
     SizeT numScissors;
-    bool bindDepth : 1;
-    bool resolve : 1;
 
-    Subpass() : bindDepth(false), resolve(false), numViewports(0), numScissors(0) {};
+    Subpass() : depthResolve(InvalidIndex), depth(InvalidIndex), numViewports(0), numScissors(0) {};
 };
 
 struct PassCreateInfo
 {
     Util::StringAtom name;
 
-    Util::Array<CoreGraphics::TextureViewId> colorAttachments;
-    Util::Array<AttachmentFlagBits> colorAttachmentFlags; 
-    Util::Array<Math::vec4> colorAttachmentClears;
+    Util::Array<CoreGraphics::TextureViewId> attachments;
+    Util::Array<AttachmentFlagBits> attachmentFlags; 
+    Util::Array<Math::vec4> attachmentClears;
+    Util::Array<bool> attachmentDepthStencil;
     
-    CoreGraphics::TextureViewId depthStencilAttachment;
-    AttachmentFlagBits depthStencilFlags;
-    float clearDepth;
-    uint clearStencil;
-
     Util::Array<Subpass> subpasses;
 
-    PassCreateInfo()
-        : depthStencilAttachment(CoreGraphics::InvalidTextureViewId)
-        , clearDepth(1.0f)
-        , clearStencil(0)
-        , depthStencilFlags(AttachmentFlagBits::NoFlags)
-    {};
+    PassCreateInfo() {};
 };
 
 enum class PassRecordMode : uint8
@@ -88,8 +80,6 @@ void PassWindowResizeCallback(const PassId id);
 
 /// get number of color attachments for entire pass (attachment list)
 const Util::Array<CoreGraphics::TextureViewId>& PassGetAttachments(const CoreGraphics::PassId id);
-/// get depth stencil attachment
-const CoreGraphics::TextureViewId PassGetDepthStencilAttachment(const CoreGraphics::PassId id);
 
 /// get number of color attachments for a subpass
 const uint32_t PassGetNumSubpassAttachments(const CoreGraphics::PassId id, const IndexT subpass);

--- a/code/render/coregraphics/resourcetable.h
+++ b/code/render/coregraphics/resourcetable.h
@@ -254,6 +254,16 @@ struct ResourceTableBuffer
         , offset(0)
     {};
 
+    ResourceTableBuffer(const CoreGraphics::BufferId buf, IndexT slot, SizeT size, SizeT offset)
+        : buf(buf)
+        , slot(slot)
+        , index(0)
+        , texelBuffer(false)
+        , dynamicOffset(false)
+        , size(size)
+        , offset(offset)
+    {};
+
     ResourceTableBuffer(const CoreGraphics::BufferId buf, IndexT slot, SizeT index, SizeT size, SizeT offset, bool texelBuffer = false, bool dynamicOffset = false)
         : buf(buf)
         , slot(slot)

--- a/code/render/coregraphics/texture.h
+++ b/code/render/coregraphics/texture.h
@@ -64,6 +64,11 @@ __ImplementEnumBitOperators(CoreGraphics::TextureUsage);
 struct TextureDimensions
 {
     SizeT width, height, depth;
+
+    bool operator==(const TextureDimensions& dims)
+    {
+        return this->width == dims.width && this->height == dims.height && this->depth == dims.depth;
+    }
 };
 
 struct TextureRelativeDimensions

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -194,6 +194,11 @@ CreateCmdBuffer(const CmdBufferCreateInfo& info)
     pipelineBundle.pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
     pipelineBundle.pipelineInfo.basePipelineIndex = 0;
 
+    pipelineBundle.multisampleInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    pipelineBundle.multisampleInfo.pNext = nullptr;
+    pipelineBundle.multisampleInfo.flags = 0;
+    pipelineBundle.multisampleInfo.pSampleMask = nullptr;
+
     pipelineBundle.computeLayout = VK_NULL_HANDLE;
     pipelineBundle.graphicsLayout = VK_NULL_HANDLE;
 
@@ -427,12 +432,18 @@ CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pr
         pipelineBundle.blendInfo.logicOp = info.colorBlendInfo.logicOp;
         pipelineBundle.blendInfo.logicOpEnable = info.colorBlendInfo.logicOpEnable;
         pipelineBundle.blendInfo.pAttachments = info.colorBlendAttachments;
-        memcpy(pipelineBundle.blendInfo.blendConstants, info.colorBlendInfo.blendConstants, sizeof(float) * 4);
+        memcpy(pipelineBundle.blendInfo.blendConstants, info.colorBlendInfo.blendConstants, sizeof(info.colorBlendInfo.blendConstants));
+
+        pipelineBundle.multisampleInfo.alphaToCoverageEnable = info.multisampleInfo.alphaToCoverageEnable;
+        pipelineBundle.multisampleInfo.alphaToOneEnable = info.multisampleInfo.alphaToOneEnable;
+        pipelineBundle.multisampleInfo.minSampleShading = info.multisampleInfo.minSampleShading;
+        pipelineBundle.multisampleInfo.sampleShadingEnable = info.multisampleInfo.sampleShadingEnable;
+        pipelineBundle.multisampleInfo.pSampleMask = info.multisampleInfo.pSampleMask;
 
         // Setup states (excluding pass)
         pipelineBundle.pipelineInfo.pDepthStencilState = &info.depthStencilInfo;
         pipelineBundle.pipelineInfo.pRasterizationState = &info.rasterizerInfo;
-        pipelineBundle.pipelineInfo.pMultisampleState = &info.multisampleInfo;
+        pipelineBundle.pipelineInfo.pMultisampleState = &pipelineBundle.multisampleInfo;
         pipelineBundle.pipelineInfo.pDynamicState = &info.dynamicInfo;
         pipelineBundle.pipelineInfo.pTessellationState = &info.tessInfo;
 
@@ -734,6 +745,7 @@ CmdBeginPass(const CmdBufferId id, const PassId pass)
     CmdSetScissors(id, scissors);
 
     pipelineBundle.pass = pass;
+    pipelineBundle.multisampleInfo.rasterizationSamples = framebufferInfo.pMultisampleState->rasterizationSamples;
     pipelineBundle.pipelineInfo.subpass = 0;
     pipelineBundle.pipelineInfo.renderPass = framebufferInfo.renderPass;
     pipelineBundle.pipelineInfo.pViewportState = framebufferInfo.pViewportState;

--- a/code/render/coregraphics/vk/vkcommandbuffer.h
+++ b/code/render/coregraphics/vk/vkcommandbuffer.h
@@ -76,6 +76,7 @@ struct VkPipelineBundle
 {
     VkGraphicsPipelineCreateInfo pipelineInfo;
     VkPipelineColorBlendStateCreateInfo blendInfo;
+    VkPipelineMultisampleStateCreateInfo multisampleInfo;
     CoreGraphics::InputAssemblyKey inputAssembly;
     VkPipelineLayout computeLayout;
     VkPipelineLayout graphicsLayout;

--- a/code/render/coregraphics/vk/vkpass.h
+++ b/code/render/coregraphics/vk/vkpass.h
@@ -25,12 +25,11 @@ struct VkPassLoadInfo
     IndexT renderTargetDimensionsVar;
 
     // we need these stored for resizing
-    Util::Array<CoreGraphics::TextureViewId> colorAttachments;
-    Util::Array<Math::vec4> colorAttachmentClears;
-    CoreGraphics::TextureViewId depthStencilAttachment;
-    Util::Array<CoreGraphics::AttachmentFlagBits> colorAttachmentFlags;
+    Util::Array<CoreGraphics::TextureViewId> attachments;
+    Util::Array<Math::vec4> attachmentClears;
+    Util::Array<CoreGraphics::AttachmentFlagBits> attachmentFlags;
+    Util::Array<bool> attachmentIsDepthStencil;
     Util::Array<CoreGraphics::Subpass> subpasses;
-    CoreGraphics::AttachmentFlagBits depthStencilFlags;
 
     // we store these so we retain the data for when we need to bind it
     VkRect2D renderArea;
@@ -44,6 +43,7 @@ struct VkPassLoadInfo
 struct VkPassRuntimeInfo
 {
     VkGraphicsPipelineCreateInfo framebufferPipelineInfo;
+    VkPipelineMultisampleStateCreateInfo multisampleInfo;
     VkPipelineViewportStateCreateInfo viewportInfo;
 
     uint32_t currentSubpassIndex;

--- a/code/render/coregraphics/vk/vktypes.cc
+++ b/code/render/coregraphics/vk/vktypes.cc
@@ -672,13 +672,19 @@ VkTypes::AsVkImageLayout(const CoreGraphics::PipelineStage stage, bool depthSten
         case CoreGraphics::PipelineStage::PixelShaderRead:
         case CoreGraphics::PipelineStage::GraphicsShadersRead:
         case CoreGraphics::PipelineStage::ComputeShaderRead:
+        case CoreGraphics::PipelineStage::ColorRead:
+        case CoreGraphics::PipelineStage::DepthStencilRead:
         case CoreGraphics::PipelineStage::AllShadersRead:
+            if (depthStencil)
+                return VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
+            else
+                return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         case CoreGraphics::PipelineStage::ColorWrite:           // The image layout from a pass is read on finished
         case CoreGraphics::PipelineStage::DepthStencilWrite:    // The image layout from a pass is read on finished
             if (depthStencil)
-                return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+                return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
             else
-                return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         case CoreGraphics::PipelineStage::VertexShaderWrite:
         case CoreGraphics::PipelineStage::HullShaderWrite:
         case CoreGraphics::PipelineStage::DomainShaderWrite:
@@ -688,10 +694,6 @@ VkTypes::AsVkImageLayout(const CoreGraphics::PipelineStage stage, bool depthSten
         case CoreGraphics::PipelineStage::ComputeShaderWrite:
         case CoreGraphics::PipelineStage::AllShadersWrite:
             return VK_IMAGE_LAYOUT_GENERAL;
-        case CoreGraphics::PipelineStage::ColorRead:
-            return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        case CoreGraphics::PipelineStage::DepthStencilRead:
-            return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
         case CoreGraphics::PipelineStage::TransferRead:
             return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         case CoreGraphics::PipelineStage::TransferWrite:

--- a/code/render/frame/frameop.cc
+++ b/code/render/frame/frameop.cc
@@ -469,6 +469,15 @@ FrameOp::Compiled::Discard()
 /**
 */
 void
+FrameOp::Compiled::SetupConstants(const IndexT bufferIndex)
+{
+    // Do nothing, the script is responsible for setting up constants if needed
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
 FrameOp::Compiled::QueuePreSync(const CoreGraphics::CmdBufferId cmdBuf)
 {
     for (const CoreGraphics::BarrierId barrier : this->barriers)

--- a/code/render/frame/frameop.h
+++ b/code/render/frame/frameop.h
@@ -81,6 +81,9 @@ protected:
         /// Discard operation
         virtual void Discard();
 
+        /// Setup constants
+        virtual void SetupConstants(const IndexT bufferIndex);
+
         /// Perform synchronization prior to execution of operation
         virtual void QueuePreSync(const CoreGraphics::CmdBufferId cmdBuf);
 

--- a/code/render/frame/frameresolve.cc
+++ b/code/render/frame/frameresolve.cc
@@ -1,0 +1,136 @@
+//------------------------------------------------------------------------------
+//  @file frameresolve.cc
+//  @copyright (C) 2022 Individual contributors, see AUTHORS file
+//------------------------------------------------------------------------------
+#include "foundation/stdneb.h"
+#include "frameresolve.h"
+#include "coregraphics/graphicsdevice.h"
+#include "coregraphics/texture.h"
+
+
+using namespace CoreGraphics;
+namespace Frame
+{
+
+//------------------------------------------------------------------------------
+/**
+*/
+FrameResolve::FrameResolve()
+{
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+FrameResolve::~FrameResolve()
+{
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+FrameOp::Compiled*
+FrameResolve::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
+{
+    CompiledImpl* ret = allocator.Alloc<CompiledImpl>();
+
+    PixelFormat::Code fmtSource = TextureGetPixelFormat(this->from);
+    PixelFormat::Code fmtDest = TextureGetPixelFormat(this->to);
+    //n_assert(fmtSource == fmtDest);
+    bool isDepth = PixelFormat::IsDepthFormat(fmtSource);
+
+    if (isDepth)
+    {
+        TextureDimensions dimsSource = TextureGetDimensions(this->from);
+        TextureDimensions dimsDest = TextureGetDimensions(this->to);
+        n_assert(dimsSource == dimsDest);
+
+        uint samples = TextureGetNumSamples(this->from);
+
+        auto shaderName = Util::String::Sprintf("shd:msaaresolvedepth%d.fxb", samples);
+        ShaderId shader = ShaderGet(shaderName);
+        ShaderProgramId program = ShaderGetProgram(shader, ShaderFeatureFromString("Resolve"));
+
+        ret->dispatchDims.x = Math::divandroundup(dimsSource.width, 64);
+        ret->dispatchDims.y = dimsSource.height;
+        ret->program = program;
+        ret->shaderResolve = true;
+
+        ret->constants.resolveSource = TextureGetBindlessHandle(this->from);
+        ret->constants.width = dimsSource.width;
+
+        ret->resourceTables.Resize(GetNumBufferedFrames());
+        for (IndexT i = 0; i < ret->resourceTables.Size(); i++)
+        {
+            ret->resourceTables[i] = ShaderCreateResourceTable(shader, NEBULA_BATCH_GROUP);
+            ResourceTableSetRWTexture(ret->resourceTables[i], { this->to, Msaaresolvedepth4::Table_Batch::resolve_SLOT, true, true });
+            ResourceTableCommitChanges(ret->resourceTables[i]);
+        }
+    }
+    else
+    {
+        ret->shaderResolve = false;
+    }
+#if NEBULA_GRAPHICS_DEBUG
+    ret->name = this->name;
+#endif
+
+    ret->toBits = this->toBits;
+    ret->fromBits = this->fromBits;
+    ret->from = this->from;
+    ret->to = this->to;
+    return ret;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+FrameResolve::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const IndexT frameIndex, const IndexT bufferIndex)
+{
+
+    if (this->shaderResolve)
+    {
+        N_CMD_SCOPE(cmdBuf, NEBULA_MARKER_COMPUTE, this->name.Value());
+
+        CmdSetShaderProgram(cmdBuf, this->program);
+        CmdSetResourceTable(cmdBuf, this->resourceTables[bufferIndex], NEBULA_BATCH_GROUP, CoreGraphics::ComputePipeline, nullptr);
+        CmdDispatch(cmdBuf, this->dispatchDims.x, this->dispatchDims.y, 1);
+    }
+    else
+    {
+        N_CMD_SCOPE(cmdBuf, NEBULA_MARKER_TRANSFER, this->name.Value());
+
+        TextureDimensions fromDims = TextureGetDimensions(this->from);
+        TextureDimensions toDims = TextureGetDimensions(this->to);
+        CoreGraphics::TextureCopy from, to;
+        from.region.set(0, 0, fromDims.width, fromDims.height);
+        from.mip = 0;
+        from.layer = 0;
+        from.bits = this->fromBits;
+        to.region.set(0, 0, toDims.width, toDims.height);
+        to.mip = 0;
+        to.layer = 0;
+        to.bits = this->toBits;
+        CmdResolve(cmdBuf, this->from, from, this->to, to);
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+FrameResolve::CompiledImpl::SetupConstants(const IndexT bufferIndex)
+{
+    uint offset = SetConstants(this->constants);
+    ResourceTableSetConstantBuffer(this->resourceTables[bufferIndex],
+                                   {
+                                       CoreGraphics::GetGraphicsConstantBuffer()
+                                       , Msaaresolvedepth4::Table_Batch::ResolveBlock::SLOT
+                                       , Msaaresolvedepth4::Table_Batch::ResolveBlock::SIZE
+                                       , (SizeT)offset
+                                   });
+    ResourceTableCommitChanges(this->resourceTables[bufferIndex]);
+}
+
+} // namespace Frame

--- a/code/render/frame/frameresolve.h
+++ b/code/render/frame/frameresolve.h
@@ -1,0 +1,56 @@
+#pragma once
+//------------------------------------------------------------------------------
+/**
+    Resolve pass
+
+    @copyright
+    (C) 2022 Individual contributors, see AUTHORS file
+*/
+//------------------------------------------------------------------------------
+#include "frameop.h"
+#include "coregraphics/shader.h"
+#include "msaaresolvedepth4.h"
+
+namespace Frame
+{
+
+class FrameResolve : public FrameOp
+{
+public:
+
+    /// Constructor
+    FrameResolve();
+    /// Destructor
+    ~FrameResolve();
+
+    struct CompiledImpl : public FrameOp::Compiled
+    {
+
+        /// Run the resolve
+        void Run(const CoreGraphics::CmdBufferId cmdBuf, const IndexT frameIndex, const IndexT bufferIndex) override;
+
+        /// Run the constant setup
+        void SetupConstants(const IndexT bufferIndex) override;
+
+#if NEBULA_GRAPHICS_DEBUG
+        Util::StringAtom name;
+#endif
+
+        CoreGraphics::ImageBits fromBits, toBits;
+        CoreGraphics::TextureId from, to;
+
+        Msaaresolvedepth4::ResolveBlock constants;
+        bool shaderResolve;
+        Math::uint2 dispatchDims;
+        CoreGraphics::ShaderProgramId program;
+
+        Util::FixedArray<CoreGraphics::ResourceTableId> resourceTables;
+    };
+
+    FrameOp::Compiled* AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator);
+
+    CoreGraphics::ImageBits fromBits, toBits;
+    CoreGraphics::TextureId from, to;
+};
+
+} // namespace Frame

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -698,7 +698,7 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         AttachmentFlagBits flags = AttachmentFlagBits::NoFlags;
         if (clear != nullptr)
         {
-            n_assert_fmt(!isDepth, "Format is depth-stencil, use clear_depth and/or clear_stencil");
+            n_assert_msg(!isDepth, "Format is depth-stencil, use clear_depth and/or clear_stencil");
             Math::vec4 clearValue;
             n_assert(clear->size <= 4);
             uint j;
@@ -715,8 +715,8 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         JzonValue* clearDepth = jzon_get(cur, "clear_depth");
         if (clearDepth != nullptr)
         {
-            n_assert_fmt(isDepth, "Format is not depth-stencil");
-            n_assert_fmt(clear == nullptr, "Attachments with 'clear_depth' must not also have 'clear'\n");
+            n_assert_msg(isDepth, "Format is not depth-stencil");
+            n_assert_msg(clear == nullptr, "Attachments with 'clear_depth' must not also have 'clear'\n");
             pass.attachmentClears.Back().x = clearDepth->float_value;
             flags |= AttachmentFlagBits::Clear;
         }
@@ -724,8 +724,8 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         JzonValue* clearStencil = jzon_get(cur, "clear_stencil");
         if (clearStencil != nullptr)
         {
-            n_assert_fmt(isDepth, "Format is not depth-stencil");
-            n_assert_fmt(clear == nullptr, "Attachments with 'clear_stencil' must not also have 'clear'\n");
+            n_assert_msg(isDepth, "Format is not depth-stencil");
+            n_assert_msg(clear == nullptr, "Attachments with 'clear_stencil' must not also have 'clear'\n");
             pass.attachmentClears.Back().y = clearStencil->int_value;
             flags |= AttachmentFlagBits::ClearStencil;
         }
@@ -741,7 +741,7 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         JzonValue* storeStencil = jzon_get(cur, "store_stencil");
         if (storeStencil && storeStencil->bool_value)
         {
-            n_assert_fmt(isDepth, "Format is not depth-stencil");
+            n_assert_msg(isDepth, "Format is not depth-stencil");
             flags |= AttachmentFlagBits::StoreStencil;
         }
 
@@ -749,7 +749,7 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         if (load && load->bool_value)
         {
             // we can't really load and clear
-            n_assert_fmt(clear == nullptr, "Can't load color/depth if value is also being cleared.");
+            n_assert_msg(clear == nullptr, "Can't load color/depth if value is also being cleared.");
             flags |= AttachmentFlagBits::Load;
         }
 
@@ -757,8 +757,8 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         if (loadStencil && loadStencil->bool_value)
         {
             // we can't really load and clear
-            n_assert_fmt(isDepth, "Format is not depth-stencil");
-            n_assert_fmt(clear == nullptr, "Can't load stencil if value is also being cleared.");
+            n_assert_msg(isDepth, "Format is not depth-stencil");
+            n_assert_msg(clear == nullptr, "Can't load stencil if value is also being cleared.");
             flags |= AttachmentFlagBits::LoadStencil;
         }
 

--- a/code/render/frame/framescriptloader.h
+++ b/code/render/frame/framescriptloader.h
@@ -58,6 +58,10 @@ private:
     static void ParseSubpassDependencies(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, JzonValue* node);
     /// parse subpass dependencies
     static void ParseSubpassAttachments(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
+    /// parse subpass depth attachment
+    static void ParseSubpassDepthAttachment(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
+    /// parse subpass dependencies
+    static void ParseSubpassResolves(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
     /// parse subpass inputs
     static void ParseSubpassInputs(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
     /// parse subpass algorithm
@@ -70,6 +74,9 @@ private:
     static void ParseSubpassSortedBatch(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
     /// parse subpass post effect
     static void ParseSubpassFullscreenEffect(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
+
+    /// Parse resolve
+    static FrameOp* ParseResolve(const Ptr<Frame::FrameScript>& script, JzonValue* node);
 
     /// helper to parse shader state
     static void ParseShaderState(const Ptr<Frame::FrameScript>& script, JzonValue* node, CoreGraphics::ShaderId& shd, CoreGraphics::ResourceTableId& table, Util::Dictionary<Util::StringAtom, CoreGraphics::BufferId>& constantBuffers, Util::Array<Util::Tuple<IndexT, CoreGraphics::BufferId, CoreGraphics::TextureId>>& textures);

--- a/code/render/frame/framesubmission.cc
+++ b/code/render/frame/framesubmission.cc
@@ -68,6 +68,15 @@ FrameSubmission::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const
     CoreGraphics::CmdBeginRecord(submissionBuffer, beginInfo);
     CoreGraphics::CmdBeginMarker(submissionBuffer, NEBULA_MARKER_PURPLE, this->name.Value());
 
+    // Setup any constants required by the ops
+    for (IndexT i = 0; i < this->compiled.Size(); i++)
+    {
+        this->compiled[i]->SetupConstants(bufferIndex);
+    }
+
+    // No more constant updates from this point
+    CoreGraphics::LockConstantUpdates();
+
     // First thing, flush all constant updates
     CoreGraphics::FlushConstants(submissionBuffer, this->queue);
     CoreGraphics::FlushUpload();
@@ -112,6 +121,9 @@ FrameSubmission::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const
 
     // Delete command buffer
     CoreGraphics::DestroyCmdBuffer(submissionBuffer);
+
+    // Open up for constant updates after waiting
+    CoreGraphics::UnlockConstantUpdates();
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/graphics/graphicsserver.cc
+++ b/code/render/graphics/graphicsserver.cc
@@ -68,7 +68,7 @@ GraphicsServer::Open()
         },
         0x10000, 0x100000, 0x100,   // Number of queries
         3,                          // Number of simultaneous frames (3 = triple buffering, 2 = ... you get the idea)
-        false                       // Validation
+        true                       // Validation
     };
     this->graphicsDevice = CoreGraphics::CreateGraphicsDevice(gfxInfo);
 
@@ -516,9 +516,6 @@ GraphicsServer::Render()
     N_SCOPE(RenderViews, Graphics);
     IndexT i;
 
-    // No more constant updates from this point
-    CoreGraphics::LockConstantUpdates();
-
     // Go through views and call before view
     for (i = 0; i < this->views.Size(); i++)
     {
@@ -551,9 +548,6 @@ GraphicsServer::NewFrame()
 {
     // Wait and get new frame
     CoreGraphics::NewFrame();
-
-    // Open up for constant updates after waiting
-    CoreGraphics::UnlockConstantUpdates();
 }
 
 } // namespace Graphics

--- a/code/render/posteffects/bloomcontext.cc
+++ b/code/render/posteffects/bloomcontext.cc
@@ -100,7 +100,6 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
     // Create subpass
     CoreGraphics::Subpass subpass;
     subpass.attachments.Append(0);
-    subpass.bindDepth = false;
     subpass.numScissors = 1;
     subpass.numViewports = 1;
 
@@ -108,9 +107,10 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
     CoreGraphics::PassCreateInfo passInfo;
     passInfo.name = "Bloom Pass";
     bloomState.bloomBufferView = CoreGraphics::CreateTextureView({ "Bloom Pass View", bloomState.bloomBuffer, 0, 1, 0, 1, TextureGetPixelFormat(bloomState.bloomBuffer) });
-    passInfo.colorAttachments.Append(bloomState.bloomBufferView);
-    passInfo.colorAttachmentFlags.Append(CoreGraphics::AttachmentFlagBits::Store);
-    passInfo.colorAttachmentClears.Append(Math::vec4(1)); // dummy value
+    passInfo.attachments.Append(bloomState.bloomBufferView);
+    passInfo.attachmentFlags.Append(CoreGraphics::AttachmentFlagBits::Store);
+    passInfo.attachmentClears.Append(Math::vec4(1)); // dummy value
+    passInfo.attachmentDepthStencil.Append(false);
     passInfo.subpasses.Append(subpass);
     bloomState.bloomPass = CoreGraphics::CreatePass(passInfo);
 

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -582,16 +582,16 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     // create pass for updating the physical cache tiles
     CoreGraphics::PassCreateInfo tileUpdatePassCreate;
     tileUpdatePassCreate.name = "TerrainVirtualTileUpdate";
-    tileUpdatePassCreate.colorAttachments.Append(CreateTextureView({ "Terrain Albedo Cache View", terrainVirtualTileState.physicalAlbedoCache, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.physicalAlbedoCache) }));
-    tileUpdatePassCreate.colorAttachments.Append(CreateTextureView({ "Terrain Normal Cache View", terrainVirtualTileState.physicalNormalCache, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.physicalNormalCache) }));
-    tileUpdatePassCreate.colorAttachments.Append(CreateTextureView({ "Terrain Material Cache View", terrainVirtualTileState.physicalMaterialCache, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.physicalMaterialCache) }));
+    tileUpdatePassCreate.attachments.Append(CreateTextureView({ "Terrain Albedo Cache View", terrainVirtualTileState.physicalAlbedoCache, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.physicalAlbedoCache) }));
+    tileUpdatePassCreate.attachments.Append(CreateTextureView({ "Terrain Normal Cache View", terrainVirtualTileState.physicalNormalCache, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.physicalNormalCache) }));
+    tileUpdatePassCreate.attachments.Append(CreateTextureView({ "Terrain Material Cache View", terrainVirtualTileState.physicalMaterialCache, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.physicalMaterialCache) }));
     AttachmentFlagBits bits = AttachmentFlagBits::Load | AttachmentFlagBits::Store;
-    tileUpdatePassCreate.colorAttachmentFlags.AppendArray({ bits, bits, bits });
-    tileUpdatePassCreate.colorAttachmentClears.AppendArray({ Math::vec4(0,0,0,0), Math::vec4(0,0,0,0), Math::vec4(0,0,0,0) });
+    tileUpdatePassCreate.attachmentFlags.AppendArray({ bits, bits, bits });
+    tileUpdatePassCreate.attachmentDepthStencil.Append(false);
+    tileUpdatePassCreate.attachmentClears.AppendArray({ Math::vec4(0,0,0,0), Math::vec4(0,0,0,0), Math::vec4(0,0,0,0) });
     
     CoreGraphics::Subpass subpass;
     subpass.attachments.AppendArray({ 0, 1, 2 });
-    subpass.bindDepth = false;
     subpass.numScissors = 3;
     subpass.numViewports = 3;
 
@@ -601,12 +601,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
     // create pass for updating the fallback textures
     CoreGraphics::PassCreateInfo lowresUpdatePassCreate;
     lowresUpdatePassCreate.name = "TerrainVirtualLowresUpdate";
-    lowresUpdatePassCreate.colorAttachments.Append(CreateTextureView({ "Terrain Lowres Albedo Cache View", terrainVirtualTileState.lowresAlbedo, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.lowresAlbedo) }));
-    lowresUpdatePassCreate.colorAttachments.Append(CreateTextureView({ "Terrain Lowres Normal Cache View", terrainVirtualTileState.lowresNormal, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.lowresNormal) }));
-    lowresUpdatePassCreate.colorAttachments.Append(CreateTextureView({ "Terrain Lowres Material Cache View", terrainVirtualTileState.lowresMaterial, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.lowresMaterial) }));
+    lowresUpdatePassCreate.attachments.Append(CreateTextureView({ "Terrain Lowres Albedo Cache View", terrainVirtualTileState.lowresAlbedo, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.lowresAlbedo) }));
+    lowresUpdatePassCreate.attachments.Append(CreateTextureView({ "Terrain Lowres Normal Cache View", terrainVirtualTileState.lowresNormal, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.lowresNormal) }));
+    lowresUpdatePassCreate.attachments.Append(CreateTextureView({ "Terrain Lowres Material Cache View", terrainVirtualTileState.lowresMaterial, 0, 1, 0, 1, TextureGetPixelFormat(terrainVirtualTileState.lowresMaterial) }));
     bits = AttachmentFlagBits::Store;
-    lowresUpdatePassCreate.colorAttachmentFlags.AppendArray({ bits, bits, bits });
-    lowresUpdatePassCreate.colorAttachmentClears.AppendArray({ Math::vec4(0,0,0,0), Math::vec4(0,0,0,0), Math::vec4(0,0,0,0) });
+    lowresUpdatePassCreate.attachmentFlags.AppendArray({ bits, bits, bits });
+    lowresUpdatePassCreate.attachmentDepthStencil.AppendArray({ false, false, false });
+    lowresUpdatePassCreate.attachmentClears.AppendArray({ Math::vec4(0,0,0,0), Math::vec4(0,0,0,0), Math::vec4(0,0,0,0) });
 
     lowresUpdatePassCreate.subpasses.Append(subpass);
     terrainVirtualTileState.tileFallbackPass = CoreGraphics::CreatePass(lowresUpdatePassCreate);

--- a/work/frame/win32/vkdefault.json
+++ b/work/frame/win32/vkdefault.json
@@ -223,16 +223,18 @@
             "ops": {
                 "pass": {
                     "name": "Sun Shadows Pass",
-                    "depth_stencil": {
-                        "name": "SunShadowDepth",
-                        "clear": 1,
-                        "store": true
-                    },
+                    "attachments": [
+                        {
+                            "name": "SunShadowDepth",
+                            "clear_depth": 1,
+                            "store": true
+                        }
+                    ],
 
                     "subpass": {
                         "name": "Sun Shadows",
                         "subpass_dependencies": [],
-                        "depth": true,
+                        "depth": "SunShadowDepth",
                         "subgraph": {
                             "name": "Sun Shadows"
                         }
@@ -252,7 +254,6 @@
                         "name": "Spotlight Shadows",
                         "subpass_dependencies": [],
                         "attachments": [ "LocalLightShadow" ],
-                        "depth": false,
                         "subgraph": {
                             "name": "Spotlight Shadows"
                         }
@@ -295,20 +296,19 @@
                             "name": "TerrainPosBuffer",
                             "clear": [ 0, 0, 0, 255 ],
                             "store": true
+                        },
+                        {
+                            "name": "ZBuffer",
+                            "clear_depth": 1,
+                            "store": true
                         }
                     ],
-
-                    "depth_stencil": {
-                        "name": "ZBuffer",
-                        "clear": 1,
-                        "store": true
-                    },
 
                     "subpass": {
                         "name": "TerrainPass",
                         "subpass_dependencies": [],
                         "attachments": [ "TerrainPosBuffer" ],
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "subgraph": {
                             "name": "Terrain Prepass"
                         }
@@ -322,17 +322,19 @@
                 "pass": {
                     "name": "Prepass",
 
-                    "depth_stencil": {
-                        "name": "ZBuffer",
-                        "store": true,
-                        "load": true
-                    },
+                    "attachments": [
+                        {
+                            "name": "ZBuffer",
+                            "store": true,
+                            "load": true
+                        }
+                    ],
 
                     "subpass": {
                         "name": "DepthPrepass",
                         "subpass_dependencies": [],
                         "attachments": [],
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "batch": "FlatGeometryDepth",
                         "subgraph": {
                             name: "Vegetation Prepass"
@@ -342,8 +344,14 @@
 
                 "copy": {
                     "name": "Copy Depth",
-                    "from": "ZBuffer",
-                    "to": "ZBufferCopy"
+                    "from": {
+                        "tex": "ZBuffer",
+                        "bits": "Depth|Stencil"
+                    },
+                    "to": {
+                        "tex": "ZBufferCopy",
+                        "bits": "Depth|Stencil"
+                    }
                 }
             }
         },
@@ -372,20 +380,19 @@
                             "name": "SpecularBuffer",
                             "store": true,
                             "clear": [ 0, 0, 0, 0 ]
+                        },
+                        {
+                            "name": "ZBuffer",
+                            "store": true,
+                            "load": true
                         }
                     ],
-
-                    "depth_stencil": {
-                        "name": "ZBuffer",
-                        "store": true,
-                        "load": true
-                    },
 
                     "subpass": {
                         "name": "OpaquePass",
                         "subpass_dependencies": [],
                         "attachments": [ "LightBuffer" ],
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "subgraph": {
                             "name": "Terrain Resolve"
                         },
@@ -398,7 +405,7 @@
                         "name": "Skypass",
                         "subpass_dependencies": [ "OpaquePass" ],
                         "attachments": [ "LightBuffer" ],
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "batch": "Background"
                     },
                     "subpass": {
@@ -406,7 +413,7 @@
                         "name": "AlphaPass",
                         "subpass_dependencies": [ "Skypass" ],
                         "attachments": [ "LightBuffer" ],
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "batch": "FlatGeometryAlphaLit"
                     }
                 },
@@ -449,14 +456,13 @@
                             "name": "ColorBuffer",
                             "load": true,
                             "store": true
+                        },
+                        {
+                            "name": "ZBuffer",
+                            "store": false,
+                            "load": true
                         }
                     ],
-
-                    "depth_stencil": {
-                        "name": "ZBuffer",
-                        "store": false,
-                        "load": true
-                    },
 
                     "subpass": {
                         "name": "FinalizePass",
@@ -464,7 +470,7 @@
                         "attachments": [
                             "ColorBuffer"
                         ],
-                        "depth": false,
+                        "depth": "ZBuffer",
 
                         "resource_dependencies": [
                             {
@@ -517,7 +523,7 @@
                         "subpass_dependencies": [
                             "FinalizePass"
                         ],
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "attachments": [
                             "ColorBuffer"
                         ],
@@ -554,18 +560,17 @@
                             "name": "ColorBuffer",
                             "load": true,
                             "store": true
+                        },
+                        {
+                            "name": "ZBuffer",
+                            "store": false,
+                            "load": true
                         }
                     ],
 
-                    "depth_stencil": {
-                        "name": "ZBuffer",
-                        "store": false,
-                        "load": true
-                    },
-
                     "subpass": {
                         "name": "DynUI",
-                        "depth": true,
+                        "depth": "ZBuffer",
                         "attachments": [
                             "ColorBuffer"
                         ],


### PR DESCRIPTION
Refactored the pass a bit to be simpler to understand. Added frame script support for defining a resolve from MSAA to ordinary render target. Changed how depth is bound, several depth attachments can be used for a single pass, but every subpass must directly reference it.

So for passes, the way we usually did it was this:
```json
"depth_stencil": {
    "name": "ZBuffer",
    "clear": 1,
    "store": true
},

...

"subpass": {
    "depth": true
}
```

Is now:

```json
"attachments": [
...
{
    "name": "ZBuffer",
    "clear_depth": 1,
    "store": true
}],

...

"subpass": {
    "depth": "ZBuffer"
}
```

Note how attachments which **may** be used as depth-stencil must be in the general attachments list, and clear_depth must be used instead of the old depth. Because we now support multiple depth-stencil attachments, we must specify which one we might use in the subpass. 

Resolves work by providing a parallel list to the attachments, and resolving each attachment to the resolve on the corresponding slot:

```json
    "subpass": {
        ...
        "attachments": [
            "AlbedoBuffer", "SpecularBuffer", "MaterialsBuffer"
        ],
        "resolve": [
            "AlbedoResolve", "SpecularResolve"
        ],
    }
```

This would resolve AlbedoBuffer -> AlbedoResolve and SpecularBuffer -> SpecularResolve but would not resolve MaterialsBuffer. If another combination is needed, the attachment order and the resolve order needs to be adjusted to account for it. 

Resolving depth has to be done with a new frame script op.

```json
"resolve": {
    "from": {
        "tex": "ZBuffer",
        "bits": "Depth"
    },
    "to": {
        "tex": "Depth",
        "bits": "Color"
    }
}
```

This would resolve the ZBuffer with the Depth bits into a color buffer (named Depth) with the color bits. In the backend, this will actually run a compute shader since average resolving a depth buffer doesn't really make a ton of sense. Copy has also changed to use the same syntax of texture and bits:

```json
"copy": {
    "from": {
        "tex": "ZBuffer",
        "bits": "Depth"
    },
    "to": {
        "tex": "Depth",
        "bits": "Color"
    }
}
```

Meaning the resolve and copy APIs are identical, however a copy won't be able to copy from an MSAA source. 