### PR TITLE
New API for creating pipelines directly on the graphics device

### DIFF
--- a/code/addons/dynui/imguicontext.h
+++ b/code/addons/dynui/imguicontext.h
@@ -13,6 +13,7 @@
 #include "coregraphics/buffer.h"
 #include "coregraphics/resourcetable.h"
 #include "input/inputevent.h"
+#include "coregraphics/pipeline.h"
 #include "graphics/graphicscontext.h"
 #include "coregraphics/vertexlayout.h"
 #include "imguiinputhandler.h"
@@ -69,6 +70,7 @@ public:
         ImguiRendererParams params;
         CoreGraphics::ShaderId uiShader;
         CoreGraphics::ShaderProgramId prog;
+        CoreGraphics::PipelineId pipeline;
 
         ImguiTextureId fontTexture;
         //CoreGraphics::TextureId fontTexture;

--- a/code/render/CMakeLists.txt
+++ b/code/render/CMakeLists.txt
@@ -156,6 +156,7 @@ ENDIF()
                 meshresource.h
                 nvx3fileformatstructs.h
                 pass.h
+                pipeline.h
                 pixelformat.cc
                 pixelformat.h
                 primitivegroup.h
@@ -301,6 +302,8 @@ ENDIF()
                 vkmemory.h
                 vkpass.cc
                 vkpass.h
+                vkpipeline.cc
+                vkpipeline.h
                 vkpipelinedatabase.cc
                 vkpipelinedatabase.h
                 vkresourcetable.cc

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -28,6 +28,7 @@ struct ShaderProgramId;
 struct BarrierId;
 struct EventId;
 struct PassId;
+struct PipelineId;
 
 struct TextureBarrierInfo;
 struct BufferBarrierInfo;
@@ -177,6 +178,8 @@ void CmdPushGraphicsConstants(const CmdBufferId id, uint offset, uint size, cons
 void CmdPushComputeConstants(const CmdBufferId id, uint offset, uint size, const void* data);
 /// Create (if necessary) and bind pipeline based on state thus far
 void CmdSetGraphicsPipeline(const CmdBufferId id);
+/// Set graphics pipeline directly
+void CmdSetGraphicsPipeline(const CmdBufferId buf, PipelineId pipeline);
 
 /// Insert pipeline barrier
 void CmdBarrier(

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -48,13 +48,12 @@ enum class CmdPipelineBuildBits : uint
 {
     NoInfoSet = 0,
     ShaderInfoSet = N_BIT(0),
-    VertexLayoutInfoSet = N_BIT(1),
-    FramebufferLayoutInfoSet = N_BIT(2),
-    InputLayoutInfoSet = N_BIT(3),
+    FramebufferLayoutInfoSet = N_BIT(1),
+    InputAssemblyInfoSet = N_BIT(2),
 
-    AllInfoSet = ShaderInfoSet | VertexLayoutInfoSet | FramebufferLayoutInfoSet | InputLayoutInfoSet,
+    AllInfoSet = ShaderInfoSet | FramebufferLayoutInfoSet | InputAssemblyInfoSet,
 
-    PipelineBuilt = N_BIT(4)
+    PipelineBuilt = N_BIT(3)
 };
 
 __ImplementEnumBitOperators(CmdPipelineBuildBits);
@@ -179,7 +178,7 @@ void CmdPushComputeConstants(const CmdBufferId id, uint offset, uint size, const
 /// Create (if necessary) and bind pipeline based on state thus far
 void CmdSetGraphicsPipeline(const CmdBufferId id);
 /// Set graphics pipeline directly
-void CmdSetGraphicsPipeline(const CmdBufferId buf, PipelineId pipeline);
+void CmdSetGraphicsPipeline(const CmdBufferId buf, const PipelineId pipeline);
 
 /// Insert pipeline barrier
 void CmdBarrier(

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -72,13 +72,6 @@ struct SubmissionWaitEvent
     CoreGraphics::QueueType queue;
 };
 
-#if __VULKAN__
-struct PipelineId
-{
-    VkPipeline pipeline;
-};
-#endif
-
 struct GraphicsDeviceState
 {
     Util::Array<CoreGraphics::TextureId> backBuffers;

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -88,6 +88,7 @@ struct GraphicsDeviceState
     Util::FixedArray<CoreGraphics::BufferId> globalGraphicsConstantBuffer;
     Util::FixedArray<CoreGraphics::BufferId> globalComputeConstantBuffer;
 
+
     CoreGraphics::ResourceTableId tickResourceTableGraphics;
     CoreGraphics::ResourceTableId tickResourceTableCompute;
     CoreGraphics::ResourceTableId frameResourceTableGraphics;
@@ -236,14 +237,6 @@ const CoreGraphics::BufferId GetUploadBuffer();
 
 /// trigger reloading a shader
 void ReloadShaderProgram(const CoreGraphics::ShaderProgramId& pro);
-
-/// Create pipeline
-CoreGraphics::PipelineId CreatePipeline(
-    const CoreGraphics::PassId pass
-    , uint subpass
-    , CoreGraphics::ShaderProgramId program
-    , const CoreGraphics::InputAssemblyKey inputAssembly
-);
 
 /// wait for an individual queue to finish
 void WaitForQueue(CoreGraphics::QueueType queue);

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -72,6 +72,13 @@ struct SubmissionWaitEvent
     CoreGraphics::QueueType queue;
 };
 
+#if __VULKAN__
+struct PipelineId
+{
+    VkPipeline pipeline;
+};
+#endif
+
 struct GraphicsDeviceState
 {
     Util::Array<CoreGraphics::TextureId> backBuffers;
@@ -236,6 +243,15 @@ const CoreGraphics::BufferId GetUploadBuffer();
 
 /// trigger reloading a shader
 void ReloadShaderProgram(const CoreGraphics::ShaderProgramId& pro);
+
+/// Create pipeline
+CoreGraphics::PipelineId CreatePipeline(
+    const CoreGraphics::PassId pass
+    , uint subpass
+    , CoreGraphics::ShaderProgramId program
+    , CoreGraphics::InputAssemblyKey inputAssembly
+    , CoreGraphics::VertexLayoutId vertexLayout
+);
 
 /// wait for an individual queue to finish
 void WaitForQueue(CoreGraphics::QueueType queue);

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -242,8 +242,7 @@ CoreGraphics::PipelineId CreatePipeline(
     const CoreGraphics::PassId pass
     , uint subpass
     , CoreGraphics::ShaderProgramId program
-    , CoreGraphics::InputAssemblyKey inputAssembly
-    , CoreGraphics::VertexLayoutId vertexLayout
+    , const CoreGraphics::InputAssemblyKey inputAssembly
 );
 
 /// wait for an individual queue to finish

--- a/code/render/coregraphics/pipeline.h
+++ b/code/render/coregraphics/pipeline.h
@@ -1,0 +1,31 @@
+#pragma once
+//------------------------------------------------------------------------------
+/**
+    A pipeline object describes the GPU state required to 
+    perform a compute or graphics job
+
+    @copyright
+    (C) 2023 Individual contributors, see AUTHORS file
+*/
+//------------------------------------------------------------------------------
+#include "shader.h"
+#include "pass.h"
+namespace CoreGraphics
+{
+
+ID_24_8_TYPE(PipelineId);
+
+struct PipelineCreateInfo
+{
+    CoreGraphics::ShaderProgramId shader;
+    CoreGraphics::PassId pass;
+    uint subpass;
+    CoreGraphics::InputAssemblyKey inputAssembly;
+};
+
+/// Create new pipeline
+PipelineId CreatePipeline(const PipelineCreateInfo& info);
+/// Destroy pipeline
+void DestroyPipeline(const PipelineId pipeline);
+
+} // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -577,6 +577,30 @@ CmdSetGraphicsPipeline(const CmdBufferId id)
 /**
 */
 void
+CmdSetGraphicsPipeline(const CmdBufferId buf, PipelineId pipeline)
+{
+    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(buf.id24);
+    vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.pipeline);
+
+    // Set viewport and scissors since Vulkan requires them to be set after the pipeline
+    ViewportBundle& viewports = commandBuffers.GetUnsafe<CmdBuffer_PendingViewports>(buf.id24);
+    if (viewports.numPending > 0)
+    {
+        vkCmdSetViewport(cmdBuf, 0, viewports.numPending, viewports.viewports.Begin());
+        viewports.numPending = 0;
+    }
+    ScissorBundle& rects = commandBuffers.GetUnsafe<CmdBuffer_PendingScissors>(buf.id24);
+    if (rects.numPending > 0)
+    {
+        vkCmdSetScissor(cmdBuf, 0, rects.numPending, rects.scissors.Begin());
+        rects.numPending = 0;
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
 CmdBarrier(
             const CmdBufferId id,
             CoreGraphics::PipelineStage fromStage,

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -141,24 +141,6 @@ struct GraphicsDeviceState : CoreGraphics::GraphicsDeviceState
 
 } state;
 
-struct GraphicsDeviceThreadState : CoreGraphics::GraphicsDeviceThreadState
-{
-    IndexT currentDevice;
-
-    Util::FixedArray<CoreGraphics::ShaderProgramId> currentShaderPrograms;
-    CoreGraphics::ShaderFeature::Mask currentShaderMask;
-
-    CoreGraphics::VertexLayoutId currentVertexLayout;
-    CoreGraphics::ShaderProgramId currentVertexLayoutShader;
-
-    VkGraphicsPipelineCreateInfo currentPipelineInfo;
-    VkPipelineLayout currentGraphicsPipelineLayout;
-    VkPipelineLayout currentComputePipelineLayout;
-    VkPipeline currentPipeline;
-
-    uint currentStencilFrontRef, currentStencilBackRef, currentStencilReadMask, currentStencilWriteMask;
-} thread_local threadState;
-
 VkDebugUtilsMessengerEXT VkErrorDebugMessageHandle = nullptr;
 PFN_vkCreateDebugUtilsMessengerEXT VkCreateDebugMessenger = nullptr;
 PFN_vkDestroyDebugUtilsMessengerEXT VkDestroyDebugMessenger = nullptr;
@@ -424,7 +406,6 @@ SparseTextureBind(const VkImage img, const Util::Array<VkSparseMemoryBind>& opaq
 {
     state.queueHandler.AppendSparseBind(CoreGraphics::SparseQueueType, img, opaqueBinds, pageBinds);
 }
-
 
 //------------------------------------------------------------------------------
 /**
@@ -1546,8 +1527,7 @@ CreatePipeline(
     const CoreGraphics::PassId pass
     , uint subpass
     , CoreGraphics::ShaderProgramId program
-    , CoreGraphics::InputAssemblyKey inputAssembly
-    , CoreGraphics::VertexLayoutId vertexLayout
+    , const CoreGraphics::InputAssemblyKey inputAssembly
 )
 {
     VkGraphicsPipelineCreateInfo shaderInfo;
@@ -1569,15 +1549,12 @@ CreatePipeline(
     multisampleInfo.sampleShadingEnable = info.multisampleInfo.sampleShadingEnable;
     multisampleInfo.pSampleMask = info.multisampleInfo.pSampleMask;
 
-    VkPipelineVertexInputStateCreateInfo* vertexInfo = VertexLayoutGetDerivative(vertexLayout, program);
-
     shaderInfo.pColorBlendState = &blendInfo;
     shaderInfo.pDepthStencilState = &info.depthStencilInfo;
     shaderInfo.pRasterizationState = &info.rasterizerInfo;
     shaderInfo.pMultisampleState = &multisampleInfo;
     shaderInfo.pDynamicState = &info.dynamicInfo;
     shaderInfo.pTessellationState = &info.tessInfo;
-    shaderInfo.pVertexInputState = vertexInfo;
     shaderInfo.layout = info.layout;
     shaderInfo.stageCount = info.stageCount;
     shaderInfo.pStages = info.shaderInfos;

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -227,7 +227,8 @@ SetupAdapter()
                     "VK_maintenance4",
                     "VK_host_query_reset",
                     "VK_descriptor_indexing",
-                    "VK_EXT_robustness2"
+                    "VK_EXT_robustness2",
+                    "VK_EXT_vertex_input_dynamic_state"
                 };
 
                 uint32_t newNumCaps = 0;
@@ -406,7 +407,7 @@ GetOrCreatePipeline(
     CoreGraphics::PassId pass
     , uint subpass
     , CoreGraphics::ShaderProgramId program
-    , CoreGraphics::InputAssemblyKey inputAssembly
+    , const CoreGraphics::InputAssemblyKey inputAssembly
     , const VkGraphicsPipelineCreateInfo& info)
 {
     Threading::CriticalScope scope(&pipelineMutex);
@@ -568,7 +569,7 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
         2,															// application version
         "Nebula",													// engine name
         4,															// engine version
-        VK_API_VERSION_1_2											// API version
+        VK_API_VERSION_1_3											// API version
     };
 
     state.usedExtensions = 0;
@@ -830,10 +831,17 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
     };
     descriptorIndexingFeatures.descriptorBindingPartiallyBound = true;
 
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT dynamicVertexFeatures =
+    {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT,
+        &descriptorIndexingFeatures,
+        true
+    };
+
     VkDeviceCreateInfo deviceInfo =
     {
         VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-        &descriptorIndexingFeatures,
+        &dynamicVertexFeatures,
         0,
         (uint32_t)queueInfos.Size(),
         &queueInfos[0],

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -1522,50 +1522,6 @@ ReloadShaderProgram(const CoreGraphics::ShaderProgramId& pro)
 //------------------------------------------------------------------------------
 /**
 */
-CoreGraphics::PipelineId
-CreatePipeline(
-    const CoreGraphics::PassId pass
-    , uint subpass
-    , CoreGraphics::ShaderProgramId program
-    , const CoreGraphics::InputAssemblyKey inputAssembly
-)
-{
-    VkGraphicsPipelineCreateInfo shaderInfo;
-    VkShaderProgramRuntimeInfo& info = shaderAlloc.Get<Shader_ProgramAllocator>(program.shaderId).Get<ShaderProgram_RuntimeInfo>(program.programId);
-
-    // Setup blend info
-    VkPipelineColorBlendStateCreateInfo blendInfo;
-    blendInfo.attachmentCount = info.colorBlendInfo.attachmentCount;
-    blendInfo.flags = info.colorBlendInfo.flags;
-    blendInfo.logicOp = info.colorBlendInfo.logicOp;
-    blendInfo.logicOpEnable = info.colorBlendInfo.logicOpEnable;
-    blendInfo.pAttachments = info.colorBlendAttachments;
-    memcpy(blendInfo.blendConstants, info.colorBlendInfo.blendConstants, sizeof(info.colorBlendInfo.blendConstants));
-
-    VkPipelineMultisampleStateCreateInfo multisampleInfo;
-    multisampleInfo.alphaToCoverageEnable = info.multisampleInfo.alphaToCoverageEnable;
-    multisampleInfo.alphaToOneEnable = info.multisampleInfo.alphaToOneEnable;
-    multisampleInfo.minSampleShading = info.multisampleInfo.minSampleShading;
-    multisampleInfo.sampleShadingEnable = info.multisampleInfo.sampleShadingEnable;
-    multisampleInfo.pSampleMask = info.multisampleInfo.pSampleMask;
-
-    shaderInfo.pColorBlendState = &blendInfo;
-    shaderInfo.pDepthStencilState = &info.depthStencilInfo;
-    shaderInfo.pRasterizationState = &info.rasterizerInfo;
-    shaderInfo.pMultisampleState = &multisampleInfo;
-    shaderInfo.pDynamicState = &info.dynamicInfo;
-    shaderInfo.pTessellationState = &info.tessInfo;
-    shaderInfo.layout = info.layout;
-    shaderInfo.stageCount = info.stageCount;
-    shaderInfo.pStages = info.shaderInfos;
-
-    VkPipeline pipeline = state.database.CreatePipeline(pass, subpass, program, inputAssembly, shaderInfo);
-    return PipelineId{ pipeline };
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
 void
 FinishFrame(IndexT frameIndex)
 {

--- a/code/render/coregraphics/vk/vkgraphicsdevice.h
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.h
@@ -69,4 +69,9 @@ void ClearPending();
 namespace CoreGraphics
 {
 
+struct PipelineId
+{
+    VkPipeline pipeline;
+};
+
 } // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkgraphicsdevice.h
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.h
@@ -65,13 +65,3 @@ void SparseTextureBind(const VkImage img, const Util::Array<VkSparseMemoryBind>&
 void ClearPending();
 
 } // namespace Vulkan
-
-namespace CoreGraphics
-{
-
-struct PipelineId
-{
-    VkPipeline pipeline;
-};
-
-} // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkgraphicsdevice.h
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.h
@@ -56,7 +56,7 @@ const VkQueue GetQueue(const CoreGraphics::QueueType type, const IndexT index);
 const VkQueue GetCurrentQueue(const CoreGraphics::QueueType type);
 
 /// Generate or return cached VkPipeline
-VkPipeline GetOrCreatePipeline(CoreGraphics::PassId pass, uint subpass, CoreGraphics::ShaderProgramId program, CoreGraphics::InputAssemblyKey inputAssembly, const VkGraphicsPipelineCreateInfo& info);
+VkPipeline GetOrCreatePipeline(CoreGraphics::PassId pass, uint subpass, CoreGraphics::ShaderProgramId program, const CoreGraphics::InputAssemblyKey inputAssembly, const VkGraphicsPipelineCreateInfo& info);
 
 /// perform a set of sparse bind operations
 void SparseTextureBind(const VkImage img, const Util::Array<VkSparseMemoryBind>& opaqueBinds, const Util::Array<VkSparseImageMemoryBind>& pageBinds);

--- a/code/render/coregraphics/vk/vkloader.cc
+++ b/code/render/coregraphics/vk/vkloader.cc
@@ -123,6 +123,9 @@ InitInstance(VkInstance instance)
     _IMP_VK(vkCmdSetStencilCompareMask);
     _IMP_VK(vkCmdSetStencilWriteMask);
     _IMP_VK(vkCmdSetStencilReference);
+    _IMP_VK(vkCmdSetPrimitiveTopology);
+    _IMP_VK(vkCmdSetPrimitiveRestartEnable);
+    _IMP_VK(vkCmdSetVertexInputEXT);
 
     _IMP_VK(vkCreateCommandPool);
     _IMP_VK(vkDestroyCommandPool);
@@ -287,6 +290,9 @@ _DEF_VK(vkCmdSetScissor);
 _DEF_VK(vkCmdSetStencilCompareMask);
 _DEF_VK(vkCmdSetStencilWriteMask);
 _DEF_VK(vkCmdSetStencilReference);
+_DEF_VK(vkCmdSetPrimitiveTopology);
+_DEF_VK(vkCmdSetPrimitiveRestartEnable);
+_DEF_VK(vkCmdSetVertexInputEXT);
 
 _DEF_VK(vkCreateCommandPool);
 _DEF_VK(vkDestroyCommandPool);

--- a/code/render/coregraphics/vk/vkloader.h
+++ b/code/render/coregraphics/vk/vkloader.h
@@ -107,6 +107,9 @@ _DEC_VK(vkCmdSetScissor);
 _DEC_VK(vkCmdSetStencilCompareMask);
 _DEC_VK(vkCmdSetStencilWriteMask);
 _DEC_VK(vkCmdSetStencilReference);
+_DEC_VK(vkCmdSetPrimitiveTopology);
+_DEC_VK(vkCmdSetPrimitiveRestartEnable);
+_DEC_VK(vkCmdSetVertexInputEXT);
 
 _DEC_VK(vkCreateCommandPool);
 _DEC_VK(vkDestroyCommandPool);

--- a/code/render/coregraphics/vk/vkpipeline.cc
+++ b/code/render/coregraphics/vk/vkpipeline.cc
@@ -1,0 +1,89 @@
+//------------------------------------------------------------------------------
+//  @file vkpipeline.cc
+//  @copyright (C) 2023 Individual contributors, see AUTHORS file
+//------------------------------------------------------------------------------
+#include "foundation/stdneb.h"
+#include "coregraphics/pipeline.h"
+#include "vkshaderprogram.h"
+#include "vkshader.h"
+#include "vkpipeline.h"
+#include "vktypes.h"
+#include "vkgraphicsdevice.h"
+namespace Vulkan
+{
+Ids::IdAllocator<Pipeline> pipelineAllocator;
+};
+
+namespace CoreGraphics
+{
+using namespace Vulkan;
+
+//------------------------------------------------------------------------------
+/**
+*/
+PipelineId
+CreatePipeline(const PipelineCreateInfo& info)
+{
+    Ids::Id32 ret = pipelineAllocator.Alloc();
+    Pipeline& obj = pipelineAllocator.Get<0>(ret);
+
+    VkGraphicsPipelineCreateInfo shaderInfo;
+    VkShaderProgramRuntimeInfo& programInfo = shaderAlloc.Get<Shader_ProgramAllocator>(info.shader.shaderId).Get<ShaderProgram_RuntimeInfo>(info.shader.programId);
+
+    // Setup blend info
+    VkPipelineColorBlendStateCreateInfo blendInfo;
+    blendInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    blendInfo.pNext = nullptr;
+    blendInfo.flags = 0x0;
+    blendInfo.attachmentCount = programInfo.colorBlendInfo.attachmentCount;
+    blendInfo.flags = programInfo.colorBlendInfo.flags;
+    blendInfo.logicOp = programInfo.colorBlendInfo.logicOp;
+    blendInfo.logicOpEnable = programInfo.colorBlendInfo.logicOpEnable;
+    blendInfo.pAttachments = programInfo.colorBlendAttachments;
+    memcpy(blendInfo.blendConstants, programInfo.colorBlendInfo.blendConstants, sizeof(programInfo.colorBlendInfo.blendConstants));
+
+    VkPipelineMultisampleStateCreateInfo multisampleInfo;
+    multisampleInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisampleInfo.pNext = nullptr;
+    multisampleInfo.flags = 0x0;
+    multisampleInfo.rasterizationSamples = programInfo.multisampleInfo.rasterizationSamples;
+    multisampleInfo.alphaToCoverageEnable = programInfo.multisampleInfo.alphaToCoverageEnable;
+    multisampleInfo.alphaToOneEnable = programInfo.multisampleInfo.alphaToOneEnable;
+    multisampleInfo.minSampleShading = programInfo.multisampleInfo.minSampleShading;
+    multisampleInfo.sampleShadingEnable = programInfo.multisampleInfo.sampleShadingEnable;
+    multisampleInfo.pSampleMask = programInfo.multisampleInfo.pSampleMask;
+
+    shaderInfo.pColorBlendState = &blendInfo;
+    shaderInfo.pDepthStencilState = &programInfo.depthStencilInfo;
+    shaderInfo.pRasterizationState = &programInfo.rasterizerInfo;
+    shaderInfo.pMultisampleState = &multisampleInfo;
+    shaderInfo.pDynamicState = &programInfo.dynamicInfo;
+    shaderInfo.pTessellationState = &programInfo.tessInfo;
+    shaderInfo.layout = programInfo.layout;
+    shaderInfo.stageCount = programInfo.stageCount;
+    shaderInfo.pStages = programInfo.shaderInfos;
+
+    // Since this is the public facing API, we have to convert the primitive type as it's expected to be in CoreGraphics 
+    InputAssemblyKey translatedKey;
+    translatedKey.topo = Vulkan::VkTypes::AsVkPrimitiveType((CoreGraphics::PrimitiveTopology::Code)info.inputAssembly.topo);
+    translatedKey.primRestart = info.inputAssembly.primRestart;
+    VkPipeline pipeline = Vulkan::GetOrCreatePipeline(info.pass, info.subpass, info.shader, translatedKey, shaderInfo);
+
+    obj.pipeline = pipeline;
+    obj.layout = programInfo.layout;
+    obj.pass = info.pass;
+    return PipelineId{ ret, 0 };
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+DestroyPipeline(const PipelineId pipeline)
+{
+    Pipeline& obj = pipelineAllocator.Get<0>(pipeline.id24);
+    vkDestroyPipeline(Vulkan::GetCurrentDevice(), obj.pipeline, nullptr);
+    pipelineAllocator.Dealloc(pipeline.id24);
+}
+
+} // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkpipeline.h
+++ b/code/render/coregraphics/vk/vkpipeline.h
@@ -1,0 +1,30 @@
+#pragma once
+//------------------------------------------------------------------------------
+/**
+    Vulkan implementation of CoreGraphics::PipelineId
+
+    @copyright
+    (C) 2023 Individual contributors, see AUTHORS file
+*/
+//------------------------------------------------------------------------------
+#include "ids/idallocator.h"
+
+namespace Vulkan
+{
+
+struct Pipeline
+{
+    VkPipeline pipeline;
+    VkPipelineLayout layout;
+
+    // Pass needed for pass related resource tables
+    CoreGraphics::PassId pass;
+};
+
+enum
+{
+    Pipeline_Object
+};
+
+extern Ids::IdAllocator<Pipeline> pipelineAllocator;
+} // namespace Vulkan

--- a/code/render/coregraphics/vk/vkpipelinedatabase.cc
+++ b/code/render/coregraphics/vk/vkpipelinedatabase.cc
@@ -5,6 +5,7 @@
 
 #include "vkpipelinedatabase.h"
 #include "vkpass.h"
+#include "vktypes.h"
 
 namespace Vulkan
 {
@@ -64,19 +65,8 @@ VkPipelineDatabase::Discard()
                 for (l = 0; l < t3->children.Size(); l++)
                 {
                     Tier4Node* t4 = t3->children.ValueAtIndex(l);
-
-                    IndexT m;
-                    for (m = 0; m < t4->children.Size(); m++)
-                    {
-                        Tier5Node* t5 = t4->children.ValueAtIndex(m);
-
-                        if (t5->pipeline != VK_NULL_HANDLE)
-                        {
-                            // destroy any existing pipeline
-                            vkDestroyPipeline(this->dev, t5->pipeline, nullptr);
-                            t5->pipeline = VK_NULL_HANDLE;
-                        }
-                    }
+                    vkDestroyPipeline(this->dev, t4->pipeline, nullptr);
+                    t4->pipeline = VK_NULL_HANDLE;
                 }
             }
         }
@@ -135,13 +125,12 @@ VkPipelineDatabase::SetShader(const CoreGraphics::ShaderProgramId program, const
     if (index != InvalidIndex)
     {
         this->ct3 = this->ct2->children.ValueAtIndex(index);
-        this->SetVertexLayout(this->currentVertexLayout);
+        this->SetInputAssembly(this->currentInputAssembly);
     }
     else
     {
         this->ct3 = tierNodeAllocator.Alloc<Tier3Node>();
         this->ct2->children.Add(program, this->ct3);
-        this->SetVertexLayout(this->currentVertexLayout);
     }
 }
 
@@ -149,39 +138,18 @@ VkPipelineDatabase::SetShader(const CoreGraphics::ShaderProgramId program, const
 /**
 */
 void
-VkPipelineDatabase::SetVertexLayout(const VkPipelineVertexInputStateCreateInfo* layout)
+VkPipelineDatabase::SetInputAssembly(const CoreGraphics::InputAssemblyKey key)
 {
-    this->currentVertexLayout = layout;
-    IndexT index = this->ct3->children.FindIndex(layout);
+    this->currentInputAssembly = key;
+    IndexT index = this->ct3->children.FindIndex(key);
     if (index != InvalidIndex)
     {
         this->ct4 = this->ct3->children.ValueAtIndex(index);
-        this->SetInputLayout(this->currentInputAssemblyInfo);
     }
     else
     {
         this->ct4 = tierNodeAllocator.Alloc<Tier4Node>();
-        this->ct3->children.Add(layout, this->ct4);
-        this->SetInputLayout(this->currentInputAssemblyInfo);
-    }
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-void
-VkPipelineDatabase::SetInputLayout(const CoreGraphics::InputAssemblyKey key)
-{
-    this->currentInputAssemblyInfo = key;
-    IndexT index = this->ct4->children.FindIndex(key);
-    if (index != InvalidIndex)
-    {
-        this->ct5 = this->ct4->children.ValueAtIndex(index);
-    }
-    else
-    {
-        this->ct5 = tierNodeAllocator.Alloc<Tier5Node>();
-        this->ct4->children.Add(key, this->ct5);
+        this->ct3->children.Add(key, this->ct4);
     }
 }
 
@@ -193,19 +161,20 @@ VkPipelineDatabase::GetCompiledPipeline()
 {
     n_assert(this->dev != VK_NULL_HANDLE);
     n_assert(this->cache != VK_NULL_HANDLE);
-    if (this->ct1->initial ||
+    if (
+        this->ct1->initial ||
         this->ct2->initial ||
         this->ct3->initial ||
-        this->ct4->initial ||
-        this->ct5->initial)
+        this->ct4->initial
+        )
     {
-        this->ct5->pipeline = this->CreatePipeline(this->currentPass, this->currentSubpass, this->currentShaderProgram, this->currentInputAssemblyInfo, this->currentShaderInfo);
+        this->ct4->pipeline = this->CreatePipeline(this->currentPass, this->currentSubpass, this->currentShaderProgram, this->currentInputAssembly, this->currentShaderInfo);
 
         // DAG path is created, so set entire path to not initial
-        this->ct1->initial = this->ct2->initial = this->ct3->initial = this->ct4->initial = this->ct5->initial = false;
+        this->ct1->initial = this->ct2->initial = this->ct3->initial = this->ct4->initial = false;
     }
 
-    this->currentPipeline = this->ct5->pipeline;
+    this->currentPipeline = this->ct4->pipeline;
     return this->currentPipeline;
 }
 
@@ -217,14 +186,13 @@ VkPipelineDatabase::GetCompiledPipeline(
     const CoreGraphics::PassId pass
     , const uint32_t subpass
     , const CoreGraphics::ShaderProgramId program
-    , CoreGraphics::InputAssemblyKey inputAssembly
+    , const CoreGraphics::InputAssemblyKey inputAssembly
     , const VkGraphicsPipelineCreateInfo& shaderInfo)
 {
     this->SetPass(pass);
     this->SetSubpass(subpass);
     this->SetShader(program, shaderInfo);
-    this->SetVertexLayout(shaderInfo.pVertexInputState);
-    this->SetInputLayout(inputAssembly);
+    this->SetInputAssembly(inputAssembly);
     return this->GetCompiledPipeline();
 }
 
@@ -232,7 +200,7 @@ VkPipelineDatabase::GetCompiledPipeline(
 /**
 */
 VkPipeline
-VkPipelineDatabase::CreatePipeline(const CoreGraphics::PassId pass, const uint32_t subpass, const CoreGraphics::ShaderProgramId program, CoreGraphics::InputAssemblyKey inputAssembly, const VkGraphicsPipelineCreateInfo& shaderInfo)
+VkPipelineDatabase::CreatePipeline(const CoreGraphics::PassId pass, const uint32_t subpass, const CoreGraphics::ShaderProgramId program, const CoreGraphics::InputAssemblyKey inputAssembly, const VkGraphicsPipelineCreateInfo& shaderInfo)
 {
     // get other fragment from framebuffer
     VkGraphicsPipelineCreateInfo passInfo = PassGetVkFramebufferInfo(pass);
@@ -240,10 +208,14 @@ VkPipelineDatabase::CreatePipeline(const CoreGraphics::PassId pass, const uint32
     VkRenderPassBeginInfo renderPassInfo = PassGetVkRenderPassBeginInfo(pass);
     colorBlendInfo.attachmentCount = PassGetNumSubpassAttachments(pass, subpass);
 
-    VkPipelineInputAssemblyStateCreateInfo inputInfo;
+    VkPipelineVertexInputStateCreateInfo dummyVertexInput{};
+    dummyVertexInput.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    dummyVertexInput.pNext = nullptr;
+    dummyVertexInput.flags = 0x0;
+    VkPipelineInputAssemblyStateCreateInfo inputInfo{};
     inputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
     inputInfo.pNext = nullptr;
-    inputInfo.flags = 0;
+    inputInfo.flags = 0x0;
     inputInfo.topology = (VkPrimitiveTopology)inputAssembly.topo;
     inputInfo.primitiveRestartEnable = inputAssembly.primRestart;
 
@@ -255,7 +227,7 @@ VkPipelineDatabase::CreatePipeline(const CoreGraphics::PassId pass, const uint32
         0,
         shaderInfo.stageCount,
         shaderInfo.pStages,
-        shaderInfo.pVertexInputState,
+        &dummyVertexInput,
         &inputInfo,
         shaderInfo.pTessellationState,
         passInfo.pViewportState,
@@ -287,13 +259,10 @@ VkPipelineDatabase::Reset()
     this->currentSubpass = -1;
     this->currentShaderProgram = CoreGraphics::InvalidShaderProgramId;
     this->currentVertexLayout = 0;
-    this->currentInputAssemblyInfo.key = 0;
     this->currentPipeline = VK_NULL_HANDLE;
     this->ct1 = NULL;
     this->ct2 = NULL;
     this->ct3 = NULL;
-    this->ct4 = NULL;
-    this->ct5 = NULL;
 }
 
 //------------------------------------------------------------------------------
@@ -302,23 +271,24 @@ VkPipelineDatabase::Reset()
 void 
 VkPipelineDatabase::Reload(const CoreGraphics::ShaderProgramId id)
 {
+    /*
     // save initial state
     Tier1Node* tmp1 = this->ct1;
     Tier2Node* tmp2 = this->ct2;
     Tier3Node* tmp3 = this->ct3;
-    Tier4Node* tmp4 = this->ct4;
-    Tier5Node* tmp5 = this->ct5;
 
     // walk through the tree and update every pipeline using the shader
     IndexT i;
     for (i = 0; i < this->tier1.Size(); i++)
     {
         Tier1Node* t1 = this->tier1.ValueAtIndex(i);
+        const CoreGraphics::PassId pass = this->tier1.KeyAtIndex(i);
         
         IndexT j;
         for (j = 0; j < t1->children.Size(); j++)
         {
             Tier2Node* t2 = t1->children.ValueAtIndex(j);
+            const uint subpass = t1->children.KeyAtIndex(j);
 
             IndexT k;
             for (k = 0; k < t2->children.Size(); k++)
@@ -329,25 +299,27 @@ VkPipelineDatabase::Reload(const CoreGraphics::ShaderProgramId id)
                 if (prog == id)
                 {
                     t3->initial = true;
-                    
                     IndexT l;
                     for (l = 0; l < t3->children.Size(); l++)
                     {
                         Tier4Node* t4 = t3->children.ValueAtIndex(l);
+                        CoreGraphics::InputAssemblyKey inputAssembly = t3->children.KeyAtIndex(l);
 
-                        IndexT m;
-                        for (m = 0; m < t4->children.Size(); m++)
-                        {
-                            Tier5Node* t5 = t4->children.ValueAtIndex(m);
-                            this->ct1 = t1;
-                            this->ct2 = t2;
-                            this->ct3 = t3;
-                            this->ct4 = t4;
-                            this->ct5 = t5;
+                        // Destroy pipeline first
+                        vkDestroyPipeline(this->dev, t4->pipeline, nullptr);
+                        t4->pipeline = VK_NULL_HANDLE;
+                        t4->initial = true;
 
-                            // since t3 is initial, we will create a new pipeline
-                            //this->GetCompiledPipeline();
-                        }
+                        // Setup all state
+                        this->ct1 = t1;
+                        this->ct2 = t2;
+                        this->ct3 = t3;
+                        this->ct4 = t4;
+
+                        t4->pipeline = this->CreatePipeline(pass, subpass, prog, inputAssembly);
+
+                        // Now requ
+                        this->GetCompiledPipeline();
                     }
                 }
             }
@@ -358,8 +330,7 @@ VkPipelineDatabase::Reload(const CoreGraphics::ShaderProgramId id)
     this->ct1 = tmp1;
     this->ct2 = tmp2;
     this->ct3 = tmp3;
-    this->ct4 = tmp4;
-    this->ct5 = tmp5;
+    */
 }
 
 //------------------------------------------------------------------------------
@@ -387,22 +358,9 @@ VkPipelineDatabase::RecreatePipelines()
                 for (l = 0; l < t3->children.Size(); l++)
                 {
                     Tier4Node* t4 = t3->children.ValueAtIndex(l);
-
-                    IndexT m;
-                    for (m = 0; m < t4->children.Size(); m++)
-                    {
-                        Tier5Node* t5 = t4->children.ValueAtIndex(m);
-
-                        if (t5->pipeline != VK_NULL_HANDLE)
-                        {
-                            // destroy any existing pipeline
-                            vkDestroyPipeline(this->dev, t5->pipeline, nullptr);
-                            t5->pipeline = VK_NULL_HANDLE;
-                        }
-
-                        // set t5 to initial, so that the next time we try to get compiled pipeline, it gets recreated
-                        t5->initial = true;
-                    }
+                    vkDestroyPipeline(this->dev, t4->pipeline, nullptr);
+                    t4->pipeline = VK_NULL_HANDLE;
+                    t4->initial = true;
                 }
             }
         }

--- a/code/render/coregraphics/vk/vkpipelinedatabase.h
+++ b/code/render/coregraphics/vk/vkpipelinedatabase.h
@@ -60,7 +60,7 @@ public:
     /// set subpass
     void SetSubpass(uint32_t subpass);
     /// set shader
-    void SetShader(const CoreGraphics::ShaderProgramId program, const VkGraphicsPipelineCreateInfo& gfxPipe);
+    void SetShader(const CoreGraphics::ShaderProgramId program, const VkGraphicsPipelineCreateInfo& shaderInfo);
     /// set vertex layout
     void SetVertexLayout(const VkPipelineVertexInputStateCreateInfo* layout);
     /// set input layout
@@ -73,7 +73,15 @@ public:
         , const uint32_t subpass
         , const CoreGraphics::ShaderProgramId program
         , CoreGraphics::InputAssemblyKey inputAssembly
-        , const VkGraphicsPipelineCreateInfo& gfxPipe);
+        , const VkGraphicsPipelineCreateInfo& shaderInfo);
+    /// Create pipeline
+    VkPipeline CreatePipeline(
+        const CoreGraphics::PassId pass
+        , const uint32_t subpass
+        , const CoreGraphics::ShaderProgramId program
+        , CoreGraphics::InputAssemblyKey inputAssembly
+        , const VkGraphicsPipelineCreateInfo& shaderInfo
+    );
     /// resets all iterators
     void Reset();
 

--- a/code/render/coregraphics/vk/vkpipelinedatabase.h
+++ b/code/render/coregraphics/vk/vkpipelinedatabase.h
@@ -61,10 +61,8 @@ public:
     void SetSubpass(uint32_t subpass);
     /// set shader
     void SetShader(const CoreGraphics::ShaderProgramId program, const VkGraphicsPipelineCreateInfo& shaderInfo);
-    /// set vertex layout
-    void SetVertexLayout(const VkPipelineVertexInputStateCreateInfo* layout);
-    /// set input layout
-    void SetInputLayout(const CoreGraphics::InputAssemblyKey input);
+    /// Set input assembly
+    void SetInputAssembly(const CoreGraphics::InputAssemblyKey key);
     /// gets pipeline if it already exists, or creates if exists
     VkPipeline GetCompiledPipeline();
     /// Gets the pipeline associated with a set of state, or returns a previously created one
@@ -72,14 +70,14 @@ public:
         const CoreGraphics::PassId pass
         , const uint32_t subpass
         , const CoreGraphics::ShaderProgramId program
-        , CoreGraphics::InputAssemblyKey inputAssembly
+        , const CoreGraphics::InputAssemblyKey inputAssembly
         , const VkGraphicsPipelineCreateInfo& shaderInfo);
     /// Create pipeline
     VkPipeline CreatePipeline(
         const CoreGraphics::PassId pass
         , const uint32_t subpass
         , const CoreGraphics::ShaderProgramId program
-        , CoreGraphics::InputAssemblyKey inputAssembly
+        , const CoreGraphics::InputAssemblyKey inputAssembly
         , const VkGraphicsPipelineCreateInfo& shaderInfo
     );
     /// resets all iterators
@@ -98,16 +96,15 @@ private:
     uint32_t currentSubpass;
     CoreGraphics::ShaderProgramId currentShaderProgram;
     VkGraphicsPipelineCreateInfo currentShaderInfo;
+    CoreGraphics::InputAssemblyKey currentInputAssembly;
     const VkPipelineVertexInputStateCreateInfo* currentVertexLayout;
 
-    CoreGraphics::InputAssemblyKey currentInputAssemblyInfo;
     StateLevel currentLevel;
 
     struct Tier1Node;
     struct Tier2Node;
     struct Tier3Node;
     struct Tier4Node;
-    struct Tier5Node;
 
     struct BaseNode
     {
@@ -126,14 +123,9 @@ private:
     };
     struct Tier3Node : public BaseNode
     {
-        Util::Dictionary<const VkPipelineVertexInputStateCreateInfo*, Tier4Node*> children;
+        Util::Dictionary<CoreGraphics::InputAssemblyKey, Tier4Node*> children;
     };
     struct Tier4Node : public BaseNode
-    {
-
-        Util::Dictionary<CoreGraphics::InputAssemblyKey, Tier5Node*> children;
-    };
-    struct Tier5Node : public BaseNode
     {
         VkPipeline pipeline = VK_NULL_HANDLE;
     };
@@ -147,7 +139,6 @@ private:
     Tier2Node* ct2;
     Tier3Node* ct3;
     Tier4Node* ct4;
-    Tier5Node* ct5;
     VkPipeline currentPipeline;
 };
 } // namespace Vulkan

--- a/code/render/coregraphics/vk/vkshader.cc
+++ b/code/render/coregraphics/vk/vkshader.cc
@@ -23,7 +23,6 @@ Util::Dictionary<Util::StringAtom, VkPipelineLayout> VkShaderPipelineCache;
 Util::Dictionary<Util::StringAtom, VkDescriptorSet> VkShaderDescriptorSetCache;
 ShaderAllocator shaderAlloc;
 
-
 //------------------------------------------------------------------------------
 /**
 */

--- a/code/render/coregraphics/vk/vkshaderprogram.cc
+++ b/code/render/coregraphics/vk/vkshaderprogram.cc
@@ -243,14 +243,16 @@ VkShaderProgramSetupAsGraphics(AnyFX::VkProgram* program, const Resources::Resou
         , VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK
         , VK_DYNAMIC_STATE_STENCIL_WRITE_MASK
         , VK_DYNAMIC_STATE_STENCIL_REFERENCE
-
+        , VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY
+        , VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE
+        , VK_DYNAMIC_STATE_VERTEX_INPUT_EXT
     };
     runtime.dynamicInfo =
     {
         VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
         nullptr,
         0,
-        5,
+        sizeof(dynamicStates) / sizeof(VkDynamicState),
         dynamicStates
     };
 

--- a/code/render/coregraphics/vk/vkvertexlayout.cc
+++ b/code/render/coregraphics/vk/vkvertexlayout.cc
@@ -63,6 +63,16 @@ VertexLayoutGetDerivative(const CoreGraphics::VertexLayoutId layout, const CoreG
     }
 }
 
+//------------------------------------------------------------------------------
+/**
+*/
+const VertexLayoutVkBindInfo&
+VertexLayoutGetVkBindInfo(const CoreGraphics::VertexLayoutId layout)
+{
+    Threading::CriticalScope scope(&vertexSignatureMutex);
+    return vertexLayoutAllocator.Get<VertexSignature_DynamicBindInfo>(layout.resourceId);
+}
+
 } // namespace Vulkan
 namespace CoreGraphics
 {
@@ -100,11 +110,24 @@ CreateVertexLayout(const VertexLayoutCreateInfo& info)
     Util::HashTable<uint64_t, DerivativeLayout>& hashTable = vertexLayoutAllocator.Get<VertexSignature_ProgramLayoutMapping>(id);
     VkPipelineVertexInputStateCreateInfo& vertexInfo = vertexLayoutAllocator.Get<VertexSignature_VkPipelineInfo>(id);
     BindInfo& bindInfo = vertexLayoutAllocator.Get<VertexSignature_BindInfo>(id);
+    VertexLayoutVkBindInfo& dynamicBindInfo = vertexLayoutAllocator.Get<VertexSignature_DynamicBindInfo>(id);
 
     // create binds
     bindInfo.binds.Resize(CoreGraphics::MaxNumVertexStreams);
     bindInfo.binds.Fill(VkVertexInputBindingDescription{});
     bindInfo.attrs.Resize(loadInfo.comps.Size());
+
+    dynamicBindInfo.binds.Resize(CoreGraphics::MaxNumVertexStreams);
+    for (auto& bind : dynamicBindInfo.binds)
+    {
+        bind.sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT;
+        bind.pNext = nullptr;
+        bind.binding = 0xFFFFFFFF;
+        bind.stride = 0xFFFFFFFF;
+        bind.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+        bind.divisor = 1;
+    }
+    dynamicBindInfo.attrs.Resize(loadInfo.comps.Size());
 
     SizeT strides[CoreGraphics::MaxNumVertexStreams] = { 0 };
 
@@ -119,25 +142,39 @@ CreateVertexLayout(const VertexLayoutCreateInfo& info)
     {
         const CoreGraphics::VertexComponent& component = loadInfo.comps[compIndex];
         VkVertexInputAttributeDescription* attr = &bindInfo.attrs[compIndex];
-
         attr->location = component.GetIndex();
         attr->binding = component.GetStreamIndex();
         attr->format = VkTypes::AsVkVertexType(component.GetFormat());
         attr->offset = curOffset[component.GetStreamIndex()];
 
+        VkVertexInputAttributeDescription2EXT* attr2 = &dynamicBindInfo.attrs[compIndex];
+        attr2->sType = VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT;
+        attr2->pNext = nullptr;
+        attr2->location = component.GetIndex();
+        attr2->binding = component.GetStreamIndex();
+        attr2->format = VkTypes::AsVkVertexType(component.GetFormat());
+        attr2->offset = curOffset[component.GetStreamIndex()];
+
         if (usedStreams[attr->binding])
+        {
             bindInfo.binds[attr->binding].stride += component.GetByteSize();
+            dynamicBindInfo.binds[attr->binding].stride += component.GetByteSize();
+        }
         else
         {
             bindInfo.binds[attr->binding].stride = component.GetByteSize();
+            dynamicBindInfo.binds[attr->binding].stride = component.GetByteSize();
             usedStreams[attr->binding] = true;
             numUsedStreams++;
         }
 
         bindInfo.binds[attr->binding].binding = component.GetStreamIndex();
         bindInfo.binds[attr->binding].inputRate = component.GetStrideType() == CoreGraphics::VertexComponent::PerVertex ? VK_VERTEX_INPUT_RATE_VERTEX : VK_VERTEX_INPUT_RATE_INSTANCE;
+        dynamicBindInfo.binds[attr->binding].binding = component.GetStreamIndex();
+        dynamicBindInfo.binds[attr->binding].inputRate = component.GetStrideType() == CoreGraphics::VertexComponent::PerVertex ? VK_VERTEX_INPUT_RATE_VERTEX : VK_VERTEX_INPUT_RATE_INSTANCE;
         curOffset[component.GetStreamIndex()] += component.GetByteSize();
     }
+    dynamicBindInfo.binds.Resize(numUsedStreams);
 
     vertexInfo =
     {

--- a/code/render/coregraphics/vk/vkvertexlayout.h
+++ b/code/render/coregraphics/vk/vkvertexlayout.h
@@ -12,8 +12,17 @@
 namespace Vulkan
 {
 
+struct VertexLayoutVkBindInfo
+{
+    Util::FixedArray<VkVertexInputBindingDescription2EXT> binds;
+    Util::FixedArray<VkVertexInputAttributeDescription2EXT> attrs;
+};
+
 /// Get derivative of vertex layout based on shader
 VkPipelineVertexInputStateCreateInfo* VertexLayoutGetDerivative(const CoreGraphics::VertexLayoutId layout, const CoreGraphics::ShaderProgramId shader);
+
+/// Get dynamic bind info
+const VertexLayoutVkBindInfo& VertexLayoutGetVkBindInfo(const CoreGraphics::VertexLayoutId layout);
 
 struct DerivativeLayout
 {
@@ -68,14 +77,15 @@ enum
     , VertexSignature_VkPipelineInfo
     , VertexSignature_BindInfo
     , VertexSignature_LayoutInfo
+    , VertexSignature_DynamicBindInfo
 };
 
-
 typedef Ids::IdAllocator<
-    Util::HashTable<uint64_t, DerivativeLayout>,        //0 program-to-derivative layout binding
-    VkPipelineVertexInputStateCreateInfo,               //1 base vertex input state
-    BindInfo,                                           //2 setup info
-    CoreGraphics::VertexLayoutInfo                      //3 base info
+    Util::HashTable<uint64_t, DerivativeLayout>,      
+    VkPipelineVertexInputStateCreateInfo,             
+    BindInfo,                                         
+    CoreGraphics::VertexLayoutInfo,                   
+    VertexLayoutVkBindInfo
 > VkVertexLayoutAllocator;
 extern VkVertexLayoutAllocator vertexLayoutAllocator;
 } // namespace Vulkan

--- a/code/render/frame/framecode.cc
+++ b/code/render/frame/framecode.cc
@@ -48,14 +48,7 @@ FrameCode::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
 /**
 */
 void
-FrameCode::Build(
-    Memory::ArenaAllocator<BIG_CHUNK>& allocator
-    , Util::Array<FrameOp::Compiled*>& compiledOps
-    , Util::Array<CoreGraphics::EventId>& events
-    , Util::Array<CoreGraphics::BarrierId>& barriers
-    , Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers
-    , Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures
-)
+FrameCode::Build(const BuildContext& ctx)
 {
     n_assert(this->func != nullptr);
 
@@ -63,11 +56,11 @@ FrameCode::Build(
     if (!this->enabled)
         return;
 
-    CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(allocator);
+    CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(ctx.allocator);
     this->compiled = myCompiled;
 
-    this->SetupSynchronization(allocator, events, barriers, rwBuffers, textures);
-    compiledOps.Append(myCompiled);
+    this->SetupSynchronization(ctx.allocator, ctx.events, ctx.barriers, ctx.buffers, ctx.textures);
+    ctx.compiledOps.Append(myCompiled);
 }
 
 } // namespace Frame

--- a/code/render/frame/framecode.cc
+++ b/code/render/frame/framecode.cc
@@ -9,7 +9,8 @@ namespace Frame
 //------------------------------------------------------------------------------
 /**
 */
-FrameCode::FrameCode()
+FrameCode::FrameCode() :
+    buildFunc(nullptr)
 {
 }
 
@@ -61,6 +62,9 @@ FrameCode::Build(const BuildContext& ctx)
 
     this->SetupSynchronization(ctx.allocator, ctx.events, ctx.barriers, ctx.buffers, ctx.textures);
     ctx.compiledOps.Append(myCompiled);
+
+    if (this->buildFunc)
+        this->buildFunc(ctx.currentPass, ctx.subpass);
 }
 
 } // namespace Frame

--- a/code/render/frame/framecode.h
+++ b/code/render/frame/framecode.h
@@ -20,6 +20,7 @@ public:
     virtual ~FrameCode();
 
     using FrameCodeFunc = void(*)(const CoreGraphics::CmdBufferId cmdBuf, const IndexT frameIndex, const IndexT bufferIndex);
+    using FrameBuildFunc = void(*)(const CoreGraphics::PassId pass, uint subpass);
     struct CompiledImpl : public FrameOp::Compiled
     {
         void Run(const CoreGraphics::CmdBufferId cmdBuf, const IndexT frameIndex, const IndexT bufferIndex) override;
@@ -33,15 +34,10 @@ public:
     FrameOp::Compiled* AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator);
 
     FrameCodeFunc func;
+    FrameBuildFunc buildFunc;
 private:
 
-    void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures) override;
+    void Build(const BuildContext& ctx) override;
 };
 
 } // namespace Frame2

--- a/code/render/frame/frameop.cc
+++ b/code/render/frame/frameop.cc
@@ -50,23 +50,17 @@ FrameOp::OnWindowResized()
 /**
 */
 void
-FrameOp::Build(
-    Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-    Util::Array<FrameOp::Compiled*>& compiledOps,
-    Util::Array<CoreGraphics::EventId>& events,
-    Util::Array<CoreGraphics::BarrierId>& barriers,
-    Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& buffers,
-    Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures)
+FrameOp::Build(const BuildContext& ctx)
 {
     // if not enable, abort early
     if (!this->enabled)
         return;
 
     // create compiled version of this op, FramePass and FrameSubpass implement this differently than ordinary ops
-    this->compiled = this->AllocCompiled(allocator);
-    compiledOps.Append(this->compiled);
+    this->compiled = this->AllocCompiled(ctx.allocator);
+    ctx.compiledOps.Append(this->compiled);
 
-    this->SetupSynchronization(allocator, events, barriers, buffers, textures);
+    this->SetupSynchronization(ctx.allocator, ctx.events, ctx.barriers, ctx.buffers, ctx.textures);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/frame/frameop.h
+++ b/code/render/frame/frameop.h
@@ -138,15 +138,19 @@ protected:
     /// allocate instance of compiled
     virtual Compiled* AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator) = 0;
 
+    struct BuildContext
+    {
+        Frame::FrameScript* script;
+        Memory::ArenaAllocator<BIG_CHUNK>& allocator;
+        Util::Array<FrameOp::Compiled*>& compiledOps;
+        Util::Array<CoreGraphics::EventId>& events;
+        Util::Array<CoreGraphics::BarrierId>& barriers;
+        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& buffers;
+        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures;
+    };
+
     /// build operation
-    virtual void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& buffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures
-        );
+    virtual void Build(const BuildContext& ctx);
 
     /// setup synchronization
     void SetupSynchronization(

--- a/code/render/frame/frameop.h
+++ b/code/render/frame/frameop.h
@@ -17,6 +17,8 @@
 #include "coregraphics/semaphore.h"
 #include "memory/arenaallocator.h"
 #include "coregraphics/commandbuffer.h"
+#include "coregraphics/pass.h"
+
 namespace Frame
 {
 
@@ -140,7 +142,8 @@ protected:
 
     struct BuildContext
     {
-        Frame::FrameScript* script;
+        CoreGraphics::PassId currentPass;
+        uint subpass;
         Memory::ArenaAllocator<BIG_CHUNK>& allocator;
         Util::Array<FrameOp::Compiled*>& compiledOps;
         Util::Array<CoreGraphics::EventId>& events;

--- a/code/render/frame/framepass.cc
+++ b/code/render/frame/framepass.cc
@@ -133,7 +133,7 @@ FramePass::Build(const BuildContext& ctx)
     for (IndexT i = 0; i < this->children.Size(); i++)
     {
         // Create new build context for each subpass
-        BuildContext newCtx = { myCompiled->pass, i, ctx.allocator, myCompiled->subpasses, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
+        BuildContext newCtx = { myCompiled->pass, (uint)i, ctx.allocator, myCompiled->subpasses, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
         this->children[i]->Build(newCtx);
     }
 

--- a/code/render/frame/framepass.cc
+++ b/code/render/frame/framepass.cc
@@ -130,9 +130,10 @@ FramePass::Build(const BuildContext& ctx)
     myCompiled->name = this->name;
 #endif
 
-    BuildContext newCtx = { ctx.script, ctx.allocator, myCompiled->subpasses, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
     for (IndexT i = 0; i < this->children.Size(); i++)
     {
+        // Create new build context for each subpass
+        BuildContext newCtx = { myCompiled->pass, i, ctx.allocator, myCompiled->subpasses, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
         this->children[i]->Build(newCtx);
     }
 

--- a/code/render/frame/framepass.h
+++ b/code/render/frame/framepass.h
@@ -51,13 +51,7 @@ public:
 private:
     friend class FrameScript;
 
-    void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& buffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures) override;
+    void Build(const BuildContext& ctx) override;
 };
 
 } // namespace Frame2

--- a/code/render/frame/frameplugin.cc
+++ b/code/render/frame/frameplugin.cc
@@ -61,13 +61,7 @@ FramePlugin::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
 /**
 */
 void
-FramePlugin::Build(
-    Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-    Util::Array<FrameOp::Compiled*>& compiledOps,
-    Util::Array<CoreGraphics::EventId>& events,
-    Util::Array<CoreGraphics::BarrierId>& barriers,
-    Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers,
-    Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures)
+FramePlugin::Build(const BuildContext& ctx)
 {
     // if not enable, abort early
     if (!this->enabled)
@@ -76,15 +70,15 @@ FramePlugin::Build(
     auto callback = Frame::GetCallback(this->name);
     if (callback != nullptr)
     {
-        CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(allocator);
+        CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(ctx.allocator);
 
         myCompiled->func = callback;
         this->compiled = myCompiled;
 
         // only setup sync if the function could be found
         if (myCompiled->func != nullptr)
-            this->SetupSynchronization(allocator, events, barriers, rwBuffers, textures);
-        compiledOps.Append(myCompiled);
+            this->SetupSynchronization(ctx.allocator, ctx.events, ctx.barriers, ctx.buffers, ctx.textures);
+        ctx.compiledOps.Append(myCompiled);
     }
 }
 

--- a/code/render/frame/frameplugin.h
+++ b/code/render/frame/frameplugin.h
@@ -36,13 +36,7 @@ public:
 
 private:
 
-    void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures) override;
+    void Build(const BuildContext& ctx) override;
 };
 
 

--- a/code/render/frame/framescript.cc
+++ b/code/render/frame/framescript.cc
@@ -232,7 +232,7 @@ FrameScript::Build()
         }
     }
 
-    FrameOp::BuildContext buildContext { this, this->buildAllocator, this->compiled, this->events, this->barriers, buffers, textures };
+    FrameOp::BuildContext buildContext { CoreGraphics::InvalidPassId, 0xFFFFFFFF, this->buildAllocator, this->compiled, this->events, this->barriers, buffers, textures };
 
     // build ops
     for (i = 0; i < this->ops.Size(); i++)

--- a/code/render/frame/framescript.cc
+++ b/code/render/frame/framescript.cc
@@ -232,10 +232,12 @@ FrameScript::Build()
         }
     }
 
+    FrameOp::BuildContext buildContext { this, this->buildAllocator, this->compiled, this->events, this->barriers, buffers, textures };
+
     // build ops
     for (i = 0; i < this->ops.Size(); i++)
     {
-        this->ops[i]->Build(this->buildAllocator, this->compiled, this->events, this->barriers, buffers, textures);
+        this->ops[i]->Build(buildContext);
     }
 
     for (i = 0; i < textures.Size(); i++)

--- a/code/render/frame/framesubgraph.cc
+++ b/code/render/frame/framesubgraph.cc
@@ -79,7 +79,7 @@ FrameSubgraph::Build(const BuildContext& ctx)
     CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(ctx.allocator);
 
     // Just fetch subgraph and build it as if it was always a part of the frame script
-    BuildContext newCtx = { ctx.script, ctx.allocator, myCompiled->subgraphOps, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
+    BuildContext newCtx = { ctx.currentPass, ctx.subpass, ctx.allocator, myCompiled->subgraphOps, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
     for (Frame::FrameOp* op : ops)
     {
         op->Build(newCtx);

--- a/code/render/frame/framesubgraph.h
+++ b/code/render/frame/framesubgraph.h
@@ -36,13 +36,7 @@ public:
 
 private:
 
-    void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures) override;
+    void Build(const BuildContext& ctx) override;
 };
 
 /// Add a subgraph by name for the framescript

--- a/code/render/frame/framesubmission.cc
+++ b/code/render/frame/framesubmission.cc
@@ -166,7 +166,7 @@ FrameSubmission::Build(const BuildContext& ctx)
     CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(ctx.allocator);
 
     // build ops
-    BuildContext newCtx = { ctx.script, ctx.allocator, myCompiled->compiled, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
+    BuildContext newCtx = { ctx.currentPass, ctx.subpass, ctx.allocator, myCompiled->compiled, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
     for (IndexT i = 0; i < this->children.Size(); i++)
     {
         this->children[i]->Build(newCtx);

--- a/code/render/frame/framesubmission.cc
+++ b/code/render/frame/framesubmission.cc
@@ -157,31 +157,26 @@ FrameSubmission::AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator)
 /**
 */
 void
-FrameSubmission::Build(
-    Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-    Util::Array<FrameOp::Compiled*>& compiledOps,
-    Util::Array<CoreGraphics::EventId>& events,
-    Util::Array<CoreGraphics::BarrierId>& barriers,
-    Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers,
-    Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures)
+FrameSubmission::Build(const BuildContext& ctx)
 {
     // if not enable, abort early
     if (!this->enabled)
         return;
 
-    CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(allocator);
+    CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(ctx.allocator);
 
     // build ops
+    BuildContext newCtx = { ctx.script, ctx.allocator, myCompiled->compiled, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
     for (IndexT i = 0; i < this->children.Size(); i++)
     {
-        this->children[i]->Build(allocator, myCompiled->compiled, events, barriers, rwBuffers, textures);
+        this->children[i]->Build(newCtx);
     }
 
     this->compiled = myCompiled;
     for (IndexT i = 0; i < this->waitSubmissions.Size(); i++)
         myCompiled->waitSubmissions.Append(static_cast<FrameSubmission::CompiledImpl*>(this->waitSubmissions[i]->compiled));
     myCompiled->commandBufferPool = this->commandBufferPool;
-    compiledOps.Append(this->compiled);
+    ctx.compiledOps.Append(this->compiled);
 }
 
 } // namespace Frame

--- a/code/render/frame/framesubmission.h
+++ b/code/render/frame/framesubmission.h
@@ -45,13 +45,7 @@ public:
     FrameOp::Compiled* AllocCompiled(Memory::ArenaAllocator<BIG_CHUNK>& allocator);
 
         /// build operation
-    virtual void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& rwBuffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures);
+    virtual void Build(const BuildContext& ctx);
 
     Util::Array<FrameSubmission*> waitSubmissions;
     Util::Array<CoreGraphics::QueueType> waitQueues;

--- a/code/render/frame/framesubpass.cc
+++ b/code/render/frame/framesubpass.cc
@@ -111,7 +111,7 @@ FrameSubpass::Build(const BuildContext& ctx)
     CompiledImpl* myCompiled = (CompiledImpl*)this->AllocCompiled(ctx.allocator);
 
     // Create new context with ops of this subgraph
-    BuildContext newCtx = { ctx.script, ctx.allocator, myCompiled->ops, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
+    BuildContext newCtx = { ctx.currentPass, ctx.subpass, ctx.allocator, myCompiled->ops, ctx.events, ctx.barriers, ctx.buffers, ctx.textures };
 
     for (IndexT i = 0; i < this->children.Size(); i++)
     {

--- a/code/render/frame/framesubpass.h
+++ b/code/render/frame/framesubpass.h
@@ -51,13 +51,7 @@ public:
 
 protected:
     friend class FramePass;
-    void Build(
-        Memory::ArenaAllocator<BIG_CHUNK>& allocator,
-        Util::Array<FrameOp::Compiled*>& compiledOps,
-        Util::Array<CoreGraphics::EventId>& events,
-        Util::Array<CoreGraphics::BarrierId>& barriers,
-        Util::Dictionary<CoreGraphics::BufferId, Util::Array<BufferDependency>>& buffers,
-        Util::Dictionary<CoreGraphics::TextureId, Util::Array<TextureDependency>>& textures) override;
+    void Build(const BuildContext& ctx) override;
 
 private:
     friend class FrameScriptLoader;


### PR DESCRIPTION
Pipelines should be first class citizens and we should really move away from using the SetProgram, SetVertexLayout, etc approach to a more pipeline oriented one. This PR allows for creations of pipelines from outside the render loop, as well as setting them on the command buffer, which is a first necessary step to avoid runtime pipeline creation.