### PR TITLE
Refactor frame script and add schema

### DIFF
--- a/code/render/coregraphics/barrier.h
+++ b/code/render/coregraphics/barrier.h
@@ -22,19 +22,19 @@ ID_24_8_TYPE(BarrierId);
 struct CmdBufferId;
 struct TextureSubresourceInfo
 {
-    CoreGraphics::ImageBits aspect;
+    CoreGraphics::ImageBits bits;
     uint mip, mipCount, layer, layerCount;
 
     TextureSubresourceInfo() :
-        aspect(CoreGraphics::ImageBits::ColorBits),
+        bits(CoreGraphics::ImageBits::ColorBits),
         mip(0),
         mipCount(1),
         layer(0),
         layerCount(1)
     {}
 
-    TextureSubresourceInfo(CoreGraphics::ImageBits aspect, uint mip, uint mipCount, uint layer, uint layerCount) :
-        aspect(aspect),
+    TextureSubresourceInfo(CoreGraphics::ImageBits bits, uint mip, uint mipCount, uint layer, uint layerCount) :
+        bits(bits),
         mip(mip),
         mipCount(mipCount),
         layer(layer),
@@ -73,7 +73,7 @@ struct TextureSubresourceInfo
 
     const bool Overlaps(const TextureSubresourceInfo& rhs) const
     {
-        return ((this->aspect & rhs.aspect) != 0) && (this->mip <= rhs.mip && this->mip + this->mipCount >= rhs.mip) && (this->layer <= rhs.layer && this->layer + this->layerCount >= rhs.layer);
+        return ((this->bits & rhs.bits) != 0) && (this->mip <= rhs.mip && this->mip + this->mipCount >= rhs.mip) && (this->layer <= rhs.layer && this->layer + this->layerCount >= rhs.layer);
     }
 };
 
@@ -181,23 +181,25 @@ inline CoreGraphics::ImageBits
 ImageBitsFromString(const Util::String& str)
 {
     Util::Array<Util::String> comps = str.Tokenize("|");
-    CoreGraphics::ImageBits aspect = CoreGraphics::ImageBits(0x0);
+    CoreGraphics::ImageBits bits = CoreGraphics::ImageBits(0x0);
     for (IndexT i = 0; i < comps.Size(); i++)
     {
-        if (comps[i] == "Color")            aspect |= CoreGraphics::ImageBits::ColorBits;
-        else if (comps[i] == "Depth")       aspect |= CoreGraphics::ImageBits::DepthBits;
-        else if (comps[i] == "Stencil")     aspect |= CoreGraphics::ImageBits::StencilBits;
-        else if (comps[i] == "Metadata")    aspect |= CoreGraphics::ImageBits::MetaBits;
-        else if (comps[i] == "Plane0")      aspect |= CoreGraphics::ImageBits::Plane0Bits;
-        else if (comps[i] == "Plane1")      aspect |= CoreGraphics::ImageBits::Plane1Bits;
-        else if (comps[i] == "Plane2")      aspect |= CoreGraphics::ImageBits::Plane2Bits;
+        if (comps[i] == "Auto")             { bits = CoreGraphics::ImageBits::Auto; break; }
+        else if (comps[i] == "Color")       bits |= CoreGraphics::ImageBits::ColorBits;
+        else if (comps[i] == "Depth")       bits |= CoreGraphics::ImageBits::DepthBits;
+        else if (comps[i] == "Stencil")     bits |= CoreGraphics::ImageBits::StencilBits;
+        else if (comps[i] == "Metadata")    bits |= CoreGraphics::ImageBits::MetaBits;
+        else if (comps[i] == "Plane0")      bits |= CoreGraphics::ImageBits::Plane0Bits;
+        else if (comps[i] == "Plane1")      bits |= CoreGraphics::ImageBits::Plane1Bits;
+        else if (comps[i] == "Plane2")      bits |= CoreGraphics::ImageBits::Plane2Bits;
+        
         else
         {
             n_error("Invalid access string '%s'\n", comps[i].AsCharPtr());
             return CoreGraphics::ImageBits::ColorBits;
         }
     }
-    return aspect;
+    return bits;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -298,10 +298,12 @@ void CmdBlit(
     const CmdBufferId id
     , const CoreGraphics::TextureId from
     , const Math::rectangle<SizeT>& fromRegion
+    , const CoreGraphics::ImageBits fromBits
     , IndexT fromMip
     , IndexT fromLayer
     , const CoreGraphics::TextureId to
     , const Math::rectangle<SizeT>& toRegion
+    , const CoreGraphics::ImageBits toBits
     , IndexT toMip
     , IndexT toLayer
 );

--- a/code/render/coregraphics/config.h
+++ b/code/render/coregraphics/config.h
@@ -102,7 +102,7 @@ __ImplementEnumBitOperators(CoreGraphics::ShaderVisibility);
 
 enum class ImageBits
 {
-    Auto = 0,
+    Auto = 0, // Special value to be used only by framescript
     ColorBits = (1 << 0),
     DepthBits = (1 << 1),
     StencilBits = (1 << 2),

--- a/code/render/coregraphics/pixelformat.cc
+++ b/code/render/coregraphics/pixelformat.cc
@@ -439,4 +439,37 @@ PixelFormat::IsDepthFormat(Code code)
     }
     return false;
 }
+
+
+//------------------------------------------------------------------------------
+/**
+*/
+bool
+PixelFormat::IsStencilFormat(Code code)
+{
+    switch (code)
+    {
+        case PixelFormat::D24S8:
+        case PixelFormat::D32S8:            return true;
+    }
+    return false;
+}
+
+
+//------------------------------------------------------------------------------
+/**
+*/
+CoreGraphics::ImageBits
+PixelFormat::ToImageBits(Code code)
+{
+    bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(code);
+    bool isStencil = CoreGraphics::PixelFormat::IsStencilFormat(code);
+
+    CoreGraphics::ImageBits ret = CoreGraphics::ImageBits::Auto;
+    ret |= isDepth ? CoreGraphics::ImageBits::DepthBits : CoreGraphics::ImageBits::Auto;
+    ret |= isStencil ? CoreGraphics::ImageBits::StencilBits : CoreGraphics::ImageBits::Auto;
+    if (ret == CoreGraphics::ImageBits::Auto)
+        ret = CoreGraphics::ImageBits::ColorBits;
+    return ret;
+}
 } // namespace CoreGraphics

--- a/code/render/coregraphics/pixelformat.h
+++ b/code/render/coregraphics/pixelformat.h
@@ -14,6 +14,7 @@
 //------------------------------------------------------------------------------
 #include "core/types.h"
 #include "util/string.h"
+#include "coregraphics/config.h"
 
 namespace CoreGraphics
 {
@@ -95,6 +96,11 @@ public:
     static uint ToILType(Code code);
     /// return true if depth format
     static bool IsDepthFormat(Code code);
+    /// return true if depth format
+    static bool IsStencilFormat(Code code);
+
+    /// Return Image bits from format
+    static CoreGraphics::ImageBits ToImageBits(Code code);
 };
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/texture.cc
+++ b/code/render/coregraphics/texture.cc
@@ -95,7 +95,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
                 }
             },
             nullptr);
-        CoreGraphics::CmdBlit(cmdBuf, id, fromRegion, mip, 0, id, toRegion, mip + 1, 0);
+        CoreGraphics::CmdBlit(cmdBuf, id, fromRegion, CoreGraphics::ImageBits::ColorBits, mip, 0, id, toRegion, CoreGraphics::ImageBits::ColorBits, mip + 1, 0);
 
         // The previous textuer will be in write, so it needs to pingpong from transfer write/read, with the first being shader read
         prevStageSrc = CoreGraphics::PipelineStage::TransferWrite;

--- a/code/render/coregraphics/textureview.h
+++ b/code/render/coregraphics/textureview.h
@@ -24,7 +24,7 @@ struct TextureViewCreateInfo
     IndexT startLayer = 0;
     SizeT numLayers = 1;
     PixelFormat::Code format = PixelFormat::InvalidPixelFormat;
-    ImageBits aspect = ImageBits::Auto;
+    ImageBits bits = ImageBits::ColorBits;
     CoreGraphics::TextureSwizzle swizzle = { TextureChannelMapping::None, TextureChannelMapping::None, TextureChannelMapping::None, TextureChannelMapping::None };
 };
 

--- a/code/render/coregraphics/vk/vkbarrier.cc
+++ b/code/render/coregraphics/vk/vkbarrier.cc
@@ -67,8 +67,9 @@ CreateBarrier(const BarrierCreateInfo& info)
         vkInfo.imageBarriers[vkInfo.numImageBarriers].dstAccessMask = VkTypes::AsVkAccessFlags(info.toStage);
 
         const TextureSubresourceInfo& subres = info.textures[i].subres;
-        bool isDepth = (subres.aspect & CoreGraphics::ImageBits::DepthBits) == CoreGraphics::ImageBits::DepthBits;
-        vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
+        n_assert(subres.bits != ImageBits::Auto);
+        bool isDepthStencil = AnyBits(subres.bits, CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits);
+        vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.bits);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseMipLevel = subres.mip;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.levelCount = subres.mipCount;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseArrayLayer = subres.layer;
@@ -83,8 +84,8 @@ CreateBarrier(const BarrierCreateInfo& info)
             vkInfo.imageBarriers[vkInfo.numImageBarriers].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         else
             vkInfo.imageBarriers[vkInfo.numImageBarriers].dstQueueFamilyIndex = CoreGraphics::GetQueueIndex(info.toQueue);
-        vkInfo.imageBarriers[vkInfo.numImageBarriers].oldLayout = VkTypes::AsVkImageLayout(info.fromStage, isDepth);
-        vkInfo.imageBarriers[vkInfo.numImageBarriers].newLayout = VkTypes::AsVkImageLayout(info.toStage, isDepth);
+        vkInfo.imageBarriers[vkInfo.numImageBarriers].oldLayout = VkTypes::AsVkImageLayout(info.fromStage, isDepthStencil);
+        vkInfo.imageBarriers[vkInfo.numImageBarriers].newLayout = VkTypes::AsVkImageLayout(info.toStage, isDepthStencil);
         vkInfo.numImageBarriers++;
 
         rts.Append(info.textures[i].tex);

--- a/code/render/coregraphics/vk/vkevent.cc
+++ b/code/render/coregraphics/vk/vkevent.cc
@@ -73,7 +73,9 @@ CreateEvent(const EventCreateInfo& info)
         vkInfo.imageBarriers[vkInfo.numImageBarriers].dstAccessMask = VkTypes::AsVkAccessFlags(info.toStage);
 
         const TextureSubresourceInfo& subres = info.textures[i].subres;
-        vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
+        n_assert(subres.bits != ImageBits::Auto);
+        bool isDepthStencil = AnyBits(subres.bits, CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits);
+        vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.bits);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseMipLevel = subres.mip;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.levelCount = subres.mipCount;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].subresourceRange.baseArrayLayer = subres.layer;
@@ -81,8 +83,8 @@ CreateEvent(const EventCreateInfo& info)
         vkInfo.imageBarriers[vkInfo.numImageBarriers].image = TextureGetVkImage(info.textures[i].tex);
         vkInfo.imageBarriers[vkInfo.numImageBarriers].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         vkInfo.imageBarriers[vkInfo.numImageBarriers].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        vkInfo.imageBarriers[vkInfo.numImageBarriers].oldLayout = VkTypes::AsVkImageLayout(info.fromStage);
-        vkInfo.imageBarriers[vkInfo.numImageBarriers].newLayout = VkTypes::AsVkImageLayout(info.toStage);
+        vkInfo.imageBarriers[vkInfo.numImageBarriers].oldLayout = VkTypes::AsVkImageLayout(info.fromStage, isDepthStencil);
+        vkInfo.imageBarriers[vkInfo.numImageBarriers].newLayout = VkTypes::AsVkImageLayout(info.toStage, isDepthStencil);
         vkInfo.numImageBarriers++;
     }
 

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -433,7 +433,7 @@ SetupTexture(const TextureId id)
             viewCreate.startLayer = 0;
             viewCreate.startMip = viewRange.baseMipLevel;
             viewCreate.tex = id;
-            viewCreate.aspect = ImageBits::StencilBits;
+            viewCreate.bits = ImageBits::StencilBits;
             TextureViewId stencilView = CreateTextureView(viewCreate);
 
             loadInfo.stencilExtension = textureStencilExtensionAllocator.Alloc();

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -1443,7 +1443,7 @@ TextureClearColor(const CoreGraphics::CmdBufferId cmd, const CoreGraphics::Textu
 {
     VkClearColorValue clear;
     VkImageSubresourceRange vksubres;
-    vksubres.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
+    vksubres.aspectMask = VkTypes::AsVkImageAspectFlags(subres.bits);
     vksubres.baseArrayLayer = subres.layer;
     vksubres.layerCount = subres.layerCount;
     vksubres.baseMipLevel = subres.mip;
@@ -1467,7 +1467,7 @@ TextureClearDepthStencil(const CoreGraphics::CmdBufferId cmd, const CoreGraphics
 {
     VkClearDepthStencilValue clear;
     VkImageSubresourceRange vksubres;
-    vksubres.aspectMask = VkTypes::AsVkImageAspectFlags(subres.aspect);
+    vksubres.aspectMask = VkTypes::AsVkImageAspectFlags(subres.bits);
     vksubres.baseArrayLayer = subres.layer;
     vksubres.layerCount = subres.layerCount;
     vksubres.baseMipLevel = subres.mip;

--- a/code/render/coregraphics/vk/vktextureview.cc
+++ b/code/render/coregraphics/vk/vktextureview.cc
@@ -63,10 +63,8 @@ CreateTextureView(const TextureViewCreateInfo& info)
 
     bool isDepthFormat = VkTypes::IsDepthFormat(info.format);
     VkImageSubresourceRange viewRange;
-    if (info.aspect == ImageBits::Auto)
-        viewRange.aspectMask = isDepthFormat ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT; // view only supports reading depth in shader
-    else
-        viewRange.aspectMask = VkTypes::AsVkImageAspectFlags(info.aspect);
+    n_assert(info.bits != ImageBits::Auto);
+    viewRange.aspectMask = VkTypes::AsVkImageAspectFlags(info.bits);
     viewRange.baseMipLevel = info.startMip;
     viewRange.levelCount = info.numMips;
     viewRange.baseArrayLayer = info.startLayer;

--- a/code/render/coregraphics/vk/vktypes.cc
+++ b/code/render/coregraphics/vk/vktypes.cc
@@ -437,13 +437,13 @@ VkTypes::AsNebulaPixelFormat(VkFormat f)
 /**
 */
 VkImageAspectFlags
-VkTypes::AsVkImageAspectFlags(const CoreGraphics::ImageBits aspect)
+VkTypes::AsVkImageAspectFlags(const CoreGraphics::ImageBits bits)
 {
     VkImageAspectFlags flags = 0;
     uint32_t bit;
-    for (bit = 1; aspect >= bit; bit *= 2)
+    for (bit = 1; bits >= bit; bit *= 2)
     {
-        if ((aspect & bit) == bit) switch ((CoreGraphics::ImageBits)bit)
+        if ((bits & bit) == bit) switch ((CoreGraphics::ImageBits)bit)
         {
         case CoreGraphics::ImageBits::ColorBits:
             flags |= VK_IMAGE_ASPECT_COLOR_BIT;

--- a/code/render/coregraphics/vk/vktypes.h
+++ b/code/render/coregraphics/vk/vktypes.h
@@ -69,7 +69,7 @@ public:
     /// convert vulkan format back to nebula format
     static CoreGraphics::PixelFormat::Code AsNebulaPixelFormat(VkFormat f);
     /// convert image aspects to Vulkan
-    static VkImageAspectFlags AsVkImageAspectFlags(const CoreGraphics::ImageBits aspect);
+    static VkImageAspectFlags AsVkImageAspectFlags(const CoreGraphics::ImageBits bits);
     /// convert shader visibility to vulkan
     static VkShaderStageFlags AsVkShaderVisibility(const CoreGraphics::ShaderVisibility vis);
     /// convert image layout to vulkan

--- a/code/render/frame/frameblit.cc
+++ b/code/render/frame/frameblit.cc
@@ -14,6 +14,8 @@ namespace Frame
 /**
 */
 FrameBlit::FrameBlit()
+    : fromBits(CoreGraphics::ImageBits::ColorBits)
+    , toBits(CoreGraphics::ImageBits::ColorBits)
 {
     // empty
 }
@@ -38,6 +40,8 @@ FrameBlit::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
     ret->name = this->name;
 #endif
 
+    ret->fromBits = this->fromBits;
+    ret->toBits = this->toBits;
     ret->from = this->from;
     ret->to = this->to;
     return ret;
@@ -67,7 +71,7 @@ FrameBlit::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const Index
 
     N_CMD_SCOPE(cmdBuf, NEBULA_MARKER_TRANSFER, this->name.Value());
 
-    CoreGraphics::CmdBlit(cmdBuf, this->from, fromRegion, 0, 0, this->to, toRegion, 0, 0);
+    CoreGraphics::CmdBlit(cmdBuf, this->from, fromRegion, this->fromBits, 0, 0, this->to, toRegion, this->toBits, 0, 0);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/frame/frameblit.h
+++ b/code/render/frame/frameblit.h
@@ -27,11 +27,13 @@ public:
         Util::StringAtom name;
 #endif
 
+        CoreGraphics::ImageBits fromBits, toBits;
         CoreGraphics::TextureId from, to;
     };
 
     FrameOp::Compiled* AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator);
 
+    CoreGraphics::ImageBits fromBits, toBits;
     CoreGraphics::TextureId from, to;
 };
 

--- a/code/render/frame/framecopy.cc
+++ b/code/render/frame/framecopy.cc
@@ -14,6 +14,8 @@ namespace Frame
 /**
 */
 FrameCopy::FrameCopy()
+    : fromBits(CoreGraphics::ImageBits::ColorBits)
+    , toBits(CoreGraphics::ImageBits::ColorBits)
 {
     // empty
 }

--- a/code/render/frame/frameop.cc
+++ b/code/render/frame/frameop.cc
@@ -352,6 +352,7 @@ FrameOp::SetupSynchronization(
                 case CoreGraphics::PipelineStage::GeometryShaderWrite:
                 case CoreGraphics::PipelineStage::PixelShaderWrite:
                 case CoreGraphics::PipelineStage::ComputeShaderWrite:
+                case CoreGraphics::PipelineStage::AllShadersWrite:
                 case CoreGraphics::PipelineStage::ColorWrite:
                 case CoreGraphics::PipelineStage::DepthStencilWrite:
                 case CoreGraphics::PipelineStage::HostWrite:

--- a/code/render/frame/frameresolve.cc
+++ b/code/render/frame/frameresolve.cc
@@ -16,6 +16,8 @@ namespace Frame
 /**
 */
 FrameResolve::FrameResolve()
+    : fromBits(CoreGraphics::ImageBits::ColorBits)
+    , toBits(CoreGraphics::ImageBits::ColorBits)
 {
 }
 

--- a/code/render/frame/framescriptloader.h
+++ b/code/render/frame/framescriptloader.h
@@ -23,66 +23,66 @@ class FrameScriptLoader
 public:
     static Ptr<FrameScript> LoadFrameScript(const IO::URI& path);
 private:
-    /// main parse function
+    /// Main parse function
     static void ParseFrameScript(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse texture list
+    /// Parse texture list
     static void ParseTextureList(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse image read-write buffer list
+    /// Parse image read-write buffer list
     static void ParseReadWriteBufferList(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse blit
+    /// Parse blit
     static FrameOp* ParseBlit(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse subpass copy
+    /// Parse subpass copy
     static FrameOp* ParseCopy(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse subpass copy
+    /// Parse resolve
+    static FrameOp* ParseResolve(const Ptr<Frame::FrameScript>& script, JzonValue* node);
+    /// Parse subpass copy
     static FrameOp* ParseMipmap(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse compute
+    /// Parse compute
     static FrameOp* ParseCompute(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse plugin (custom code execution)
+    /// Parse plugin (custom code execution)
     static FrameOp* ParsePlugin(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse subgraph
+    /// Parse subgraph
     static FrameOp* ParseSubgraph(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse frame submission phase
-    static FrameOp* ParseFrameSubmission(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse barrier
+    /// Parse barrier
     static FrameOp* ParseBarrier(const Ptr<Frame::FrameScript>& script, JzonValue* node);
     /// Parse swap
     static FrameOp* ParseSwap(const Ptr<Frame::FrameScript>& script, JzonValue* node);
 
-    /// parse pass
+    /// Parse pass
     static FrameOp* ParsePass(const Ptr<Frame::FrameScript>& script, JzonValue* node);
-    /// parse attachment list
+    /// Parse frame submission phase
+    static void ParseSubmissionList(const Ptr<Frame::FrameScript>& script, JzonValue* node);
+    /// Parse attachment list
     static void ParseAttachmentList(const Ptr<Frame::FrameScript>& script, CoreGraphics::PassCreateInfo& pass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
-    /// parse subpass
-    static void ParseSubpass(const Ptr<Frame::FrameScript>& script, CoreGraphics::PassCreateInfo& pass, Frame::FramePass* framePass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
-    /// parse subpass dependencies
-    static void ParseSubpassDependencies(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, JzonValue* node);
-    /// parse subpass dependencies
-    static void ParseSubpassAttachments(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
     /// parse subpass depth attachment
     static void ParseSubpassDepthAttachment(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
     /// parse subpass dependencies
     static void ParseSubpassResolves(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
-    /// parse subpass inputs
-    static void ParseSubpassInputs(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
-    /// parse subpass algorithm
+    /// Parse subpass
+    static void ParseSubpassList(const Ptr<Frame::FrameScript>& script, CoreGraphics::PassCreateInfo& pass, Frame::FramePass* framePass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
+    /// Parse subpass dependencies
+    static void ParseSubpassDependencyList(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, JzonValue* node);
+    /// Parse subpass dependencies
+    static void ParseSubpassAttachmentList(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
+    /// Parse subpass inputs
+    static void ParseSubpassInputList(Frame::FramePass* pass, CoreGraphics::Subpass& subpass, Util::Array<Resources::ResourceName>& attachmentNames, JzonValue* node);
+    /// Parse subpass algorithm
     static void ParseSubpassPlugin(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
     /// Parse subpass subgraph
     static void ParseSubpassSubgraph(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
-    /// parse subpass batch
+    /// Parse subpass batch
     static void ParseSubpassBatch(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
-    /// parse subpass sorted batch
+    /// Parse subpass sorted batch
     static void ParseSubpassSortedBatch(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
-    /// parse subpass post effect
+    /// Parse subpass post effect
     static void ParseSubpassFullscreenEffect(const Ptr<Frame::FrameScript>& script, Frame::FrameSubpass* subpass, JzonValue* node);
 
-    /// Parse resolve
-    static FrameOp* ParseResolve(const Ptr<Frame::FrameScript>& script, JzonValue* node);
 
-    /// helper to parse shader state
+    /// Helper to parse shader state
     static void ParseShaderState(const Ptr<Frame::FrameScript>& script, JzonValue* node, CoreGraphics::ShaderId& shd, CoreGraphics::ResourceTableId& table, Util::Dictionary<Util::StringAtom, CoreGraphics::BufferId>& constantBuffers, Util::Array<Util::Tuple<IndexT, CoreGraphics::BufferId, CoreGraphics::TextureId>>& textures);
-    /// helper to parse shader variables
+    /// Helper to parse shader variables
     static void ParseShaderVariables(const Ptr<Frame::FrameScript>& script, const CoreGraphics::ShaderId& shd, CoreGraphics::ResourceTableId& table, Util::Dictionary<Util::StringAtom, CoreGraphics::BufferId>& constantBuffers, Util::Array<Util::Tuple<IndexT, CoreGraphics::BufferId, CoreGraphics::TextureId>>& textures, JzonValue* node);
-    /// helper to parse resources
+    /// Helper to parse resources
     static void ParseResourceDependencies(const Ptr<Frame::FrameScript>& script, Frame::FrameOp* op, JzonValue* node);
     
     static Frame::FrameSubmission* LastSubmission[2];

--- a/code/render/graphics/globalconstants.cc
+++ b/code/render/graphics/globalconstants.cc
@@ -283,7 +283,7 @@ SetupBufferConstants(const Ptr<Frame::FrameScript>& frameScript)
     state.tickParams.NormalBuffer = TextureGetBindlessHandle(frameScript->GetTexture("NormalBuffer"));
     state.tickParams.SpecularBuffer = TextureGetBindlessHandle(frameScript->GetTexture("SpecularBuffer"));
     state.tickParams.DepthBuffer = TextureGetBindlessHandle(frameScript->GetTexture("ZBuffer"));
-    state.tickParams.DepthBufferCopy = TextureGetBindlessHandle(frameScript->GetTexture("ZBufferCopy"));
+    state.tickParams.DepthBufferCopy = TextureGetBindlessHandle(frameScript->GetTexture("Depth"));
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/posteffects/bloomcontext.cc
+++ b/code/render/posteffects/bloomcontext.cc
@@ -133,6 +133,12 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
                                    , CoreGraphics::PipelineStage::PixelShaderRead
                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
                                });
+    lowpassOp->textureDeps.Add(bloomState.bloomBuffer,
+                               {
+                                   "BloomBuffer"
+                                   , CoreGraphics::PipelineStage::ColorWrite
+                                   , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                               });
 
     lowpassOp->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/schemas/framescript-schema.json
+++ b/code/schemas/framescript-schema.json
@@ -1,0 +1,562 @@
+{
+    "title": "framescript",
+    "type": "object",
+    "properties": {
+
+
+        "framescript": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "version": {
+                    "type": "number"
+                },
+                "engine": {
+                    "type": "string"
+                },
+                "textures": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "pattern": "^(__WINDOW__)$"
+                                    },
+                                    "_comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "format": {
+                                        "type": "string"
+                                    },
+                                    "relative": {
+                                        "type": "boolean"
+                                    },
+                                    "usage": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "pattern": "^(Texture1D|Texture2D|Texture3D|TextureCube)(Array)?$"
+                                    },
+                                    "width": {
+                                        "type": "number",
+                                        "minimum": 0.1
+                                    },
+                                    "height": {
+                                        "type": "number",
+                                        "minimum": 0.1
+                                    },
+                                    "layers": {
+                                        "type": "number",
+                                        "minimum": 1,
+                                        "maximum": 1000
+                                    },
+                                    "samples": {
+                                        "type": "number",
+                                        "minimum": 1,
+                                        "maximum": 16
+                                    },
+                                    "mips": {
+                                        "oneOf": [
+                                            {
+                                                "type": "number",
+                                                "minimum": 1,
+                                                "maximum": 1000
+                                            },
+                                            {
+                                                "type": "string",
+                                                "pattern": "^(auto)$"
+                                            }
+                                        ]
+                                    },
+                                    "_comment": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "format",
+                                    "usage"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "_comment": {
+                    "type": "string"
+                },
+                "submissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "_comment": {
+                                "type": "string"
+                            },
+                            "queue": {
+                                "type": "string",
+                                "pattern": "^(Graphics|Compute)$"
+                            },
+                            "wait_for_queue": {
+                                "type": "string",
+                                "pattern": "^(Graphics|Compute)$"
+                            },
+                            "wait_for_submissions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "ops": {
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "pass": {
+                                                    "type": "object",
+                                                    "required": [ "name", "subpasses" ],
+
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "attachments": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "store": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "store_stencil": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "load": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "load_stencil": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "clear": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "number",
+                                                                            "length": 4
+                                                                        }
+                                                                    },
+                                                                    "clear_depth": {
+                                                                        "type": "number",
+                                                                        "minimum": 0,
+                                                                        "maximum": 1
+                                                                    },
+                                                                    "clear_stencil": {
+                                                                        "type": "number",
+                                                                        "minimum": 0,
+                                                                        "maximum": 1
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "subpasses": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "additionalProperties": false,
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "_comment": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "subpass_dependencies": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "attachments": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+
+                                                                    "resource_dependencies": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "stage": {
+                                                                                    "enum": [
+                                                                                        "Top",
+                                                                                        "Bottom",
+                                                                                        "IndirectRead",
+                                                                                        "IndexRead",
+                                                                                        "VertexRead",
+                                                                                        "UniformGraphicsRead",
+                                                                                        "UniformComputeRead",
+                                                                                        "InputAttachmentRead",
+                                                                                        "VertexShaderRead",
+                                                                                        "VertexShaderWrite",
+                                                                                        "HullShaderRead",
+                                                                                        "HullShaderWrite",
+                                                                                        "DomainShaderRead",
+                                                                                        "DomainShaderWrite",
+                                                                                        "GeometryShaderRead",
+                                                                                        "GeometryShaderWrite",
+                                                                                        "PixelShaderRead",
+                                                                                        "PixelShaderWrite",
+                                                                                        "ComputeShaderRead",
+                                                                                        "ComputeShaderWrite",
+                                                                                        "ColorAttachmentRead",
+                                                                                        "ColorAttachmentWrite",
+                                                                                        "DepthAttachmentRead",
+                                                                                        "DepthAttachmentWrite",
+                                                                                        "TransferAttachmentRead",
+                                                                                        "TransferAttachmentWrite",
+                                                                                        "HostAttachmentRead",
+                                                                                        "HostAttachmentWrite",
+                                                                                        "MemoryAttachmentRead",
+                                                                                        "MemoryAttachmentWrite",
+                                                                                        "Present"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "resolves": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "depth": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ops": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false,
+                                                                                    "properties": {
+                                                                                        "batch": {
+                                                                                            "type": "object",
+                                                                                            "additionalProperties": false,
+                                                                                            "properties": {
+                                                                                                "name": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "_comment": {
+                                                                                                    "type": "string"
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false,
+                                                                                    "properties": {
+                                                                                        "subgraph": {
+                                                                                            "type": "object",
+                                                                                            "additionalProperties": false,
+                                                                                            "properties": {
+                                                                                                "name": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "_comment": {
+                                                                                                    "type": "string"
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [ "name" ]
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false,
+                                                                                    "properties": {
+                                                                                        "fullscreen_effect": {
+                                                                                            "type": "object",
+                                                                                            "additionalProperties": false,
+                                                                                            "properties": {
+                                                                                                "name": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "_comment": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "size_from_texture": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "shader_state": {
+                                                                                                    "type": "object",
+                                                                                                    "properties": {
+                                                                                                        "shader": {
+                                                                                                            "type": "string"
+                                                                                                        },
+                                                                                                        "variables": {
+                                                                                                            "type": "array",
+                                                                                                            "items": {
+                                                                                                                "type": "object",
+                                                                                                                "properties": {
+                                                                                                                    "semantic": {
+                                                                                                                        "type": "string"
+                                                                                                                    },
+                                                                                                                    "value": {
+                                                                                                                        "type": "string"
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        }
+
+                                                                    }
+                                                                },
+                                                                "required": [ "name", "ops" ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "subgraph": {
+
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [ "name" ]
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "resolve": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "from": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "bits": {
+                                                                    "type": "string",
+                                                                    "pattern": "^((Depth|Stencil|Color)(\\|(Depth|Stencil|Color))*)|(Auto)$"
+                                                                },
+                                                                "tex": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [ "tex" ]
+                                                        },
+                                                        "to": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "bits": {
+                                                                    "type": "string",
+                                                                    "pattern": "^((Depth|Stencil|Color)(\\|(Depth|Stencil|Color))*)|(Auto)$"
+                                                                },
+                                                                "tex": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [ "tex" ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "copy": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "from": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "bits": {
+                                                                    "type": "string",
+                                                                    "pattern": "^((Depth|Stencil|Color)(\\|(Depth|Stencil|Color))*)|(Auto)$"
+                                                                },
+                                                                "tex": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [ "tex" ]
+                                                        },
+                                                        "to": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "bits": {
+                                                                    "type": "string",
+                                                                    "pattern": "^((Depth|Stencil|Color)(\\|(Depth|Stencil|Color))*)|(Auto)$"
+                                                                },
+                                                                "tex": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [ "tex" ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "blit": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "from": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "bits": {
+                                                                    "type": "string",
+                                                                    "pattern": "^((Depth|Stencil|Color)(\\|(Depth|Stencil|Color))*)|(Auto)$"
+                                                                },
+                                                                "tex": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [ "tex" ]
+                                                        },
+                                                        "to": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "bits": {
+                                                                    "type": "string",
+                                                                    "pattern": "^((Depth|Stencil|Color)(\\|(Depth|Stencil|Color))*)|(Auto)$"
+                                                                },
+                                                                "tex": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [ "tex" ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "mipmap": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        },
+                                                        "texture": {
+                                                            "type": "string"
+                                                        },
+                                                        "queue": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "swap": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "_comment": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/work/frame/win32/vkdefault.json
+++ b/work/frame/win32/vkdefault.json
@@ -1,12 +1,14 @@
 {
-    "version": 2,
-    "engine": "Nebula",
+    "$schema": "../../../code/schemas/framescript-schema.json",
     "framescript": {
+        "version": 3,
+        "engine": "Nebula",
         "textures": [
             {
                 "name": "__WINDOW__"
             },
             {
+
                 "name": "ScreenBuffer",
                 "format": "R11G11B10F",
                 "relative": true,
@@ -80,7 +82,7 @@
             },
             {
                 "name": "LightBuffer",
-                "format": "R16G16B16A16F",
+                "format": "R11G11B10F",
                 "relative": true,
                 "usage": "Render|ReadWrite|TransferSource",
                 "width": 1.0,
@@ -125,11 +127,19 @@
                 "type": "Texture2D"
             },
             {
-                "name": "ZBufferCopy",
+                "name": "Depth",
                 "format": "D32S8",
                 "relative": true,
-                "usage": "Render|TransferDestination",
-                "mips": "auto",
+                "usage": "TransferDestination|Sample",
+                "width": 1.0,
+                "height": 1.0,
+                "type": "Texture2D"
+            },
+            {
+                "name": "Stencil",
+                "format": "R8",
+                "relative": true,
+                "usage": "TransferDestination|Sample",
                 "width": 1.0,
                 "height": 1.0,
                 "type": "Texture2D"
@@ -191,417 +201,566 @@
             }
         ],
 
-        "_comment": "------------ COMPUTE PREPASS ------------",
-        "submission": {
-            "name": "Compute Prepass",
-            "queue": "Compute",
-            "wait_for_queue": "Graphics",
-            "_comment": "Perform clustering AABB generation and run culling for clustering systems",
-            "ops": {
-                "subgraph": {
-                    "name": "Cluster AABB Generation"
-                },
-                "subgraph": {
-                    "name": "Lights Cull"
-                },
-                "subgraph": {
-                    "name": "Decal Cull"
-                },
-                "subgraph": {
-                    "name": "Fog Cull"
-                },
-                "subgraph": {
-                    "name": "Sun Terrain Shadows"
-                }
-            }
-        },
-
-        "submission": {
-            "name": "Shadows",
-            "queue": "Graphics",
-            "_comment": "Render and blur shadow maps",
-            "ops": {
-                "pass": {
-                    "name": "Sun Shadows Pass",
-                    "attachments": [
-                        {
-                            "name": "SunShadowDepth",
-                            "clear_depth": 1,
-                            "store": true
-                        }
-                    ],
-
-                    "subpass": {
-                        "name": "Sun Shadows",
-                        "subpass_dependencies": [],
-                        "depth": "SunShadowDepth",
+        "submissions": [
+            {
+                "name": "Compute Prepass",
+                "queue": "Compute",
+                "wait_for_queue": "Graphics",
+                "_comment": "Perform clustering AABB generation and run culling for clustering systems",
+                "ops": [
+                    {
                         "subgraph": {
-                            "name": "Sun Shadows"
+                            "name": "Cluster AABB Generation"
                         }
                     },
-                },
-
-                "pass": {
-                    "name": "Local Shadows Pass",
-                    "attachments": [
-                        {
-                            "name": "LocalLightShadow",
-                            "clear": [ 1000, 1000, 0, 0 ],
-                            "store": true
-                        }
-                    ],
-                    "subpass": {
-                        "name": "Spotlight Shadows",
-                        "subpass_dependencies": [],
-                        "attachments": [ "LocalLightShadow" ],
+                    {
                         "subgraph": {
-                            "name": "Spotlight Shadows"
+                            "name": "Lights Cull"
                         }
-                    }
-                },
-
-                "subgraph": {
-                    "name": "Spotlight Blur"
-                },
-                "subgraph": {
-                    "name": "Sun Blur"
-                }
-            }
-        },
-
-        "submission": {
-            "name": "Prepass",
-            "queue": "Graphics",
-            "_comment": "Calculate shadow maps and depth prepass",
-            "ops": {
-
-                "_comment": "------------ UI ------------",
-                "subgraph": {
-                    "name": "StaticUI"
-                },
-
-                "_comment": "------------ VEGETATION ------------",
-                "subgraph": {
-                    "name": "Vegetation Generate Draws"
-                },
-
-                "_comment": "------------ TERRAIN ------------",
-                "subgraph": {
-                    "name": "Terrain Prepare"
-                },
-                "pass": {
-                    "name": "Terrain GBuffer",
-                    "attachments": [
-                        {
-                            "name": "TerrainPosBuffer",
-                            "clear": [ 0, 0, 0, 255 ],
-                            "store": true
-                        },
-                        {
-                            "name": "ZBuffer",
-                            "clear_depth": 1,
-                            "store": true
-                        }
-                    ],
-
-                    "subpass": {
-                        "name": "TerrainPass",
-                        "subpass_dependencies": [],
-                        "attachments": [ "TerrainPosBuffer" ],
-                        "depth": "ZBuffer",
-                        "subgraph": {
-                            "name": "Terrain Prepass"
-                        }
-                    }
-                },
-                "subgraph": {
-                    "name": "Terrain Update Caches"
-                },
-
-                "_comment": "------------ PREPASS ------------",
-                "pass": {
-                    "name": "Prepass",
-
-                    "attachments": [
-                        {
-                            "name": "ZBuffer",
-                            "store": true,
-                            "load": true
-                        }
-                    ],
-
-                    "subpass": {
-                        "name": "DepthPrepass",
-                        "subpass_dependencies": [],
-                        "attachments": [],
-                        "depth": "ZBuffer",
-                        "batch": "FlatGeometryDepth",
-                        "subgraph": {
-                            name: "Vegetation Prepass"
-                        }
-                    }
-                },
-
-                "copy": {
-                    "name": "Copy Depth",
-                    "from": {
-                        "tex": "ZBuffer",
-                        "bits": "Depth|Stencil"
                     },
-                    "to": {
-                        "tex": "ZBufferCopy",
-                        "bits": "Depth|Stencil"
-                    }
-                }
-            }
-        },
-
-        "submission": {
-            "name": "Forward shading and post effects",
-            "wait_for_submissions": [ "Compute Prepass", "Prepass" ],
-            "queue": "Graphics",
-            "_comment": "Main graphics submission",
-            "ops": {
-                "_comment": "------------ FORWARD PASS ------------",
-                "pass": {
-                    "name": "ForwardRendering",
-                    "attachments": [
-                        {
-                            "name": "LightBuffer",
-                            "store": true,
-                            "clear": [ 0, 0, 0, 0 ]
-                        },
-                        {
-                            "name": "NormalBuffer",
-                            "store": true,
-                            "clear": [ 0, 0, 0, 0 ]
-                        },
-                        {
-                            "name": "SpecularBuffer",
-                            "store": true,
-                            "clear": [ 0, 0, 0, 0 ]
-                        },
-                        {
-                            "name": "ZBuffer",
-                            "store": true,
-                            "load": true
-                        }
-                    ],
-
-                    "subpass": {
-                        "name": "OpaquePass",
-                        "subpass_dependencies": [],
-                        "attachments": [ "LightBuffer" ],
-                        "depth": "ZBuffer",
+                    {
                         "subgraph": {
-                            "name": "Terrain Resolve"
-                        },
-                        "subgraph": {
-                            "name": "Vegetation Render"
-                        },
-                        "batch": "FlatGeometryLit"
-                    },
-                    "subpass": {
-                        "name": "Skypass",
-                        "subpass_dependencies": [ "OpaquePass" ],
-                        "attachments": [ "LightBuffer" ],
-                        "depth": "ZBuffer",
-                        "batch": "Background"
-                    },
-                    "subpass": {
-                        "_comment": "TODO: Move this to a separate pass later on",
-                        "name": "AlphaPass",
-                        "subpass_dependencies": [ "Skypass" ],
-                        "attachments": [ "LightBuffer" ],
-                        "depth": "ZBuffer",
-                        "batch": "FlatGeometryAlphaLit"
-                    }
-                },
-
-                "_comment": "------------ VEGETATION COPY ------------",
-                "subgraph": {
-                    "name": "Vegetation Copy Indirect"
-                },
-
-                "_comment": "------------ SSAO ------------",
-                "subgraph": {
-                    "name": "HBAO"
-                },
-
-                "_comment": "------------ VOLUMETRIC FOG ------------",
-                "subgraph": {
-                    "name": "Fog Compute"
-                },
-
-                "_comment": "------------ LIGHTS COMBINE ------------",
-                "subgraph": {
-                    "name": "Lights Combine"
-                },
-
-                "_comment": "------------ HISTOGRAM ------------",
-                "subgraph": {
-                    "name": "Histogram"
-                },
-
-                "_comment": "------------ BLOOM ------------",
-                "subgraph": {
-                    "name": "Bloom"
-                },
-
-                "_comment": "------------ POST EFFECTS ------------",
-                "pass": {
-                    "name": "PostEffects",
-                    "attachments": [
-                        {
-                            "name": "ColorBuffer",
-                            "load": true,
-                            "store": true
-                        },
-                        {
-                            "name": "ZBuffer",
-                            "store": false,
-                            "load": true
+                            "name": "Decal Cull"
                         }
-                    ],
+                    },
+                    {
+                        "subgraph": {
+                            "name": "Fog Cull"
+                        }
+                    },
+                    {
+                        "subgraph": {
+                            "name": "Sun Terrain Shadows"
+                        }
+                    }
+                ]
+            },
 
-                    "subpass": {
-                        "name": "FinalizePass",
-                        "subpass_dependencies": [],
-                        "attachments": [
-                            "ColorBuffer"
-                        ],
-                        "depth": "ZBuffer",
+            {
+                "name": "Shadows",
+                "queue": "Graphics",
+                "_comment": "Render and blur shadow maps",
+                "ops": [
+                    {
+                        "pass": {
+                            "name": "Sun Shadows Pass",
+                            "attachments": [
+                                {
+                                    "name": "SunShadowDepth",
+                                    "clear_depth": 1,
+                                    "store": true
+                                }
+                            ],
 
-                        "resource_dependencies": [
-                            {
-                                "name": "BloomBufferBlurred",
-                                "stage": "PixelShaderRead"
+                            "subpasses": [
+                                {
+                                    "name": "Sun Shadows",
+                                    "subpass_dependencies": [],
+                                    "depth": "SunShadowDepth",
+                                    "ops": [
+                                        {
+                                            "subgraph": {
+                                                "name": "Sun Shadows"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+
+                    },
+
+                    {
+                        "pass": {
+                            "name": "Local Shadows Pass",
+                            "attachments": [
+                                {
+                                    "name": "LocalLightShadow",
+                                    "clear": [ 1000, 1000, 0, 0 ],
+                                    "store": true
+                                }
+                            ],
+                            
+                            "subpasses": [
+                                {
+                                    "name": "Spotlight Shadows",
+                                    "subpass_dependencies": [],
+                                    "attachments": [ "LocalLightShadow" ],
+                                    "ops": [
+                                        {
+                                            "subgraph": {
+                                                "name": "Spotlight Shadows"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+
+                    {
+                        "subgraph": {
+                            "name": "Spotlight Blur"
+
+                        }
+                    },
+                    {
+                        "subgraph": {
+                            "name": "Sun Blur"
+                        }
+                    }
+                ]
+            },
+
+            {
+                "name": "Prepass",
+                "queue": "Graphics",
+                "_comment": "Calculate shadow maps and depth prepass",
+                "ops": [
+
+                    {
+                        "subgraph": {
+                            "name": "StaticUI"
+                        }
+                    },
+
+                    {
+                        "subgraph": {
+                            "name": "Vegetation Generate Draws"
+                        }
+                    },
+
+                    {
+                        "subgraph": {
+                            "name": "Terrain Prepare"
+                        }
+                    },
+                    {
+                        "pass": {
+                            "name": "Terrain GBuffer",
+                            "attachments": [
+                                {
+                                    "name": "TerrainPosBuffer",
+                                    "clear": [ 0, 0, 0, 255 ],
+                                    "store": true
+                                },
+                                {
+                                    "name": "ZBuffer",
+                                    "clear_depth": 1,
+                                    "store": true
+                                }
+                            ],
+
+                            "subpasses": [
+                                {
+                                    "name": "TerrainPass",
+                                    "subpass_dependencies": [],
+                                    "attachments": [ "TerrainPosBuffer" ],
+                                    "depth": "ZBuffer",
+                                    "ops": [
+                                        {
+                                            "subgraph": {
+                                                "name": "Terrain Prepass"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "subgraph": {
+                            "name": "Terrain Update Caches"
+
+                        }
+                    },
+
+                    {
+                        "pass": {
+                            "name": "Prepass",
+                            "attachments": [
+                                {
+                                    "name": "ZBuffer",
+                                    "clear_depth": 1,
+                                    "clear_stencil": 0,
+                                    "store": true,
+                                    "store_stencil": true
+                                }
+                            ],
+
+                            "subpasses": [
+                                {
+                                    "name": "DepthPrepass",
+                                    "subpass_dependencies": [],
+                                    "attachments": [],
+                                    "depth": "ZBuffer",
+                                    "ops": [
+                                        {
+                                            "batch": {
+                                                "name": "FlatGeometryDepth"
+                                            }
+                                        },
+                                        {
+                                            "batch": {
+                                                "name": "Vegetation Prepass"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+
+                    {
+                        "copy": {
+                            "name": "Copy ZBuffer",
+                            "from": {
+                                "tex": "ZBuffer",
+                                "bits": "Depth|Stencil"
                             },
-                            {
-                                "name": "AverageLumBuffer",
-                                "stage": "PixelShaderRead"
-                            },
-                            {
-                                "name": "LightBuffer",
-                                "stage": "PixelShaderRead"
-                            },
-                            {
-                                "name": "ZBufferCopy",
-                                "stage": "PixelShaderRead"
+                            "to": {
+                                "tex": "Depth",
+                                "bits": "Depth|Stencil"
                             }
-                        ],
+                        }
+                    }
+                ]
+            },
 
-                        "fullscreen_effect": {
-                            "name": "Finalize",
-                            "shader_state": {
-                                "shader": "finalize",
-                                "variables": [
-                                    {
-                                        "semantic": "LuminanceTexture",
-                                        "value": "AverageLumBuffer"
-                                    },
-                                    {
-                                        "semantic": "DepthTexture",
-                                        "value": "ZBufferCopy"
-                                    },
-                                    {
-                                        "semantic": "ColorTexture",
-                                        "value": "LightBuffer"
-                                    },
-                                    {
-                                        "semantic": "BloomTexture",
-                                        "value": "BloomBufferBlurred"
-                                    }
-                                ]
-                            },
-                            "size_from_texture": "ColorBuffer"
+            {
+                "name": "Forward shading and post effects",
+                "wait_for_submissions": [ "Compute Prepass", "Prepass" ],
+                "queue": "Graphics",
+                "_comment": "Main graphics submission",
+                "ops": [
+                    {
+                        "pass": {
+                            "name": "ForwardRendering",
+                            "attachments": [
+                                {
+                                    "name": "ZBuffer",
+                                    "store": false,
+                                    "load": true,
+                                    "load_stencil": true
+                                },
+                                {
+                                    "name": "LightBuffer",
+                                    "clear": [ 0, 0, 0, 0 ],
+                                    "store": true
+                                },
+                                {
+                                    "name": "NormalBuffer",
+                                    "store": true,
+                                    "clear": [ 0, 0, 0, 0 ]
+                                },
+                                {
+                                    "name": "SpecularBuffer",
+                                    "store": true,
+                                    "clear": [ 0, 0, 0, 0 ]
+                                }
+
+                            ],
+
+                            "subpasses": [
+                                {
+                                    "name": "OpaquePass",
+                                    "subpass_dependencies": [],
+                                    "attachments": [ "LightBuffer" ],
+
+                                    "resource_dependencies": [
+                                        {
+                                            "name": "SunShadowDepth",
+                                            "stage": "PixelShaderRead"
+                                        }
+                                    ],
+
+                                    "depth": "ZBuffer",
+                                    "ops": [
+                                        {
+                                            "subgraph": {
+                                                "name": "Terrain Resolve"
+                                            }
+                                        },
+                                        {
+                                            "subgraph": {
+                                                "name": "Vegetation Render"
+                                            }
+                                        },
+                                        {
+                                            "batch": {
+                                                "name": "FlatGeometryLit"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Skypass",
+                                    "subpass_dependencies": [ "OpaquePass" ],
+                                    "attachments": [ "LightBuffer" ],
+                                    "depth": "ZBuffer",
+                                    "ops": [
+                                        {
+                                            "batch": {
+                                                "name": "Background"
+                                            }
+                                        }
+                                    ]
+
+                                },
+                                {
+                                    "name": "AlphaPass",
+                                    "_comment": "TODO: Move this to a separate pass later on",
+                                    "subpass_dependencies": [ "Skypass" ],
+                                    "attachments": [ "LightBuffer" ],
+                                    "depth": "ZBuffer",
+                                    "ops": [
+                                        {
+                                            "batch": {
+                                                "name": "FlatGeometryAlphaLit"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }                       
+                    },
+
+                    {
+                        "subgraph": {
+                            "name": "Vegetation Copy Indirect"
+                        }
+                    },
+                    {
+                        "subgraph": {
+                            "name": "HBAO"
+                        }
+                    },
+                    {
+                        "subgraph": {
+                            "name": "Fog Compute"
                         }
                     },
 
-                    "subpass": {
-                        "name": "Direct",
-                        "subpass_dependencies": [
-                            "FinalizePass"
-                        ],
-                        "depth": "ZBuffer",
-                        "attachments": [
-                            "ColorBuffer"
-                        ],
+                    {
+                        "subgraph": {
+                            "name": "Lights Combine"
+                        }
+                    },
 
-                        "resource_dependencies": [
-                            {
-                                "name": "ZBufferCopy",
-                                "stage": "PixelShaderRead"
+                    {
+                        "subgraph": {
+                            "name": "Histogram"
+                        }
+                    },
+
+                    {
+                        "subgraph": {
+                            "name": "Bloom"
+                        }
+                    },
+
+                    {
+                        "pass": {
+                            "name": "PostEffects",
+                            "attachments": [
+                                {
+                                    "name": "ColorBuffer",
+                                    "load": true,
+                                    "store": true
+                                },
+                                {
+                                    "name": "ZBuffer",
+                                    "load": true,
+                                    "store": false
+                                }
+                            ],
+
+                            "subpasses": [
+                                {
+                                    "name": "FinalizePass",
+                                    "subpass_dependencies": [],
+                                    "attachments": [
+                                        "ColorBuffer"
+                                    ],
+
+                                    "resource_dependencies": [
+                                        {
+                                            "name": "BloomBufferBlurred",
+                                            "stage": "PixelShaderRead"
+                                        },
+                                        {
+                                            "name": "AverageLumBuffer",
+                                            "stage": "PixelShaderRead"
+                                        },
+                                        {
+                                            "name": "LightBuffer",
+                                            "stage": "PixelShaderRead"
+                                        },
+                                        {
+                                            "name": "Depth",
+                                            "stage": "PixelShaderRead"
+                                        }
+                                    ],
+
+                                    "ops": [
+                                        {
+                                            "fullscreen_effect": {
+                                                "name": "Finalize",
+                                                "shader_state": {
+                                                    "shader": "finalize",
+                                                    "variables": [
+                                                        {
+                                                            "semantic": "LuminanceTexture",
+                                                            "value": "AverageLumBuffer"
+                                                        },
+                                                        {
+                                                            "semantic": "DepthTexture",
+                                                            "value": "Depth"
+                                                        },
+                                                        {
+                                                            "semantic": "ColorTexture",
+                                                            "value": "LightBuffer"
+                                                        },
+                                                        {
+                                                            "semantic": "BloomTexture",
+                                                            "value": "BloomBufferBlurred"
+                                                        }
+                                                    ]
+                                                },
+                                                "size_from_texture": "ColorBuffer"
+                                            }
+                                        }
+                                    ]
+                                },
+
+                                {
+                                    "name": "Direct",
+                                    "subpass_dependencies": [
+                                        "FinalizePass"
+                                    ],
+                                    "depth": "ZBuffer",
+                                    "attachments": [
+                                        "ColorBuffer"
+                                    ],
+
+                                    "resource_dependencies": [
+                                        {
+                                            "name": "Depth",
+                                            "stage": "PixelShaderRead"
+                                        }
+                                    ],
+
+                                    "ops": [
+                                        {
+                                            "batch": {
+                                                "name": "DirectToColor"
+                                            }
+                                        },
+                                        {
+                                            "batch": {
+                                                "name": "ParticleUnlit"
+                                            }
+                                        },
+                                        {
+                                            "batch": {
+                                                "name": "ParticleLit"
+                                            }
+                                        },
+                                        {
+                                            "batch": {
+                                                "name": "Debug Shapes"
+                                            }
+                                        },
+                                        {
+                                            "batch": {
+                                                "name": "Im3D"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+
+                    {
+                        "blit": {
+                            "name": "ColorBuffer Copy",
+                            "from": {
+                                "tex": "ColorBuffer"
+                            },
+                            "to": {
+                                "tex": "ColorBufferNoGUI"
                             }
-                        ],
+                        }
+                    },
 
-                        "batch": "DirectToColor",
-                        "batch": "ParticleUnlit",
-                        "batch": "ParticleLit",
-                        "subgraph": {
-                            "name": "Debug Shapes"
-                        },
-                        "subgraph": {
-                            "name": "Im3D"
+                    {
+                        "pass": {
+                            "name": "GUI",
+                            "attachments": [
+                                {
+                                    "name": "ColorBuffer",
+                                    "load": true,
+                                    "store": true
+                                },
+                                {
+                                    "name": "ZBuffer",
+                                    "store": false,
+                                    "load": true
+                                }
+                            ],
+
+                            "subpasses": [
+                                {
+                                    "name": "DynUI",
+                                    "depth": "ZBuffer",
+                                    "attachments": [
+                                        "ColorBuffer"
+                                    ],
+
+                                    "resource_dependencies": [
+                                        {
+                                            "name": "Depth",
+                                            "stage": "PixelShaderRead"
+                                        }
+                                    ],
+
+                                    "ops": [
+                                        {
+                                            "subgraph": {
+                                                "name": "ImGUI"
+                                            }
+                                        },
+                                        {
+                                            "subgraph": {
+                                                "name": "StaticUI To Backbuffer"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+
+                    {
+                        "swap": {
+                            "name": "Swap"
+                        }
+                    },
+
+                    {
+                        "blit": {
+                            "name": "Copy To Backbuffer",
+                            "from": {
+                                "tex": "ColorBuffer"
+                            },
+                            "to": {
+                                "tex": "__WINDOW__"
+                            }
                         }
                     }
-                },
-
-                "blit": {
-                    "name": "ColorBuffer Copy",
-                    "from": "ColorBuffer",
-                    "to": "ColorBufferNoGUI"
-                },
-
-                "pass": {
-                    "name": "GUI",
-                    "attachments": [
-                        {
-                            "name": "ColorBuffer",
-                            "load": true,
-                            "store": true
-                        },
-                        {
-                            "name": "ZBuffer",
-                            "store": false,
-                            "load": true
-                        }
-                    ],
-
-                    "subpass": {
-                        "name": "DynUI",
-                        "depth": "ZBuffer",
-                        "attachments": [
-                            "ColorBuffer"
-                        ],
-
-                        "resource_dependencies": [
-                            {
-                                "name": "ZBufferCopy",
-                                "stage": "PixelShaderRead"
-                            }
-                        ],
-                        "subgraph": {
-                            "name": "ImGUI"
-                        },
-                        "subgraph": {
-                            "name": "StaticUI To Backbuffer"
-                        },
-                    }
-                },
-
-                "_comment": "Swap just before we need the backbuffer",
-                "swap": {
-                    "name": "Swap"
-                },
-
-                "_comment": "------------ COPY TO BACKBUFFER ------------",
-                "blit": {
-                    "name": "Copy To Backbuffer",
-                    "from": "ColorBuffer",
-                    "to": "__WINDOW__"
-                }
+                ]
             }
-        }
+        ]
     }
 }


### PR DESCRIPTION
- Fixes #136. 
- Added a framescript schema for validation and assistance in writing framescript operations. 
- Changed ImageAspect to ImageBits for clarity.
- Fixed synchronization barrier for Bloom.
- Changed the default render texture layout from shader read only to depth/color attachment read, this is to prevent unnecessary decompressions triggered by transitioning render textures. 
- Removed the use of the Auto ImageBits enum, forcing it to only be used for setup. 
- Added stencil format check for pixel format, along with a way to convert the format to image bits.