### PR TITLE
Coherently mapped constants

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -42,7 +42,7 @@ UltralightRenderer::UltralightRenderer()
 
     CoreGraphics::ResourceTableSetConstantBuffer(ultralightState.resourceTable,
         {
-            CoreGraphics::GetGraphicsConstantBuffer(),
+            CoreGraphics::GetGraphicsConstantBuffer(0),
             Staticui::Table_DynamicOffset::PerDrawState::SLOT,
             0,
             Staticui::Table_DynamicOffset::PerDrawState::SIZE, 0,

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -87,9 +87,8 @@ struct GraphicsDeviceState
     Util::FixedArray<CoreGraphics::SemaphoreId> renderingFinishedSemaphores;
 
     uint globalConstantBufferMaxValue;
-    Util::FixedArray<CoreGraphics::BufferId> globalConstantStagingBuffer;
-    CoreGraphics::BufferId globalGraphicsConstantBuffer;
-    CoreGraphics::BufferId globalComputeConstantBuffer;
+    Util::FixedArray<CoreGraphics::BufferId> globalGraphicsConstantBuffer;
+    Util::FixedArray<CoreGraphics::BufferId> globalComputeConstantBuffer;
 
     CoreGraphics::ResourceTableId tickResourceTableGraphics;
     CoreGraphics::ResourceTableId tickResourceTableCompute;
@@ -192,9 +191,9 @@ void SetConstantsInternal(ConstantBufferOffset offset, const void* data, SizeT s
 ConstantBufferOffset AllocateConstantBufferMemory(uint size);
 
 /// return id to global graphics constant buffer
-CoreGraphics::BufferId GetGraphicsConstantBuffer();
+CoreGraphics::BufferId GetGraphicsConstantBuffer(IndexT i);
 /// Return buffer used for compute constants
-CoreGraphics::BufferId GetComputeConstantBuffer();
+CoreGraphics::BufferId GetComputeConstantBuffer(IndexT i);
 /// Flush constants for queue type, do this before recording any commands doing draw or dispatch
 void FlushConstants(const CoreGraphics::CmdBufferId cmds, const CoreGraphics::QueueType queue);
 

--- a/code/render/coregraphics/shader.h
+++ b/code/render/coregraphics/shader.h
@@ -93,6 +93,8 @@ const ShaderId ShaderGet(const Resources::ResourceName& name);
 
 /// create resource table from shader
 const ResourceTableId ShaderCreateResourceTable(const ShaderId id, const IndexT group, const uint overallocationSize = 1);
+/// Returns true if there is a resource table for the given group in the shader
+const bool ShaderHasResourceTable(const ShaderId id, const IndexT group);
 /// create constant buffer from shader using name (don't use too frequently)
 const BufferId ShaderCreateConstantBuffer(const ShaderId id, const Util::StringAtom& name, BufferAccessMode mode = BufferAccessMode::HostCached);
 /// create constant buffer from index

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -918,7 +918,7 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
     cboInfo.name = "Global Staging Constant Buffer";
     cboInfo.byteSize = info.globalConstantBufferMemorySize;
     cboInfo.mode = CoreGraphics::BufferAccessMode::DeviceAndHost;
-    cboInfo.usageFlags = CoreGraphics::ConstantBuffer;
+    cboInfo.usageFlags = CoreGraphics::ConstantBuffer | CoreGraphics::TransferBufferDestination;
     state.globalGraphicsConstantBuffer.Resize(info.numBufferedFrames);
     state.globalComputeConstantBuffer.Resize(info.numBufferedFrames);
     for (IndexT i = 0; i < info.numBufferedFrames; i++)

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -917,26 +917,20 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
 
     cboInfo.name = "Global Staging Constant Buffer";
     cboInfo.byteSize = info.globalConstantBufferMemorySize;
-    cboInfo.mode = CoreGraphics::BufferAccessMode::HostLocal;
-    cboInfo.usageFlags = CoreGraphics::TransferBufferSource;
-    state.globalConstantStagingBuffer.Resize(info.numBufferedFrames);
-    for (IndexT i = 0; i < state.globalConstantStagingBuffer.Size(); i++)
+    cboInfo.mode = CoreGraphics::BufferAccessMode::DeviceAndHost;
+    cboInfo.usageFlags = CoreGraphics::ConstantBuffer;
+    state.globalGraphicsConstantBuffer.Resize(info.numBufferedFrames);
+    state.globalComputeConstantBuffer.Resize(info.numBufferedFrames);
+    for (IndexT i = 0; i < info.numBufferedFrames; i++)
     {
-        state.globalConstantStagingBuffer[i] = CreateBuffer(cboInfo);
+        auto gfxCboInfo = cboInfo;
+        gfxCboInfo.queueSupport = CoreGraphics::GraphicsQueueSupport;
+        state.globalGraphicsConstantBuffer[i] = CreateBuffer(gfxCboInfo);
+
+        auto cmpCboInfo = cboInfo;
+        cmpCboInfo.queueSupport = CoreGraphics::ComputeQueueSupport;
+        state.globalComputeConstantBuffer[i] = CreateBuffer(cmpCboInfo);
     }
-
-    cboInfo.byteSize = info.globalConstantBufferMemorySize;
-    cboInfo.name = "Global Graphics Constant Buffer";
-    cboInfo.mode = CoreGraphics::BufferAccessMode::DeviceLocal;
-    cboInfo.usageFlags = CoreGraphics::TransferBufferDestination | CoreGraphics::ConstantBuffer;
-    cboInfo.queueSupport = CoreGraphics::GraphicsQueueSupport;
-    state.globalGraphicsConstantBuffer = CreateBuffer(cboInfo);
-
-    cboInfo.name = "Global Compute Constant Buffer";
-    cboInfo.mode = CoreGraphics::BufferAccessMode::DeviceLocal;
-    cboInfo.usageFlags = CoreGraphics::TransferBufferDestination | CoreGraphics::ConstantBuffer;
-    cboInfo.queueSupport = CoreGraphics::ComputeQueueSupport;
-    state.globalComputeConstantBuffer = CreateBuffer(cboInfo);
 
     state.maxNumBufferedFrames = info.numBufferedFrames;
 
@@ -1145,14 +1139,12 @@ DestroyGraphicsDevice()
 
     if (state.globalConstantBufferMaxValue > 0)
     {
-        DestroyBuffer(state.globalGraphicsConstantBuffer);
-        DestroyBuffer(state.globalComputeConstantBuffer);
         for (IndexT i = 0; i < state.maxNumBufferedFrames; i++)
-            DestroyBuffer(state.globalConstantStagingBuffer[i]);
+        {
+            DestroyBuffer(state.globalGraphicsConstantBuffer[i]);
+            DestroyBuffer(state.globalComputeConstantBuffer[i]);
+        }
     }
-    state.globalGraphicsConstantBuffer = InvalidBufferId;
-    state.globalComputeConstantBuffer = InvalidBufferId;
-    state.globalConstantStagingBuffer.Clear();
 
     state.database.Discard();
 
@@ -1435,7 +1427,8 @@ LockConstantUpdates()
 void
 SetConstantsInternal(ConstantBufferOffset offset, const void* data, SizeT size)
 {
-    BufferUpdate(state.globalConstantStagingBuffer[state.currentBufferedFrameIndex], data, size, offset);
+    BufferUpdate(state.globalGraphicsConstantBuffer[state.currentBufferedFrameIndex], data, size, offset);
+    BufferUpdate(state.globalComputeConstantBuffer[state.currentBufferedFrameIndex], data, size, offset);
 }
 
 //------------------------------------------------------------------------------
@@ -1469,18 +1462,18 @@ AllocateConstantBufferMemory(uint size)
 /**
 */
 CoreGraphics::BufferId
-GetGraphicsConstantBuffer()
+GetGraphicsConstantBuffer(IndexT i)
 {
-    return state.globalGraphicsConstantBuffer;
+    return state.globalGraphicsConstantBuffer[i];
 }
 
 //------------------------------------------------------------------------------
 /**
 */
 CoreGraphics::BufferId
-GetComputeConstantBuffer()
+GetComputeConstantBuffer(IndexT i)
 {
-    return state.globalComputeConstantBuffer;
+    return state.globalComputeConstantBuffer[i];
 }
 
 //------------------------------------------------------------------------------
@@ -1489,6 +1482,7 @@ GetComputeConstantBuffer()
 void
 FlushConstants(const CoreGraphics::CmdBufferId cmds, const CoreGraphics::QueueType queue)
 {
+    /*
     // Flush constants, should be the first command on the queue
     Vulkan::GraphicsDeviceState::ConstantsRingBuffer& sub = state.constantBufferRings[state.currentBufferedFrameIndex];
     CoreGraphics::BufferId buf = queue == CoreGraphics::GraphicsQueueType ? state.globalGraphicsConstantBuffer : state.globalComputeConstantBuffer;
@@ -1527,6 +1521,7 @@ FlushConstants(const CoreGraphics::CmdBufferId cmds, const CoreGraphics::QueueTy
         );
     }
     ranges.flushedStart = sub.endAddress;
+    */
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vk/vkmemory.cc
+++ b/code/render/coregraphics/vk/vkmemory.cc
@@ -231,7 +231,7 @@ AllocateMemory(const VkDevice dev, const VkBuffer& buf, MemoryPoolType type)
         flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
         break;
     case MemoryPool_DeviceAndHost:
-        flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         // Memory needs to be aligned to non coherent atom size for flushing
         req.size = Math::align(req.size, props.limits.nonCoherentAtomSize);
         req.alignment = Math::align(req.alignment, props.limits.nonCoherentAtomSize);

--- a/code/render/coregraphics/vk/vkshader.cc
+++ b/code/render/coregraphics/vk/vkshader.cc
@@ -699,6 +699,16 @@ ShaderCreateResourceTable(const CoreGraphics::ShaderId id, const IndexT group, c
 //------------------------------------------------------------------------------
 /**
 */
+const bool
+ShaderHasResourceTable(const ShaderId id, const IndexT group)
+{
+    const VkShaderSetupInfo& info = shaderAlloc.Get<Shader_SetupInfo>(id.resourceId);
+    return info.descriptorSetLayoutMap.FindIndex(group) != InvalidIndex;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
 const CoreGraphics::BufferId
 ShaderCreateConstantBuffer(const CoreGraphics::ShaderId id, const Util::StringAtom& name, CoreGraphics::BufferAccessMode mode)
 {

--- a/code/render/decals/decalcontext.cc
+++ b/code/render/decals/decalcontext.cc
@@ -110,12 +110,12 @@ DecalContext::Create()
         // update resource table
         ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
         ResourceTableSetRWBuffer(computeTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(i), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
         ResourceTableCommitChanges(computeTable);
 
         ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalIndexLists, Shared::Table_Frame::DecalIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
         ResourceTableSetRWBuffer(graphicsTable, { decalState.clusterDecalsList, Shared::Table_Frame::DecalLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(i), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 
@@ -397,9 +397,9 @@ DecalContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     CoreGraphics::ResourceTableId graphicsTable = Graphics::GetFrameResourceTableGraphics(bufferIndex);
 
     uint offset = SetConstants(decalUniforms);
-    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(bufferIndex), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(computeTable);
-    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(bufferIndex), Shared::Table_Frame::DecalUniforms::SLOT, 0, Shared::Table_Frame::DecalUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(graphicsTable);
 
     // update list of point lights

--- a/code/render/fog/volumetricfogcontext.cc
+++ b/code/render/fog/volumetricfogcontext.cc
@@ -125,12 +125,12 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
 
         ResourceTableSetRWBuffer(computeTable, { fogState.clusterFogIndexLists, Shared::Table_Frame::FogIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
         ResourceTableSetRWBuffer(computeTable, { fogState.clusterFogLists, Shared::Table_Frame::FogLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(i), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
         ResourceTableCommitChanges(computeTable);
 
         ResourceTableSetRWBuffer(graphicsTable, { fogState.clusterFogIndexLists, Shared::Table_Frame::FogIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
         ResourceTableSetRWBuffer(graphicsTable, { fogState.clusterFogLists, Shared::Table_Frame::FogLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(i), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 
@@ -473,9 +473,9 @@ VolumetricFogContext::UpdateViewDependentResources(const Ptr<Graphics::View>& vi
     CoreGraphics::ResourceTableId viewTablesGraphics = Graphics::GetFrameResourceTableGraphics(bufferIndex);
 
     uint offset = SetConstants(fogUniforms);
-    ResourceTableSetConstantBuffer(viewTablesCompute, { GetComputeConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(viewTablesCompute, { GetComputeConstantBuffer(bufferIndex), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(viewTablesCompute);
-    ResourceTableSetConstantBuffer(viewTablesGraphics, { GetGraphicsConstantBuffer(), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(viewTablesGraphics, { GetGraphicsConstantBuffer(bufferIndex), Shared::Table_Frame::VolumeFogUniforms::SLOT, 0, Shared::Table_Frame::VolumeFogUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(viewTablesGraphics);
 
     // setup blur tables

--- a/code/render/frame/frameresolve.cc
+++ b/code/render/frame/frameresolve.cc
@@ -127,7 +127,7 @@ FrameResolve::CompiledImpl::SetupConstants(const IndexT bufferIndex)
     uint offset = SetConstants(this->constants);
     ResourceTableSetConstantBuffer(this->resourceTables[bufferIndex],
                                    {
-                                       CoreGraphics::GetGraphicsConstantBuffer()
+                                       CoreGraphics::GetGraphicsConstantBuffer(bufferIndex)
                                        , Msaaresolvedepth4::Table_Batch::ResolveBlock::SLOT
                                        , Msaaresolvedepth4::Table_Batch::ResolveBlock::SIZE
                                        , (SizeT)offset

--- a/code/render/frame/framesubpassbatch.cc
+++ b/code/render/frame/framesubpassbatch.cc
@@ -63,9 +63,9 @@ FrameSubpassBatch::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
 /**
 */
 void
-FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id)
+FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id, const IndexT bufferIndex)
 {
-        // now do usual render stuff
+    // now do usual render stuff
     ShaderServer* shaderServer = ShaderServer::Instance();
     ShaderConfigServer* matServer = ShaderConfigServer::Instance();
 
@@ -142,7 +142,7 @@ FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphic
                         // Apply draw packet constants and draw
                         if (primGroup.GetNumIndices() > 0 || primGroup.GetNumVertices() > 0)
                         {
-                            instance->Apply(cmdBuf, batchIndex, shaderConfig);
+                            instance->Apply(cmdBuf, batchIndex, shaderConfig, bufferIndex);
                             CoreGraphics::CmdDraw(cmdBuf, numInstances, baseInstance, primGroup);
                         }
                     }
@@ -156,7 +156,7 @@ FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphic
 /**
 */
 void
-FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id, const SizeT numInstances, const IndexT baseInstance)
+FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id, const SizeT numInstances, const IndexT baseInstance, const IndexT bufferIndex)
 {
     // now do usual render stuff
     ShaderServer* shaderServer = ShaderServer::Instance();
@@ -229,7 +229,7 @@ FrameSubpassBatch::DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphic
                         }
 
                         // Apply draw packet constants and draw
-                        instance->Apply(cmdBuf, batchIndex, shaderConfig);
+                        instance->Apply(cmdBuf, batchIndex, shaderConfig, bufferIndex);
                         CoreGraphics::CmdDraw(cmdBuf, baseNumInstances * numInstances, baseBaseInstance + baseInstance, primGroup);
                     }
                 }
@@ -245,7 +245,7 @@ void
 FrameSubpassBatch::CompiledImpl::Run(const CoreGraphics::CmdBufferId cmdBuf, const IndexT frameIndex, const IndexT bufferIndex)
 {
     const Ptr<View>& view = Graphics::GraphicsServer::Instance()->GetCurrentView();
-    FrameSubpassBatch::DrawBatch(cmdBuf, this->batch, view->GetCamera());
+    FrameSubpassBatch::DrawBatch(cmdBuf, this->batch, view->GetCamera(), bufferIndex);
 }
 
 } // namespace Frame2

--- a/code/render/frame/framesubpassbatch.h
+++ b/code/render/frame/framesubpassbatch.h
@@ -31,9 +31,9 @@ public:
     CoreGraphics::BatchGroup::Code batch;
 
     /// Do the actual drawing
-    static void DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id);
+    static void DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id, const IndexT bufferIndex);
     /// Do the actual drawing, but with duplicate instances
-    static void DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id, const SizeT numInstances, const IndexT baseInstance);
+    static void DrawBatch(const CoreGraphics::CmdBufferId cmdBuf, CoreGraphics::BatchGroup::Code batch, const Graphics::GraphicsEntityId id, const SizeT numInstances, const IndexT baseInstance, const IndexT bufferIndex);
 };
 
 } // namespace Frame2

--- a/code/render/lighting/lightcontext.cc
+++ b/code/render/lighting/lightcontext.cc
@@ -196,12 +196,12 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
 
         ResourceTableSetRWBuffer(computeTable, { clusterState.clusterLightIndexLists, Shared::Table_Frame::LightIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
         ResourceTableSetRWBuffer(computeTable, { clusterState.clusterLightsList, Shared::Table_Frame::LightLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), 0 });
+        ResourceTableSetConstantBuffer(computeTable, { CoreGraphics::GetComputeConstantBuffer(i), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), 0 });
         ResourceTableCommitChanges(computeTable);
 
         ResourceTableSetRWBuffer(graphicsTable, { clusterState.clusterLightIndexLists, Shared::Table_Frame::LightIndexLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
         ResourceTableSetRWBuffer(graphicsTable, { clusterState.clusterLightsList, Shared::Table_Frame::LightLists::SLOT, 0, NEBULA_WHOLE_BUFFER_SIZE, 0 });
-        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), 0 });
+        ResourceTableSetConstantBuffer(graphicsTable, { CoreGraphics::GetGraphicsConstantBuffer(i), Shared::Table_Frame::LightUniforms::SLOT, 0, sizeof(LightsCluster::LightUniforms), 0 });
         ResourceTableCommitChanges(graphicsTable);
     }
 
@@ -1058,9 +1058,9 @@ LightContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     consts.NumLightClusters = Clustering::ClusterContext::GetNumClusters();
     consts.SSAOBuffer = CoreGraphics::TextureGetBindlessHandle(textureState.aoTexture);
     IndexT offset = SetConstants(consts);
-    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, Shared::Table_Frame::LightUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(computeTable, { GetComputeConstantBuffer(bufferIndex), Shared::Table_Frame::LightUniforms::SLOT, 0, Shared::Table_Frame::LightUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(computeTable);
-    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(), Shared::Table_Frame::LightUniforms::SLOT, 0, Shared::Table_Frame::LightUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(graphicsTable, { GetGraphicsConstantBuffer(bufferIndex), Shared::Table_Frame::LightUniforms::SLOT, 0, Shared::Table_Frame::LightUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(graphicsTable);
 
     TextureDimensions dims = TextureGetDimensions(textureState.lightingTexture);
@@ -1068,7 +1068,7 @@ LightContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, cons
     combineConsts.LowresResolution[0] = 1.0f / dims.width;
     combineConsts.LowresResolution[1] = 1.0f / dims.height;
     offset = SetConstants(combineConsts);
-    ResourceTableSetConstantBuffer(combineState.resourceTables[bufferIndex], { GetGraphicsConstantBuffer(), Combine::Table_Batch::CombineUniforms::SLOT, 0, Combine::Table_Batch::CombineUniforms::SIZE, (SizeT)offset });
+    ResourceTableSetConstantBuffer(combineState.resourceTables[bufferIndex], { GetGraphicsConstantBuffer(bufferIndex), Combine::Table_Batch::CombineUniforms::SLOT, 0, Combine::Table_Batch::CombineUniforms::SIZE, (SizeT)offset });
     ResourceTableCommitChanges(combineState.resourceTables[bufferIndex]);
 }
 

--- a/code/render/lighting/lightcontext.cc
+++ b/code/render/lighting/lightcontext.cc
@@ -242,7 +242,7 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
         {
             // draw it!
             int slice = shadowCasterSliceMap[lightServerState.shadowcastingLocalLights[i]];
-            Frame::FrameSubpassBatch::DrawBatch(cmdBuf, lightServerState.spotlightsBatchCode, lightServerState.shadowcastingLocalLights[i], 1, slice);
+            Frame::FrameSubpassBatch::DrawBatch(cmdBuf, lightServerState.spotlightsBatchCode, lightServerState.shadowcastingLocalLights[i], 1, slice, bufferIndex);
         }
     };
     Frame::AddSubgraph("Spotlight Shadows", { spotlightShadowsRender });
@@ -270,7 +270,7 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
             for (IndexT i = 0; i < observers.Size(); i++)
             {
                 // draw it!
-                Frame::FrameSubpassBatch::DrawBatch(cmdBuf, lightServerState.globalLightsBatchCode, observers[i], 1, i);
+                Frame::FrameSubpassBatch::DrawBatch(cmdBuf, lightServerState.globalLightsBatchCode, observers[i], 1, i, bufferIndex);
             }
         }
     };

--- a/code/render/materials/material.h
+++ b/code/render/materials/material.h
@@ -82,7 +82,7 @@ enum MaterialMembers
     Material_MinLOD,
     Material_LODTextures,
     Material_Table,
-    Material_InstanceTable,
+    Material_InstanceTables,
     Material_Buffers,
     Material_InstanceBuffers,
     Material_Textures,
@@ -95,7 +95,7 @@ typedef Ids::IdAllocator<
     float,
     Util::Array<Resources::ResourceId>,
     Util::FixedArray<CoreGraphics::ResourceTableId>,                                // surface level resource table, mapped batch -> table
-    Util::FixedArray<CoreGraphics::ResourceTableId>,                                // instance level resource table, mapped batch -> table
+    Util::FixedArray<Util::FixedArray<CoreGraphics::ResourceTableId>>,              // instance level resource table, mapped batch -> table
     Util::FixedArray<Util::Array<Util::Tuple<IndexT, CoreGraphics::BufferId>>>,     // surface level constant buffers, mapped batch -> buffers
     Util::FixedArray<Util::Tuple<IndexT, SizeT>>,                                   // instance level instance buffer, mapped batch -> memory + size
     Util::FixedArray<Util::Array<MaterialTexture>>,                                 // textures
@@ -111,7 +111,7 @@ void DestroyMaterialInstance(const MaterialInstanceId materialInstance);
 /// Allocate instance constants, call per frame when instance constants are needed
 CoreGraphics::ConstantBufferOffset MaterialInstanceAllocate(const MaterialInstanceId mat, const BatchIndex batch);
 /// Apply material instance
-void MaterialInstanceApply(const MaterialInstanceId id, const CoreGraphics::CmdBufferId buf, IndexT index);
+void MaterialInstanceApply(const MaterialInstanceId id, const CoreGraphics::CmdBufferId buf, IndexT index, IndexT bufferIndex);
 
 
 /// Get material instance buffer size for batch

--- a/code/render/models/modelcontext.cc
+++ b/code/render/models/modelcontext.cc
@@ -145,7 +145,7 @@ ModelContext::Setup(const Graphics::GraphicsEntityId gfxId, const Resources::Res
             state.objectConstantsIndex = sNode->objectTransformsIndex;
             state.skinningConstantsIndex = sNode->skinningTransformsIndex;
             state.particleConstantsIndex = InvalidIndex;
-            state.resourceTable = sNode->resourceTable;
+            state.resourceTables = sNode->resourceTables;
 
             // Okay, so how this basically has to work is that there are 4 different dynamic offset constant indices in the entire engine.
             // Any change of this will break this code, so consider improving this in the future by providing a way to overload the binding point

--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -92,7 +92,7 @@ public:
      
     struct NodeInstanceState
     {
-        CoreGraphics::ResourceTableId resourceTable;
+        Util::FixedArray<CoreGraphics::ResourceTableId> resourceTables;
         Materials::MaterialInstanceId materialInstance;
         Util::FixedArray<uint32_t> resourceTableOffsets;
         IndexT objectConstantsIndex;

--- a/code/render/models/nodes/characterskinnode.cc
+++ b/code/render/models/nodes/characterskinnode.cc
@@ -75,9 +75,12 @@ CharacterSkinNode::OnFinishedLoading()
 {
     PrimitiveNode::OnFinishedLoading();
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderServer::Instance()->GetShader("shd:objects_shared.fxb"_atm);
-    CoreGraphics::BufferId cbo = CoreGraphics::GetGraphicsConstantBuffer();
-    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, ObjectsShared::Table_DynamicOffset::JointBlock::SLOT, 0, (SizeT)(sizeof(Math::mat4) * this->skinFragments[0].jointPalette.Size()), 0, false, true });
-    CoreGraphics::ResourceTableCommitChanges(this->resourceTable);
+    SizeT numFrames = CoreGraphics::GetNumBufferedFrames();
+    for (IndexT i = 0; i < numFrames; i++)
+    {
+        CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTables[i], { CoreGraphics::GetGraphicsConstantBuffer(i), ObjectsShared::Table_DynamicOffset::JointBlock::SLOT, 0, (SizeT)(sizeof(Math::mat4) * this->skinFragments[0].jointPalette.Size()), 0, false, true });
+        CoreGraphics::ResourceTableCommitChanges(this->resourceTables[i]);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/models/nodes/particlesystemnode.cc
+++ b/code/render/models/nodes/particlesystemnode.cc
@@ -95,14 +95,18 @@ ParticleSystemNode::OnFinishedLoading()
     this->emitterMesh.Setup(this->mesh, this->primGroupIndex);
 
     ShaderId shader = ShaderServer::Instance()->GetShader("shd:particle.fxb"_atm);
-    BufferId cbo = GetGraphicsConstantBuffer();
     this->objectTransformsIndex = ::Particle::Table_DynamicOffset::ObjectBlock::SLOT;
     this->instancingTransformsIndex = ::Particle::Table_DynamicOffset::InstancingBlock::SLOT;
     this->skinningTransformsIndex = ::Particle::Table_DynamicOffset::JointBlock::SLOT;
     this->particleConstantsIndex = ::Particle::Table_DynamicOffset::ParticleObjectBlock::SLOT;
-    this->resourceTable = ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
-    ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->particleConstantsIndex, 0, sizeof(::Particle::ParticleObjectBlock), 0, false, true });
-    ResourceTableCommitChanges(this->resourceTable);
+    SizeT numFrames = CoreGraphics::GetNumBufferedFrames();
+    this->resourceTables.Resize(CoreGraphics::GetNumBufferedFrames());
+    for (IndexT i = 0; i < numFrames; i++)
+    {
+        this->resourceTables[i] = CoreGraphics::ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
+        CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTables[i], { CoreGraphics::GetGraphicsConstantBuffer(i), this->particleConstantsIndex, 0, sizeof(::Particle::ParticleObjectBlock), 0, false, true });
+        CoreGraphics::ResourceTableCommitChanges(this->resourceTables[i]);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/models/nodes/shaderstatenode.cc
+++ b/code/render/models/nodes/shaderstatenode.cc
@@ -163,11 +163,11 @@ ShaderStateNode::OnFinishedLoading()
 /**
 */
 void
-ShaderStateNode::DrawPacket::Apply(const CoreGraphics::CmdBufferId cmdBuf, IndexT batchIndex, Materials::ShaderConfig* type)
+ShaderStateNode::DrawPacket::Apply(const CoreGraphics::CmdBufferId cmdBuf, IndexT batchIndex, Materials::ShaderConfig* type, IndexT bufferIndex)
 {
     // Apply per-draw surface parameters
     if (this->materialInstance != Materials::MaterialInstanceId::Invalid())
-        MaterialInstanceApply(this->materialInstance, cmdBuf, batchIndex);
+        MaterialInstanceApply(this->materialInstance, cmdBuf, batchIndex, bufferIndex);
 
     // Set per-draw resource tables
     IndexT prevOffset = 0;

--- a/code/render/models/nodes/shaderstatenode.cc
+++ b/code/render/models/nodes/shaderstatenode.cc
@@ -128,7 +128,8 @@ ShaderStateNode::Unload()
     Resources::DiscardResource(this->materialRes);
 
     // destroy table and constant buffer
-    CoreGraphics::DestroyResourceTable(this->resourceTable);
+    for (auto table : this->resourceTables)
+        CoreGraphics::DestroyResourceTable(table);
 }
 
 //------------------------------------------------------------------------------
@@ -144,14 +145,18 @@ ShaderStateNode::OnFinishedLoading()
     this->material = this->materialRes;
     this->sortCode = MaterialGetSortCode(this->material);
     CoreGraphics::ShaderId shader = CoreGraphics::ShaderServer::Instance()->GetShader("shd:objects_shared.fxb"_atm);
-    CoreGraphics::BufferId cbo = CoreGraphics::GetGraphicsConstantBuffer();
     this->objectTransformsIndex = ObjectsShared::Table_DynamicOffset::ObjectBlock::SLOT;
     this->instancingTransformsIndex = ObjectsShared::Table_DynamicOffset::InstancingBlock::SLOT;
     this->skinningTransformsIndex = ObjectsShared::Table_DynamicOffset::JointBlock::SLOT;
 
-    this->resourceTable = CoreGraphics::ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
-    CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTable, { cbo, this->objectTransformsIndex, 0, sizeof(ObjectsShared::ObjectBlock), 0, false, true });
-    CoreGraphics::ResourceTableCommitChanges(this->resourceTable);
+    SizeT numFrames = CoreGraphics::GetNumBufferedFrames();
+    this->resourceTables.Resize(CoreGraphics::GetNumBufferedFrames());
+    for (IndexT i = 0; i < numFrames; i++)
+    {
+        this->resourceTables[i] = CoreGraphics::ShaderCreateResourceTable(shader, NEBULA_DYNAMIC_OFFSET_GROUP, 256);
+        CoreGraphics::ResourceTableSetConstantBuffer(this->resourceTables[i], { CoreGraphics::GetGraphicsConstantBuffer(i), this->objectTransformsIndex, 0, sizeof(ObjectsShared::ObjectBlock), 0, false, true });
+        CoreGraphics::ResourceTableCommitChanges(this->resourceTables[i]);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/models/nodes/shaderstatenode.h
+++ b/code/render/models/nodes/shaderstatenode.h
@@ -46,7 +46,7 @@ public:
 #endif
 
         /// Apply the resource table
-        void Apply(const CoreGraphics::CmdBufferId cmdBuf, IndexT batchIndex, Materials::ShaderConfig* type);
+        void Apply(const CoreGraphics::CmdBufferId cmdBuf, IndexT batchIndex, Materials::ShaderConfig* type, IndexT bufferIndex);
     };
 
     /// get surface

--- a/code/render/models/nodes/shaderstatenode.h
+++ b/code/render/models/nodes/shaderstatenode.h
@@ -76,7 +76,7 @@ protected:
     uint8_t instancingTransformsIndex;
     uint8_t skinningTransformsIndex;
 
-    CoreGraphics::ResourceTableId resourceTable;
+    Util::FixedArray<CoreGraphics::ResourceTableId> resourceTables;
 };
 
 } // namespace Models

--- a/code/render/posteffects/ssaocontext.cc
+++ b/code/render/posteffects/ssaocontext.cc
@@ -28,7 +28,6 @@ struct
 
     Util::FixedArray<CoreGraphics::ResourceTableId> hbaoTable, blurTableX, blurTableY;
     //CoreGraphics::ResourceTableId hbaoTable, blurTableX, blurTableY;
-    CoreGraphics::BufferId hbaoConstants, blurConstants;
 
     IndexT uvToViewAVar, uvToViewBVar, r2Var,
         aoResolutionVar, invAOResolutionVar, strengthVar, tanAngleBiasVar,
@@ -134,9 +133,6 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
     ssaoState.yDirectionHBAO = ShaderGetProgram(ssaoState.hbaoShader, ShaderFeatureFromString("Alt1"));
     ssaoState.xDirectionBlur = ShaderGetProgram(ssaoState.blurShader, ShaderFeatureFromString("Alt0"));
     ssaoState.yDirectionBlur = ShaderGetProgram(ssaoState.blurShader, ShaderFeatureFromString("Alt1"));
-
-    ssaoState.hbaoConstants = CoreGraphics::GetGraphicsConstantBuffer();
-    ssaoState.blurConstants = CoreGraphics::GetGraphicsConstantBuffer();
 
     ssaoState.ssaoOutput = script->GetTexture("SSAOBuffer");
     ssaoState.zBuffer = script->GetTexture("ZBuffer");
@@ -370,7 +366,7 @@ SSAOContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, const
 
     IndexT bufferIndex = CoreGraphics::GetBufferedFrameIndex();
 
-    ResourceTableSetConstantBuffer(ssaoState.hbaoTable[bufferIndex], { ssaoState.hbaoConstants, HbaoCs::Table_Batch::HBAOBlock::SLOT, 0, HbaoCs::Table_Batch::HBAOBlock::SIZE, (SizeT)hbaoOffset });
+    ResourceTableSetConstantBuffer(ssaoState.hbaoTable[bufferIndex], { CoreGraphics::GetGraphicsConstantBuffer(bufferIndex), HbaoCs::Table_Batch::HBAOBlock::SLOT, 0, HbaoCs::Table_Batch::HBAOBlock::SIZE, (SizeT)hbaoOffset });
     ResourceTableCommitChanges(ssaoState.hbaoTable[bufferIndex]);
 
     HbaoblurCs::HBAOBlur blurBlock;
@@ -379,8 +375,8 @@ SSAOContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, const
     blurBlock.PowerExponent = 1.5f;
     uint blurOffset = CoreGraphics::SetConstants(blurBlock);
 
-    ResourceTableSetConstantBuffer(ssaoState.blurTableX[bufferIndex], { ssaoState.blurConstants, HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
-    ResourceTableSetConstantBuffer(ssaoState.blurTableY[bufferIndex], { ssaoState.blurConstants, HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
+    ResourceTableSetConstantBuffer(ssaoState.blurTableX[bufferIndex], { CoreGraphics::GetGraphicsConstantBuffer(bufferIndex), HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
+    ResourceTableSetConstantBuffer(ssaoState.blurTableY[bufferIndex], { CoreGraphics::GetGraphicsConstantBuffer(bufferIndex), HbaoblurCs::Table_Batch::HBAOBlur::SLOT, 0, HbaoblurCs::Table_Batch::HBAOBlur::SIZE, (SizeT)blurOffset });
     ResourceTableCommitChanges(ssaoState.blurTableX[bufferIndex]);
     ResourceTableCommitChanges(ssaoState.blurTableY[bufferIndex]);
 }

--- a/code/render/posteffects/ssrcontext.cc
+++ b/code/render/posteffects/ssrcontext.cc
@@ -29,8 +29,6 @@ struct
     CoreGraphics::ShaderProgramId traceProgram;
     CoreGraphics::ShaderProgramId resolveProgram;
 
-    CoreGraphics::BufferId constants;
-
     CoreGraphics::TextureId traceBuffer;
     CoreGraphics::TextureId reflectionBuffer;
 } ssrState;
@@ -121,7 +119,6 @@ SSRContext::Setup(const Ptr<Frame::FrameScript>& script)
 
     // create trace shader
     ssrState.traceShader = ShaderGet("shd:ssr_cs.fxb");
-    ssrState.constants = CoreGraphics::GetGraphicsConstantBuffer();
 
     ssrState.ssrTraceTables.SetSize(numFrames);
     for (IndexT i = 0; i < numFrames; ++i)
@@ -180,7 +177,7 @@ SSRContext::UpdateViewDependentResources(const Ptr<Graphics::View>& view, const 
 
     IndexT bufferIndex = CoreGraphics::GetBufferedFrameIndex();
 
-    ResourceTableSetConstantBuffer(ssrState.ssrTraceTables[bufferIndex], { ssrState.constants, SsrCs::Table_Batch::SSRBlock::SLOT, 0, SsrCs::Table_Batch::SSRBlock::SIZE, (SizeT)ssrOffset });
+    ResourceTableSetConstantBuffer(ssrState.ssrTraceTables[bufferIndex], { CoreGraphics::GetGraphicsConstantBuffer(bufferIndex), SsrCs::Table_Batch::SSRBlock::SLOT, 0, SsrCs::Table_Batch::SSRBlock::SIZE, (SizeT)ssrOffset });
     ResourceTableCommitChanges(ssrState.ssrTraceTables[bufferIndex]);
 }
 

--- a/code/render/terrain/terraincontext.h
+++ b/code/render/terrain/terraincontext.h
@@ -155,7 +155,7 @@ private:
         Resources::ResourceId normalMap;
         Resources::ResourceId decisionMap;
 
-        CoreGraphics::ResourceTableId patchTable;
+        Util::FixedArray<CoreGraphics::ResourceTableId> patchTables;
 
         CoreGraphics::BufferId vbo;
         CoreGraphics::BufferId ibo;

--- a/code/render/visibility/visibilitycontext.cc
+++ b/code/render/visibility/visibilitycontext.cc
@@ -354,7 +354,7 @@ ObserverContext::RunVisibilityTests(const Graphics::FrameContext& ctx)
                 Models::ShaderStateNode::DrawPacket* packet = reinterpret_cast<Models::ShaderStateNode::DrawPacket*>(mem);
                 packet->numOffsets[0] = context->renderables->nodeStates[index].resourceTableOffsets.Size();
                 packet->numTables = 1;
-                packet->tables[0] = context->renderables->nodeStates[index].resourceTable;
+                packet->tables[0] = context->renderables->nodeStates[index].resourceTables[CoreGraphics::GetBufferedFrameIndex()];
                 packet->materialInstance = context->renderables->nodeStates[index].materialInstance;
 #ifndef PUBLIC_BUILD
                 packet->boundingBox = context->renderables->nodeBoundingBoxes[index];


### PR DESCRIPTION
Make use of Resizable BAR (nvidia) or SAM (AMD) for constants. On mobile GPUs, this would be simple shared memory. 

Changes all resource tables to setup one per frame if they need to use the per-frame constants. Also deletes the staging constant buffers (meaning we save 1 global constant buffer in memory). 