### PR TITLE
Enable parallel custom build commands for cmake 

### DIFF
--- a/fips-include.cmake
+++ b/fips-include.cmake
@@ -1,4 +1,9 @@
 fips_ide_group(nebula)
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+cmake_policy(SET CMP0147 NEW)
+endif()
+
 SET(NROOT ${CMAKE_CURRENT_LIST_DIR})
 SET(CODE_ROOT ${CMAKE_CURRENT_LIST_DIR}/code)
 


### PR DESCRIPTION
starting with cmake 3.27 it supports the BuildInParallel feature for custom build steps