### PR TITLE
Optimize updating the material with the lowest LOD.

### DIFF
--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -118,6 +118,7 @@ public:
             Util::Array<Math::bbox> nodeBoundingBoxes;
             Util::Array<Util::Tuple<float, float>> nodeLodDistances;
             Util::Array<float> nodeLods;
+            Util::Array<float> textureLods;
             Util::Array<uint32> nodeTransformIndex;
             Util::Array<uint64> nodeSortId;
             Util::Array<NodeInstanceFlags> nodeFlags;


### PR DESCRIPTION
Previously we would spam this function which has to lock the material to avoid multiple objects writing to the same value. To prevent that, objects will only request another LOD if they haven't been closer before.