### PR TITLE
Fix validation issues

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -198,7 +198,7 @@ UltralightRenderer::UpdateTexture(uint32_t texture_id, ultralight::Ref<ultraligh
                             CoreGraphics::TextureBarrierInfo
                             {
                                 storage.tex,
-                                CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                CoreGraphics::TextureSubresourceInfo::Color(storage.tex)
                             }
                         });
     CoreGraphics::CmdCopy(setupCmd, tempBuf, { from }, storage.tex, { to });
@@ -207,7 +207,7 @@ UltralightRenderer::UpdateTexture(uint32_t texture_id, ultralight::Ref<ultraligh
                             CoreGraphics::TextureBarrierInfo
                             {
                                 storage.tex,
-                                CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                CoreGraphics::TextureSubresourceInfo::Color(storage.tex)
                             }
                         });
 

--- a/code/render/coregraphics/barrier.h
+++ b/code/render/coregraphics/barrier.h
@@ -22,7 +22,7 @@ ID_24_8_TYPE(BarrierId);
 struct CmdBufferId;
 struct TextureSubresourceInfo
 {
-    CoreGraphics::ImageBits bits;
+    ImageBits bits;
     uint mip, mipCount, layer, layerCount;
 
     TextureSubresourceInfo() :
@@ -41,29 +41,44 @@ struct TextureSubresourceInfo
         layerCount(layerCount)
     {}
 
+    static TextureSubresourceInfo Texture(CoreGraphics::ImageBits bits, TextureId tex)
+    {
+        return TextureSubresourceInfo(bits, 0, TextureGetNumMips(tex), 0, TextureGetNumLayers(tex));
+    }
+
+    static TextureSubresourceInfo Color(TextureId tex)
+    {
+        return TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(tex), 0, TextureGetNumLayers(tex));
+    }
+
+    static TextureSubresourceInfo DepthStencil(TextureId tex)
+    {
+        return TextureSubresourceInfo(ImageBits::DepthBits | ImageBits::StencilBits, 0, TextureGetNumMips(tex), 0, TextureGetNumLayers(tex));
+    }
+
     static TextureSubresourceInfo ColorNoMipNoLayer()
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, 0, 1, 0, 1);
+        return TextureSubresourceInfo(ImageBits::ColorBits, 0, 1, 0, 1);
     }
 
     static TextureSubresourceInfo ColorNoMip(uint layerCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, 0, 1, 0, layerCount);
+        return TextureSubresourceInfo(ImageBits::ColorBits, 0, 1, 0, layerCount);
     }
 
     static TextureSubresourceInfo ColorNoLayer(uint mipCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageBits::ColorBits, 0, mipCount, 0, 1);
+        return TextureSubresourceInfo(ImageBits::ColorBits, 0, mipCount, 0, 1);
     }
 
     static TextureSubresourceInfo DepthStencilNoMipNoLayer()
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits, 0, 1, 0, 1);
+        return TextureSubresourceInfo(ImageBits::DepthBits | ImageBits::StencilBits, 0, 1, 0, 1);
     }
 
     static TextureSubresourceInfo DepthStencilNoMip(uint layerCount)
     {
-        return TextureSubresourceInfo(CoreGraphics::ImageBits::DepthBits | CoreGraphics::ImageBits::StencilBits, 0, 1, 0, layerCount);
+        return TextureSubresourceInfo(ImageBits::DepthBits | ImageBits::StencilBits, 0, 1, 0, layerCount);
     }
 
     static TextureSubresourceInfo DepthStencilNoLayer(uint mipCount)

--- a/code/render/coregraphics/texture.cc
+++ b/code/render/coregraphics/texture.cc
@@ -41,7 +41,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
         {
             {
                 id,
-                CoreGraphics::TextureSubresourceInfo{ ImageBits::ColorBits, 0, (uint)numMips, 0, 1 },
+                CoreGraphics::TextureSubresourceInfo::Texture(ImageBits::ColorBits, id),
             },
         });
 
@@ -111,7 +111,7 @@ TextureGenerateMipmaps(const CoreGraphics::CmdBufferId cmdBuf, const TextureId i
             CoreGraphics::TextureBarrierInfo
             {
                 id,
-                CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, mip, 1, 0, 1),
+                CoreGraphics::TextureSubresourceInfo::Texture(ImageBits::ColorBits, id)
             }
         },
         nullptr);

--- a/code/render/fog/volumetricfogcontext.cc
+++ b/code/render/fog/volumetricfogcontext.cc
@@ -216,13 +216,13 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "Fog Volume Texture 0"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(fogState.fogVolumeTexture0)
                                 });
     fogCompute->textureDeps.Add(fogState.zBuffer,
                                 {
                                     "ZBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::TextureSubresourceInfo::DepthStencilNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::DepthStencil(fogState.zBuffer)
                                 });
     fogCompute->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -242,13 +242,13 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "Fog Volume Texture 0"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(fogState.fogVolumeTexture0)
                                 });
     blurX->textureDeps.Add(fogState.fogVolumeTexture1,
                                 {
                                     "Fog Volume Texture 1"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(fogState.fogVolumeTexture1)
                                 });
     blurX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -266,13 +266,13 @@ VolumetricFogContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "Fog Volume Texture 1"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(fogState.fogVolumeTexture1)
                                 });
     blurY->textureDeps.Add(fogState.fogVolumeTexture0,
                                 {
                                     "Fog Volume Texture 0"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(fogState.fogVolumeTexture0)
                                 });
     blurY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/lighting/lightcontext.cc
+++ b/code/render/lighting/lightcontext.cc
@@ -337,25 +337,25 @@ LightContext::Create(const Ptr<Frame::FrameScript>& frameScript)
                                 {
                                     "LightBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderWrite
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(textureState.lightingTexture)
                                 });
     lightsCombine->textureDeps.Add(textureState.aoTexture,
                                {
                                    "SSAOBuffer"
                                    , CoreGraphics::PipelineStage::ComputeShaderRead
-                                   , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                   , CoreGraphics::TextureSubresourceInfo::Color(textureState.aoTexture)
                                });
     lightsCombine->textureDeps.Add(textureState.fogTexture,
                                 {
                                     "VolumeFogBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(textureState.fogTexture)
                                 });
     lightsCombine->textureDeps.Add(textureState.reflectionTexture,
                                 {
                                     "ReflectionBuffer"
                                     , CoreGraphics::PipelineStage::ComputeShaderRead
-                                    , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                                    , CoreGraphics::TextureSubresourceInfo::Color(textureState.reflectionTexture)
                                 });
     lightsCombine->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/posteffects/bloomcontext.cc
+++ b/code/render/posteffects/bloomcontext.cc
@@ -108,14 +108,14 @@ BloomContext::Setup(const Ptr<Frame::FrameScript>& script)
         {
             "LightBuffer"
             , PipelineStage::ComputeShaderRead
-            , TextureSubresourceInfo::ColorNoLayer(mips)
+            , TextureSubresourceInfo::Color(bloomState.lightBuffer)
         });
     upscale->textureDeps.Add(
         bloomState.bloomBuffer,
         {
             "BloomBuffer"
             , PipelineStage::ComputeShaderWrite
-            , TextureSubresourceInfo::ColorNoMipNoLayer()
+            , TextureSubresourceInfo::Color(bloomState.bloomBuffer)
         });
     upscale->func = [](const CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/posteffects/downsamplingcontext.cc
+++ b/code/render/posteffects/downsamplingcontext.cc
@@ -218,7 +218,7 @@ DownsamplingContext::Setup(const Ptr<Frame::FrameScript>& script)
                                         {
                                              "LightBuffer"
                                              , PipelineStage::ComputeShaderWrite
-                                             , TextureSubresourceInfo::ColorNoMipNoLayer()
+                                             , TextureSubresourceInfo::Color(state.lightBuffer)
                                         });
 
     colorDownsamplePass->func = [](const CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
@@ -240,7 +240,7 @@ DownsamplingContext::Setup(const Ptr<Frame::FrameScript>& script)
                                         {
                                              "DepthBuffer"
                                              , PipelineStage::ComputeShaderWrite
-                                             , TextureSubresourceInfo::DepthStencilNoMipNoLayer()
+                                             , TextureSubresourceInfo::DepthStencil(state.depthBuffer)
                                         });
 
     depthDownsamplePass->func = [](const CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)

--- a/code/render/posteffects/ssaocontext.cc
+++ b/code/render/posteffects/ssaocontext.cc
@@ -123,7 +123,6 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
     ssaoState.internalTargets[0] = CreateTexture(tinfo);
     tinfo.name = "HBAO-Internal1";
     ssaoState.internalTargets[1] = CreateTexture(tinfo);
-    TextureSubresourceInfo subres = TextureSubresourceInfo::ColorNoMipNoLayer();
 
     // setup shaders
     ssaoState.hbaoShader = ShaderGet("shd:hbao_cs.fxb");
@@ -196,13 +195,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "ZBuffer"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::TextureSubresourceInfo::DepthStencilNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::DepthStencil(ssaoState.zBuffer)
                          });
     aoX->textureDeps.Add(ssaoState.internalTargets[0],
                          {
                             "SSAOBuffer0"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[0])
                          });
     aoX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -222,13 +221,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "SSAOBuffer0"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[0])
                          });
     aoY->textureDeps.Add(ssaoState.internalTargets[1],
                          {
                             "SSAOBuffer1"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[1])
                          });
     aoY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -248,13 +247,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "SSAOBuffer1"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[1])
                          });
     blurX->textureDeps.Add(ssaoState.internalTargets[0],
                          {
                             "SSAOBuffer0"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[0])
                          });
     blurX->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -274,13 +273,13 @@ SSAOContext::Setup(const Ptr<Frame::FrameScript>& script)
                          {
                             "SSAOBuffer1"
                             , CoreGraphics::PipelineStage::ComputeShaderRead
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[0])
                          });
     blurY->textureDeps.Add(ssaoState.ssaoOutput,
                          {
                             "SSAOOutput"
                             , CoreGraphics::PipelineStage::ComputeShaderWrite
-                            , CoreGraphics::TextureSubresourceInfo::ColorNoMipNoLayer()
+                            , CoreGraphics::TextureSubresourceInfo::Color(ssaoState.internalTargets[1])
                          });
     blurY->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -636,13 +636,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                                 {
                                     "Indirection Texture",
                                     CoreGraphics::PipelineStage::TransferWrite,
-                                    CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
+                                    CoreGraphics::TextureSubresourceInfo::Color(terrainVirtualTileState.indirectionTexture)
                                 });
     terrainPrepare->textureDeps.Add(terrainVirtualTileState.indirectionTextureCopy,
                                 {
                                     "Indirection Texture Copy",
                                     CoreGraphics::PipelineStage::TransferRead,
-                                    CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
+                                    CoreGraphics::TextureSubresourceInfo::Color(terrainVirtualTileState.indirectionTextureCopy)
                                 });
     terrainPrepare->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -760,13 +760,13 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Indirection Texture",
                                 CoreGraphics::PipelineStage::TransferRead,
-                                CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTexture), 0, 1)
+                                CoreGraphics::TextureSubresourceInfo::Color(terrainVirtualTileState.indirectionTexture)
                             });
     indirectionCopy->textureDeps.Add(terrainVirtualTileState.indirectionTextureCopy,
                             {
                                 "Indirection Texture Copy",
                                 CoreGraphics::PipelineStage::TransferWrite,
-                                CoreGraphics::TextureSubresourceInfo(ImageBits::ColorBits, 0, TextureGetNumMips(terrainVirtualTileState.indirectionTextureCopy), 0, 1)
+                                CoreGraphics::TextureSubresourceInfo::Color(terrainVirtualTileState.indirectionTextureCopy)
                             });
     indirectionCopy->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -904,19 +904,19 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::ColorWrite,
-                                TextureSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::Color(terrainVirtualTileState.physicalAlbedoCache)
                             });
     cacheUpdate->textureDeps.Add(terrainVirtualTileState.physicalMaterialCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::ColorWrite,
-                                TextureSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::Color(terrainVirtualTileState.physicalMaterialCache)
                             });
     cacheUpdate->textureDeps.Add(terrainVirtualTileState.physicalNormalCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::ColorWrite,
-                                TextureSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::Color(terrainVirtualTileState.physicalNormalCache)
                             });
     cacheUpdate->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
@@ -1010,25 +1010,25 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::PixelShaderRead,
-                                TextureSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::Color(terrainVirtualTileState.physicalAlbedoCache)
                             });
     screenSpace->textureDeps.Add(terrainVirtualTileState.physicalMaterialCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::PixelShaderRead,
-                                TextureSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::Color(terrainVirtualTileState.physicalMaterialCache)
                             });
     screenSpace->textureDeps.Add(terrainVirtualTileState.physicalNormalCache,
                             {
                                 "Terrain Albedo Cache",
                                 CoreGraphics::PipelineStage::PixelShaderRead,
-                                TextureSubresourceInfo::ColorNoMipNoLayer()
+                                TextureSubresourceInfo::Color(terrainVirtualTileState.physicalNormalCache)
                             });
     screenSpace->textureDeps.Add(terrainVirtualTileState.indirectionTexture,
                         {
                             "Indirection Texture",
                             CoreGraphics::PipelineStage::PixelShaderRead,
-                            TextureSubresourceInfo::ColorNoLayer(CoreGraphics::TextureGetNumMips(terrainVirtualTileState.indirectionTexture))
+                            TextureSubresourceInfo::Color(terrainVirtualTileState.indirectionTexture)
                         });
     screenSpace->func = [](const CoreGraphics::CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {

--- a/work/frame/win32/vkdefault.json
+++ b/work/frame/win32/vkdefault.json
@@ -66,7 +66,7 @@
                 "name": "BloomBuffer",
                 "format": "R11G11B10F",
                 "relative": true,
-                "usage": "Render|TransferSource",
+                "usage": "Render|TransferSource|ReadWrite",
                 "width": 1.0,
                 "height": 1.0,
                 "type": "Texture2D"
@@ -122,7 +122,7 @@
                 "format": "D32S8",
                 "mips": "auto",
                 "relative": true,
-                "usage": "TransferDestination|Sample",
+                "usage": "TransferDestination|Sample|ReadWrite",
                 "width": 1.0,
                 "height": 1.0,
                 "type": "Texture2D"


### PR DESCRIPTION
Fixes validation issues with new bloom, where textures didn't sync their entire mip chains. This is also future proofed by changing the way image barriers are setup, which instead of taking a mip count and layer count, reads it from the texture. 