### PR TITLE
Fix invalid depth image layouts

### DIFF
--- a/code/render/coregraphics/texture.h
+++ b/code/render/coregraphics/texture.h
@@ -52,12 +52,13 @@ enum TextureCubeFace
 /// type of texture usage
 enum TextureUsage
 {
-    InvalidTextureUsage         = 0x0,      // invalid usage
-    SampleTexture               = 0x1,      // texture is a shader sampleable 1D, 2D, 3D or Cube texture
-    RenderTexture               = 0x2,      // texture supports to be rendered to as an attachment, also supports sampling
-    ReadWriteTexture            = 0x4,      // texture supports to be bound as an RWTexture (DX) or Image (GL/Vulkan), also supports sampling
-    TransferTextureSource       = 0x8,      // texture supports being a copy source
-    TransferTextureDestination  = 0x10      // texture supports being a copy destination
+    InvalidTextureUsage         = 0x0,      // Invalid usage
+    SampleTexture               = 0x1,      // Texture is a shader sampleable 1D, 2D, 3D or Cube texture
+    RenderTexture               = 0x2,      // Texture supports to be rendered to as an attachment, also supports sampling
+    ReadWriteTexture            = 0x4,      // Texture supports to be bound as an RWTexture (DX) or Image (GL/Vulkan), also supports sampling
+    TransferTextureSource       = 0x8,      // Texture supports being a copy source
+    TransferTextureDestination  = 0x10,     // Texture supports being a copy destination
+    DeviceExclusive             = 0x20      // Texture will be managed entirely by the device (copy target, RW target, etc)
 };
 __ImplementEnumBitOperators(CoreGraphics::TextureUsage);
 

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -622,7 +622,7 @@ CmdBarrier(
         vkBar.dstAccessMask = VkTypes::AsVkAccessFlags(toStage);
 
         const TextureSubresourceInfo& subres = nebBar.subres;
-        bool isDepth = (subres.bits & CoreGraphics::ImageBits::DepthBits) == 1;
+        bool isDepth = AnyBits(subres.bits, CoreGraphics::ImageBits::DepthBits);
         vkBar.subresourceRange.aspectMask = VkTypes::AsVkImageAspectFlags(subres.bits);
         vkBar.subresourceRange.baseMipLevel = subres.mip;
         vkBar.subresourceRange.levelCount = subres.mipCount;

--- a/code/render/coregraphics/vk/vkpass.cc
+++ b/code/render/coregraphics/vk/vkpass.cc
@@ -705,9 +705,7 @@ PassWindowResizeCallback(const PassId id)
 
     // update attachments because their underlying textures might have changed
     for (IndexT i = 0; i < loadInfo.attachments.Size(); i++)
-    {
         CoreGraphics::TextureViewReload(loadInfo.attachments[i]);
-    }
 
     // setup pass again
     SetupPass(id);

--- a/code/render/frame/framescriptloader.cc
+++ b/code/render/frame/framescriptloader.cc
@@ -164,7 +164,7 @@ FrameScriptLoader::ParseTextureList(const Ptr<Frame::FrameScript>& script, JzonV
             // create texture
             TextureCreateInfo info;
             info.name = name->string_value;
-            info.usage = TextureUsageFromString(usage->string_value);
+            info.usage = TextureUsageFromString(usage->string_value) | DeviceExclusive;
             info.tag = "frame_script"_atm;
             info.type = TextureTypeFromString(type->string_value);
             info.format = fmt;
@@ -781,6 +781,11 @@ FrameScriptLoader::ParseAttachmentList(const Ptr<Frame::FrameScript>& script, Co
         };
 
         bool isDepth = CoreGraphics::PixelFormat::IsDepthFormat(CoreGraphics::TextureGetPixelFormat(tex));
+
+        if (isDepth)
+        {
+            viewCreate.bits = CoreGraphics::ImageBits::DepthBits;
+        }
 
         pass.attachments.Append(CreateTextureView(viewCreate));
         attachmentNames.Append(name->string_value);


### PR DESCRIPTION
For some textures, the frame script incorrectly assumed their layout was different to what it was, which resulted in a bunch of bad layout transitions. 

This has been fixed in two parts, one is a new texture flag which signals to the engine that a texture will be completely managed on device, even if this texture is not a read-write texture. Such textures can be copy/blit targets, where there is no source data, they are not meant for compute shaders, and so they would never transition away from their initial layouts. 