### PR TITLE
Better safe allocators

### DIFF
--- a/code/addons/staticui/ultralight/ultralightrenderer.cc
+++ b/code/addons/staticui/ultralight/ultralightrenderer.cc
@@ -441,7 +441,7 @@ UltralightRenderer::DestroyGeometry(uint32_t geometry_id)
 void
 UltralightRenderer::UpdateCommandList(const ultralight::CommandList& list)
 {
-    this->commands.SetSize(list.size);
+    this->commands.Resize(list.size);
     memcpy(this->commands.Begin(), list.commands, list.size * sizeof(ultralight::Command));
 }
 

--- a/code/foundation/CMakeLists.txt
+++ b/code/foundation/CMakeLists.txt
@@ -114,6 +114,7 @@ nebula_begin_module(foundation)
             list.h
             localstringatomtable.cc
             localstringatomtable.h
+            pinnedarray.h
             priorityarray.h
             quadtree.h
             queue.h

--- a/code/foundation/core/types.h
+++ b/code/foundation/core/types.h
@@ -47,8 +47,8 @@ typedef ptrdiff_t ptrdiff;
 
 typedef int IndexT;         // the index type
 typedef int SizeT;          // the size type
-typedef int64_t Index64T;         // the index type
-typedef int64_t Size64T;          // the size type
+typedef int64_t Index64T;   // the index type
+typedef int64_t Size64T;    // the size type
 typedef uintptr PtrT;       // the ptr type
 typedef ptrdiff PtrDiff;
 static const int InvalidIndex = -1;

--- a/code/foundation/ids/idallocator.h
+++ b/code/foundation/ids/idallocator.h
@@ -101,7 +101,7 @@ private:
     struct name##Lock \
     { \
         name##Lock(name##Id element) : element(element) { allocator.Acquire(this->element.id24); } \
-        ~##name##Lock() { allocator.Release(this->element.id24); } \
+        ~name##Lock() { allocator.Release(this->element.id24); } \
     private: \
         name##Id element; \
     };

--- a/code/foundation/ids/idallocator.h
+++ b/code/foundation/ids/idallocator.h
@@ -85,12 +85,33 @@ private:
     Util::Array<uint32_t> freeIds;
 };
 
-template<class ... TYPES>
-class IdAllocatorSafe : public Util::ArrayAllocatorSafe<TYPES...>
+#define _DECL_ACQUIRE_RELEASE(ty) \
+    void ty##Acquire(const ty id); \
+    void ty##Release(const ty id);
+
+#define _IMPL_ACQUIRE_RELEASE(ty, allocator) \
+    void ty##Acquire(const ty id) { allocator.TryAcquire(id.id24); } \
+    void ty##Release(const ty id) { allocator.Release(id.id24); }
+
+#define _IMPL_ACQUIRE_RELEASE_RESOURCE(ty, allocator) \
+    void ty##Acquire(const ty id) { allocator.TryAcquire(id.resourceId); } \
+    void ty##Release(const ty id) { allocator.Release(id.resourceId); }
+
+#define _DECLARE_LOCK(name, allocator) \
+    struct name##Lock \
+    { \
+        name##Lock(name##Id element) : element(element) { allocator.TryAcquire(this->element.id24); } \
+        ~##name##Lock() { allocator.Release(this->element.id24); } \
+    private: \
+        name##Id element; \
+    };
+
+template<int MAX_ALLOCS, class... TYPES>
+class IdAllocatorSafe : public Util::ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>
 {
 public:
     /// constructor
-    IdAllocatorSafe(uint32_t maxid = 0xFFFFFFFF) : maxId(maxid)
+    IdAllocatorSafe()
     {
     };
 
@@ -98,20 +119,22 @@ public:
     uint32_t Alloc()
     {
         /// @note   This purposefully hides the default allocation method and should definitely not be virtual!
-        this->Lock(Util::ArrayAllocatorAccess::Write);
+        this->allocationLock.Lock();
         uint32_t index;
         if (this->freeIds.Size() > 0)
         {
             index = this->freeIds.Back();
+            this->owners[index] = Threading::Thread::GetMyThreadId();
             this->freeIds.EraseBack();
         }
         else
         {
             alloc_for_each_in_tuple(this->objects);
             index = this->size++;
-            n_assert2(this->maxId > index, "max amount of allocations exceeded!\n");
+            this->owners.Append(Threading::Thread::GetMyThreadId());
+            n_assert2(MAX_ALLOCS > index, "max amount of allocations exceeded!\n");
         }
-        this->Unlock(Util::ArrayAllocatorAccess::Write);
+        this->allocationLock.Unlock();
 
         return index;
     }
@@ -120,20 +143,12 @@ public:
     void Dealloc(uint32_t index)
     {
         // TODO: We could possibly get better performance when defragging if we insert it in reverse order (high to low)
-        this->Lock(Util::ArrayAllocatorAccess::Write);
+        this->allocationLock.Lock();
         this->freeIds.Append(index);
-        this->Unlock(Util::ArrayAllocatorAccess::Write);
-    }
-
-    /// Returns the list of free ids.
-    Util::Array<uint32_t>& FreeIds()
-    {
-        n_assert(this->inBeginGet);
-        return this->freeIds;
+        this->allocationLock.Unlock();
     }
 
 private:
-    uint32_t maxId = 0xFFFFFFFF;
     Util::Array<uint32_t> freeIds;
 };
 

--- a/code/foundation/ids/idallocator.h
+++ b/code/foundation/ids/idallocator.h
@@ -90,17 +90,17 @@ private:
     void ty##Release(const ty id);
 
 #define _IMPL_ACQUIRE_RELEASE(ty, allocator) \
-    void ty##Acquire(const ty id) { allocator.TryAcquire(id.id24); } \
+    void ty##Acquire(const ty id) { allocator.Acquire(id.id24); } \
     void ty##Release(const ty id) { allocator.Release(id.id24); }
 
 #define _IMPL_ACQUIRE_RELEASE_RESOURCE(ty, allocator) \
-    void ty##Acquire(const ty id) { allocator.TryAcquire(id.resourceId); } \
+    void ty##Acquire(const ty id) { allocator.Acquire(id.resourceId); } \
     void ty##Release(const ty id) { allocator.Release(id.resourceId); }
 
 #define _DECLARE_LOCK(name, allocator) \
     struct name##Lock \
     { \
-        name##Lock(name##Id element) : element(element) { allocator.TryAcquire(this->element.id24); } \
+        name##Lock(name##Id element) : element(element) { allocator.Acquire(this->element.id24); } \
         ~##name##Lock() { allocator.Release(this->element.id24); } \
     private: \
         name##Id element; \

--- a/code/foundation/memory/poolarrayallocator.cc
+++ b/code/foundation/memory/poolarrayallocator.cc
@@ -76,9 +76,9 @@ PoolArrayAllocator::Alloc(SizeT size)
     IndexT poolIndex = (size + 3) >> 5;
     if (poolIndex < NumPools)
     {
-        #if NEBULA_DEBUG
+#if NEBULA_DEBUG
         n_assert(uint(size) <= memoryPools[poolIndex].GetBlockSize());
-        #endif
+#endif
         void* ptr = this->memoryPools[poolIndex].Alloc();
         if (0 == ptr)
         {
@@ -90,9 +90,9 @@ PoolArrayAllocator::Alloc(SizeT size)
     else
     {
         // size too big, need to allocate directly from the heap
-        #if NEBULA_DEBUG
+#if NEBULA_DEBUG
         // n_printf("WARNING: Allocation of size '%d' in PoolArrayAllocator '%s' going directly to heap!\n", size, this->name);        
-        #endif
+#endif
         return Memory::Alloc(this->heapType, size);
     }
 }

--- a/code/foundation/memory/rangeallocator.h
+++ b/code/foundation/memory/rangeallocator.h
@@ -3,8 +3,9 @@
 /**
     @class Memory::RangeAllocator
     
-    Doesn't actually allocate memory, but is used to keep track of free ranges
-    of elements in a virtual memory buffer
+    An allocator that reserves a range of memory and outputs an offset to that
+    range. Doesn't allocate any memory but is supposed to be used on a single
+    memory block. 
 
     @copyright
     (C) 2020 Individual contributors, see AUTHORS file

--- a/code/foundation/threading/spinlock.h
+++ b/code/foundation/threading/spinlock.h
@@ -2,6 +2,7 @@
 //------------------------------------------------------------------------------
 /**
     A spinlock is a lock which keeps the core busy while the lock is being held.
+    Efficiently waits where we can guarantee the acquire/release happens within a short time. 
 
     Use with caution, as this is not a synchronization primitive, the OS won't 
     be able to yield the CPU core to other threads with the same affinity, which

--- a/code/foundation/util/array.h
+++ b/code/foundation/util/array.h
@@ -993,7 +993,7 @@ Array<TYPE, SMALL_VECTOR_SIZE>::Back() const
 */
 template<class TYPE, int SMALL_VECTOR_SIZE>
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::push_back(const TYPE& item)
+Array<TYPE, SMALL_VECTOR_SIZE>::push_back(const TYPE& item)
 {
     this->Append(item);
 }
@@ -1001,7 +1001,7 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::push_back(const TYPE& item)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 bool 
 Array<TYPE, SMALL_VECTOR_SIZE>::IsEmpty() const
 {
@@ -1566,7 +1566,7 @@ Array<TYPE, SMALL_VECTOR_SIZE>::Resize(SizeT num)
 */
 template<class TYPE, int SMALL_VECTOR_SIZE>
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::clear() noexcept
+Array<TYPE, SMALL_VECTOR_SIZE>::clear() noexcept
 {
     this->Clear();
 }

--- a/code/foundation/util/array.h
+++ b/code/foundation/util/array.h
@@ -1007,9 +1007,13 @@ Array<TYPE, SMALL_VECTOR_SIZE>::IsEmpty() const
 {
     return (this->count == 0);
 }
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<class TYPE, int SMALL_VECTOR_SIZE>
 bool
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::IsValidIndex(IndexT index) const
+Array<TYPE, SMALL_VECTOR_SIZE>::IsValidIndex(IndexT index) const
 {
     return this->elements && (index < this->count) && (index >= 0);
 }

--- a/code/foundation/util/array.h
+++ b/code/foundation/util/array.h
@@ -36,9 +36,7 @@
 #include "math/scalar.h"
 #include <type_traits>
 
-#ifdef __linux__
-#include <sys/mman.h>
-#endif
+
 
 //------------------------------------------------------------------------------
 namespace Util
@@ -58,14 +56,14 @@ struct _smallvector<TYPE, 0>
     TYPE* data() { return nullptr; }
 };
 
-template<class TYPE, int SMALL_VECTOR_SIZE = 0, bool PINNED = false> class Array
+template<class TYPE, int SMALL_VECTOR_SIZE = 0> class Array
 {
 public:
     /// define iterator
     typedef TYPE* Iterator;
     typedef const TYPE* ConstIterator;
 
-    using ArrayT = Array<TYPE, SMALL_VECTOR_SIZE, PINNED>;
+    using ArrayT = Array<TYPE, SMALL_VECTOR_SIZE>;
 
     /// constructor with default parameters
     Array();
@@ -73,8 +71,6 @@ public:
     Array(SizeT initialCapacity, SizeT initialGrow);
     /// constructor with initial size, grow size and initial values
     Array(SizeT initialSize, SizeT initialGrow, const TYPE& initialValue);
-    /// constructor for pinned array
-    Array(SizeT maxSize);
     /// copy constructor
     Array(const ArrayT& rhs);
     /// move constructor
@@ -89,17 +85,17 @@ public:
     ~Array();
 
     /// assignment operator
-    void operator=(const ArrayT& rhs);
+    void operator=(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs);
     /// move operator
-    void operator=(ArrayT&& rhs) noexcept;
+    void operator=(Array<TYPE, SMALL_VECTOR_SIZE>&& rhs) noexcept;
     /// [] operator
     TYPE& operator[](IndexT index) const;
     /// [] operator
     TYPE& operator[](IndexT index);
     /// equality operator
-    bool operator==(const ArrayT& rhs) const;
+    bool operator==(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs) const;
     /// inequality operator
-    bool operator!=(const ArrayT& rhs) const;
+    bool operator!=(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs) const;
     /// convert to "anything"
     template<typename T> T As() const;
 
@@ -114,7 +110,7 @@ public:
     /// append an element which is being forwarded
     void Append(TYPE&& elm);
     /// append the contents of an array to this array
-    void AppendArray(const ArrayT& rhs);
+    void AppendArray(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs);
     /// append from C array
     void AppendArray(const TYPE* arr, const SizeT count);
     /// Emplace item (create new item and return reference)
@@ -124,8 +120,6 @@ public:
     /// increase capacity to fit N more elements into the array.
     void Reserve(SizeT num);
     
-    /// set number of elements (clears existing content)
-    void SetSize(SizeT s);
     /// get number of elements in array
     const SizeT Size() const;
     /// return the byte size of the array.
@@ -191,7 +185,7 @@ public:
     /// clear contents and preallocate with new attributes
     void Realloc(SizeT capacity, SizeT grow);
     /// returns new array with elements which are not in rhs (slow!)
-    ArrayT Difference(const ArrayT& rhs);
+    ArrayT Difference(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs);
     /// sort the array
     void Sort();
     /// sort with custom function
@@ -224,7 +218,7 @@ protected:
     /// destroy an element (call destructor without freeing memory)
     void Destroy(TYPE* elm);
     /// copy content
-    void Copy(const ArrayT& src);
+    void Copy(const Array<TYPE, SMALL_VECTOR_SIZE>& src);
     /// delete content
     void Delete();
     /// grow array to target size
@@ -246,35 +240,30 @@ protected:
     TYPE* elements;                         // pointer to element array
 
     _smallvector<TYPE, SMALL_VECTOR_SIZE> stackElements;
-
-    struct _e {};
-    std::conditional_t<PINNED, SizeT, _e> maxCommitSize;
 };
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array() :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array() :
     grow(16),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(this->stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(SizeT _capacity, SizeT _grow) :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(SizeT _capacity, SizeT _grow) :
     grow(_grow),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(this->stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
     if (0 == this->grow)
     {
         this->grow = 16;
@@ -285,14 +274,13 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(SizeT _capacity, SizeT _grow) :
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(SizeT initialSize, SizeT _grow, const TYPE& initialValue) :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(SizeT initialSize, SizeT _grow, const TYPE& initialValue) :
     grow(_grow),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
     if (0 == this->grow)
     {
         this->grow = 16;
@@ -310,29 +298,13 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(SizeT initialSize, SizeT _grow, co
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(SizeT maxSize) :
-    grow(16),
-    capacity(0),
-    count(0),
-    elements(nullptr),
-    maxCommitSize(maxSize)
-{
-    static_assert(PINNED, "Array must be pinned to use this constructor");
-    static_assert(SMALL_VECTOR_SIZE == 0, "Pinned arrays may not use small vector optimization");
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(const TYPE* const buf, SizeT num) :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(const TYPE* const buf, SizeT num) :
     grow(16),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
     static_assert(std::is_trivially_copyable<TYPE>::value, "TYPE is not trivially copyable; Util::Array cannot be constructed from pointer of TYPE.");
     this->GrowTo(num);
     this->count = num;
@@ -343,14 +315,13 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(const TYPE* const buf, SizeT num) 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(std::initializer_list<TYPE> list) :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(std::initializer_list<TYPE> list) :
     grow(16),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
     this->GrowTo((SizeT)list.size());
     this->count = (SizeT)list.size();
     IndexT i;
@@ -363,35 +334,33 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(std::initializer_list<TYPE> list) 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(std::nullptr_t) :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(std::nullptr_t) :
     grow(16),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& rhs) :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs) :
     grow(16),
     capacity(SMALL_VECTOR_SIZE),
     count(0),
     elements(this->stackElements.data())
 {
-    static_assert(!PINNED, "Use the Array(SizeT) constructor for pinned arrays");
     this->Copy(rhs);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(Array<TYPE, SMALL_VECTOR_SIZE, PINNED>&& rhs) noexcept :
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Array(Array<TYPE, SMALL_VECTOR_SIZE>&& rhs) noexcept :
     grow(rhs.grow),
     capacity(rhs.capacity),
     count(rhs.count),
@@ -416,9 +385,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Array(Array<TYPE, SMALL_VECTOR_SIZE, PIN
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Copy(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& src)
+Array<TYPE, SMALL_VECTOR_SIZE>::Copy(const Array<TYPE, SMALL_VECTOR_SIZE>& src)
 {
     #if NEBULA_BOUNDSCHECKS
     // Make sure array is either empty, or stack array before copy
@@ -438,9 +407,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Copy(const Array<TYPE, SMALL_VECTOR_SIZE
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Delete()
+Array<TYPE, SMALL_VECTOR_SIZE>::Delete()
 {
     this->grow = 16;
     
@@ -448,15 +417,7 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Delete()
     {
         if (this->elements != this->stackElements.data())
         {
-            if constexpr (PINNED)
-            {
-                // If in small vector, run destructor
-                this->DestroyRange(0, this->count);
-
-                Memory::FreeVirtual(this->elements, this->capacity * sizeof(TYPE));
-            }
-            else
-                ArrayFree(this->capacity, this->elements);
+            ArrayFree(this->capacity, this->elements);
         }
         else
         {
@@ -472,8 +433,8 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Delete()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Destroy(TYPE* elm)
+template<class TYPE, int SMALL_VECTOR_SIZE> void
+Array<TYPE, SMALL_VECTOR_SIZE>::Destroy(TYPE* elm)
 {
     elm->~TYPE();
 }
@@ -481,8 +442,8 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Destroy(TYPE* elm)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::~Array()
+template<class TYPE, int SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::~Array()
 {
     this->Delete();
 }
@@ -490,8 +451,8 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::~Array()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Realloc(SizeT _capacity, SizeT _grow)
+template<class TYPE, int SMALL_VECTOR_SIZE> void
+Array<TYPE, SMALL_VECTOR_SIZE>::Realloc(SizeT _capacity, SizeT _grow)
 {
     this->Delete();
     this->grow = _grow;
@@ -510,8 +471,8 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Realloc(SizeT _capacity, SizeT _grow)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator=(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& rhs)
+template<class TYPE, int SMALL_VECTOR_SIZE> void 
+Array<TYPE, SMALL_VECTOR_SIZE>::operator=(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs)
 {
     if (this != &rhs)
     {
@@ -540,8 +501,8 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator=(const Array<TYPE, SMALL_VECTOR
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator=(Array<TYPE, SMALL_VECTOR_SIZE, PINNED>&& rhs) noexcept
+template<class TYPE, int SMALL_VECTOR_SIZE> void
+Array<TYPE, SMALL_VECTOR_SIZE>::operator=(Array<TYPE, SMALL_VECTOR_SIZE>&& rhs) noexcept
 {
     if (this != &rhs)
     {
@@ -562,8 +523,6 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator=(Array<TYPE, SMALL_VECTOR_SIZE,
         this->grow = rhs.grow;
         this->count = rhs.count;
         this->capacity = rhs.capacity;
-        if constexpr (PINNED)
-            this->maxCommitSize = rhs.maxCommitSize;
         rhs.count = 0;
         rhs.capacity = 0;
     }
@@ -572,61 +531,31 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator=(Array<TYPE, SMALL_VECTOR_SIZE,
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::GrowTo(SizeT newCapacity)
+template<class TYPE, int SMALL_VECTOR_SIZE> void
+Array<TYPE, SMALL_VECTOR_SIZE>::GrowTo(SizeT newCapacity)
 {
     if (newCapacity > SMALL_VECTOR_SIZE)
     {
-        if constexpr (PINNED)
+        TYPE* newArray = ArrayAlloc<TYPE>(newCapacity);
+        if (this->elements)
         {
-            if (this->elements == nullptr)
-            {
-                SizeT pageSize = System::PageSize;
-                SizeT reservationSize = Math::align(this->maxCommitSize * sizeof(TYPE), pageSize);
-                this->elements = (TYPE*)Memory::AllocVirtual(reservationSize);
-            }
+            this->MoveRange(newArray, this->elements, this->count);
 
-            SizeT pageSize = System::PageSize;
-
-            // Total amount of bytes needed to fill new capacity
-            SizeT totalByteSize = newCapacity * sizeof(TYPE);
-
-            // Rounded up to the page size so we don't waste memory we allocate anyways
-            SizeT totalBytesNeeded = Math::align(totalByteSize, pageSize);
-            n_assert(totalBytesNeeded <= this->maxCommitSize);
-            SizeT roundedUpNewCapacity = totalBytesNeeded / sizeof(TYPE);
-            SizeT offset = this->capacity * sizeof(TYPE);
-            if (totalBytesNeeded > offset)
-            {
-                // The amount of bytes we need to commit is the difference between the new and the old capacity
-                SizeT commitSize = (roundedUpNewCapacity - this->capacity) * sizeof(TYPE);
-                this->capacity = roundedUpNewCapacity;
-                Memory::CommitVirtual(((byte*)this->elements) + offset, commitSize);
-            }
+            // discard old array if not the stack array
+            if (this->elements != this->stackElements.data())
+                ArrayFree(this->capacity, this->elements);
         }
-        else
-        {
-            TYPE* newArray = ArrayAlloc<TYPE>(newCapacity);
-            if (this->elements)
-            {
-                this->MoveRange(newArray, this->elements, this->count);
-
-                // discard old array if not the stack array
-                if (this->elements != this->stackElements.data())
-                    ArrayFree(this->capacity, this->elements);
-            }
-            this->elements = newArray;
-            this->capacity = newCapacity;
-        }
+        this->elements = newArray;
+        this->capacity = newCapacity;
     }
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Grow()
+Array<TYPE, SMALL_VECTOR_SIZE>::Grow()
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->grow > 0);
@@ -659,9 +588,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Grow()
     30-Jan-03   floh    serious bugfixes!
     07-Dec-04   jo      bugfix: neededSize >= this->capacity => neededSize > capacity   
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Move(IndexT fromIndex, IndexT toIndex)
+Array<TYPE, SMALL_VECTOR_SIZE>::Move(IndexT fromIndex, IndexT toIndex)
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements);
@@ -710,9 +639,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Move(IndexT fromIndex, IndexT toIndex)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::DestroyRange(IndexT fromIndex, IndexT toIndex)
+Array<TYPE, SMALL_VECTOR_SIZE>::DestroyRange(IndexT fromIndex, IndexT toIndex)
 {    
     if constexpr (!std::is_trivially_destructible<TYPE>::value)
     {
@@ -721,20 +650,18 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::DestroyRange(IndexT fromIndex, IndexT to
             this->Destroy(&(this->elements[i]));
         }
     }
-#if NEBULA_DEBUG
     else
     {
         Memory::Clear((void*)&this->elements[fromIndex], sizeof(TYPE) * (toIndex - fromIndex));        
     }
-#endif
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::CopyRange(TYPE* to, TYPE* from, SizeT num)
+Array<TYPE, SMALL_VECTOR_SIZE>::CopyRange(TYPE* to, TYPE* from, SizeT num)
 {
     // this is a backward move
     if constexpr (!std::is_trivially_copyable<TYPE>::value)
@@ -754,9 +681,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::CopyRange(TYPE* to, TYPE* from, SizeT nu
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::MoveRange(TYPE* to, TYPE* from, SizeT num)
+Array<TYPE, SMALL_VECTOR_SIZE>::MoveRange(TYPE* to, TYPE* from, SizeT num)
 {
     // copy over contents
     if constexpr (!std::is_trivially_move_assignable<TYPE>::value && std::is_move_assignable<TYPE>::value)
@@ -776,9 +703,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::MoveRange(TYPE* to, TYPE* from, SizeT nu
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline TYPE& 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Get(IndexT index) const
+Array<TYPE, SMALL_VECTOR_SIZE>::Get(IndexT index) const
 {
 #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements != nullptr);
@@ -790,9 +717,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Get(IndexT index) const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Append(const TYPE& elm)
+Array<TYPE, SMALL_VECTOR_SIZE>::Append(const TYPE& elm)
 {
     // grow allocated space if exhausted
     if (this->count == this->capacity)
@@ -808,9 +735,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Append(const TYPE& elm)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Append(TYPE&& elm)
+Array<TYPE, SMALL_VECTOR_SIZE>::Append(TYPE&& elm)
 {
     // grow allocated space if exhausted
     if (this->count == this->capacity)
@@ -826,9 +753,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Append(TYPE&& elm)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::AppendArray(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& rhs)
+Array<TYPE, SMALL_VECTOR_SIZE>::AppendArray(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs)
 {
     SizeT neededCapacity = this->count + rhs.count;
     if (neededCapacity > this->capacity)
@@ -848,9 +775,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::AppendArray(const Array<TYPE, SMALL_VECT
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::AppendArray(const TYPE* arr, const SizeT count)
+Array<TYPE, SMALL_VECTOR_SIZE>::AppendArray(const TYPE* arr, const SizeT count)
 {
     SizeT neededCapacity = this->count + count;
     if (neededCapacity > this->capacity)
@@ -870,9 +797,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::AppendArray(const TYPE* arr, const SizeT
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 TYPE& 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Emplace()
+Array<TYPE, SMALL_VECTOR_SIZE>::Emplace()
 {
     // grow allocated space if exhausted
     if (this->count == this->capacity)
@@ -882,16 +809,16 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Emplace()
 #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements);
 #endif
-    this->elements[count] = TYPE();
+    this->elements[this->count] = TYPE();
     return this->elements[this->count++];
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 TYPE* 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EmplaceArray(const SizeT count)
+Array<TYPE, SMALL_VECTOR_SIZE>::EmplaceArray(const SizeT count)
 {
     SizeT neededCapacity = this->count + count;
     if (neededCapacity > this->capacity)
@@ -920,9 +847,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EmplaceArray(const SizeT count)
     NOTE: the functionality of this method has been changed as of 26-Apr-08,
     it will now only change the capacity of the array, not its size.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Reserve(SizeT num)
+Array<TYPE, SMALL_VECTOR_SIZE>::Reserve(SizeT num)
 {
 #if NEBULA_BOUNDSCHECKS
     n_assert(num >= 0);
@@ -938,9 +865,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Reserve(SizeT num)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 const SizeT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Size() const
+Array<TYPE, SMALL_VECTOR_SIZE>::Size() const
 {
     return this->count;
 }
@@ -948,9 +875,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Size() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 const SizeT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ByteSize() const
+Array<TYPE, SMALL_VECTOR_SIZE>::ByteSize() const
 {
     return this->count * sizeof(TYPE);
 }
@@ -958,9 +885,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ByteSize() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 const SizeT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Capacity() const
+Array<TYPE, SMALL_VECTOR_SIZE>::Capacity() const
 {
     return this->capacity;
 }
@@ -970,9 +897,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Capacity() const
     Access an element. This method will NOT grow the array, and instead do
     a range check, which may throw an assertion.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 TYPE&
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator[](IndexT index) const
+Array<TYPE, SMALL_VECTOR_SIZE>::operator[](IndexT index) const
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (index < this->count) && (index >= 0));
@@ -985,9 +912,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator[](IndexT index) const
     Access an element. This method will NOT grow the array, and instead do
     a range check, which may throw an assertion.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 TYPE&
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator[](IndexT index) 
+Array<TYPE, SMALL_VECTOR_SIZE>::operator[](IndexT index) 
 {
 #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (index < this->count) && (index >= 0));
@@ -1000,9 +927,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator[](IndexT index)
     The equality operator returns true if all elements are identical. The
     TYPE class must support the equality operator.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 bool
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator==(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& rhs) const
+Array<TYPE, SMALL_VECTOR_SIZE>::operator==(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs) const
 {
     if (rhs.Size() == this->Size())
     {
@@ -1028,9 +955,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator==(const Array<TYPE, SMALL_VECTO
     The inequality operator returns true if at least one element in the 
     array is different, or the array sizes are different.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 bool
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator!=(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& rhs) const
+Array<TYPE, SMALL_VECTOR_SIZE>::operator!=(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs) const
 {
     return !(*this == rhs);
 }
@@ -1038,9 +965,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::operator!=(const Array<TYPE, SMALL_VECTO
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 TYPE&
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Front() const
+Array<TYPE, SMALL_VECTOR_SIZE>::Front() const
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (this->count > 0));
@@ -1051,9 +978,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Front() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 TYPE&
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Back() const
+Array<TYPE, SMALL_VECTOR_SIZE>::Back() const
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (this->count > 0));
@@ -1064,7 +991,7 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Back() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 void
 Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::push_back(const TYPE& item)
 {
@@ -1076,7 +1003,7 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::push_back(const TYPE& item)
 */
 template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
 bool 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::IsEmpty() const
+Array<TYPE, SMALL_VECTOR_SIZE>::IsEmpty() const
 {
     return (this->count == 0);
 }
@@ -1090,9 +1017,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::IsValidIndex(IndexT index) const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseIndex(IndexT index)
+Array<TYPE, SMALL_VECTOR_SIZE>::EraseIndex(IndexT index)
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (index < this->count) && (index >= 0));
@@ -1112,9 +1039,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseIndex(IndexT index)
 /**    
     NOTE: this method is fast but destroys the sorting order!
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseIndexSwap(IndexT index)
+Array<TYPE, SMALL_VECTOR_SIZE>::EraseIndexSwap(IndexT index)
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (index < this->count) && (index >= 0));
@@ -1135,9 +1062,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseIndexSwap(IndexT index)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Erase(typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator iter)
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::Erase(typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator iter)
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (iter >= this->elements) && (iter < (this->elements + this->count)));
@@ -1150,9 +1077,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Erase(typename Array<TYPE, SMALL_VECTOR_
 /**
     NOTE: this method is fast but destroys the sorting order!
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseSwap(typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator iter)
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::EraseSwap(typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator iter)
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(this->elements && (iter >= this->elements) && (iter < (this->elements + this->count)));
@@ -1164,9 +1091,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseSwap(typename Array<TYPE, SMALL_VEC
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseRange(IndexT start, IndexT end)
+Array<TYPE, SMALL_VECTOR_SIZE>::EraseRange(IndexT start, IndexT end)
 {
     n_assert(end >= start);
     n_assert(end <= this->count);
@@ -1185,9 +1112,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseRange(IndexT start, IndexT end)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseBack()
+Array<TYPE, SMALL_VECTOR_SIZE>::EraseBack()
 {
     n_assert(this->count > 0);
     if constexpr (!std::is_trivially_destructible<TYPE>::value)
@@ -1198,9 +1125,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseBack()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseFront()
+Array<TYPE, SMALL_VECTOR_SIZE>::EraseFront()
 {
     this->EraseIndex(0);
 }
@@ -1208,9 +1135,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::EraseFront()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline TYPE 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::PopFront()
+Array<TYPE, SMALL_VECTOR_SIZE>::PopFront()
 {
     TYPE ret = std::move(this->elements[0]);
     this->EraseIndex(0);
@@ -1220,9 +1147,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::PopFront()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline TYPE 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::PopBack()
+Array<TYPE, SMALL_VECTOR_SIZE>::PopBack()
 {
     this->count--;
     return std::move(this->elements[this->count - 1]);
@@ -1231,9 +1158,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::PopBack()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Insert(IndexT index, const TYPE& elm)
+Array<TYPE, SMALL_VECTOR_SIZE>::Insert(IndexT index, const TYPE& elm)
 {
     #if NEBULA_BOUNDSCHECKS
     n_assert(index <= this->count && (index >= 0));
@@ -1255,9 +1182,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Insert(IndexT index, const TYPE& elm)
     The current implementation of this method does not shrink the 
     preallocated space. It simply sets the array _size to 0.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Clear()
+Array<TYPE, SMALL_VECTOR_SIZE>::Clear()
 {
     if (this->count > 0)
     {
@@ -1271,9 +1198,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Clear()
     This is identical with Clear(), but does NOT call destructors (it just
     resets the _size member. USE WITH CARE!
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Reset()
+Array<TYPE, SMALL_VECTOR_SIZE>::Reset()
 {
     this->count = 0;
 }
@@ -1282,20 +1209,20 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Reset()
 /**
     Free up memory and reset the grow
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Free()
+Array<TYPE, SMALL_VECTOR_SIZE>::Free()
 {
     this->Delete();
-    this->grow = 8;
+    this->grow = 16;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Begin() const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::Begin() const
 {
     return this->elements;
 }
@@ -1303,19 +1230,19 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Begin() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstIterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstBegin() const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::ConstIterator
+Array<TYPE, SMALL_VECTOR_SIZE>::ConstBegin() const
 {
-    return static_cast<Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstIterator>(this->elements);
+    return static_cast<Array<TYPE, SMALL_VECTOR_SIZE>::ConstIterator>(this->elements);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::End() const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::End() const
 {
     return this->elements + this->count;
 }
@@ -1323,11 +1250,11 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::End() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstIterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstEnd() const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::ConstIterator
+Array<TYPE, SMALL_VECTOR_SIZE>::ConstEnd() const
 {
-    return static_cast<Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstIterator>(this->elements + this->count);
+    return static_cast<Array<TYPE, SMALL_VECTOR_SIZE>::ConstIterator>(this->elements + this->count);
 }
 
 //------------------------------------------------------------------------------
@@ -1338,9 +1265,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::ConstEnd() const
     @param  elm     element to find
     @return         element iterator, or 0 if not found
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Find(const TYPE& elm, const IndexT start) const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::Find(const TYPE& elm, const IndexT start) const
 {
     n_assert(start <= this->count);
     IndexT index;
@@ -1362,9 +1289,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Find(const TYPE& elm, const IndexT start
     @param  elm     element to find
     @return         index to element, or InvalidIndex if not found
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 IndexT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::FindIndex(const TYPE& elm, const IndexT start) const
+Array<TYPE, SMALL_VECTOR_SIZE>::FindIndex(const TYPE& elm, const IndexT start) const
 {
     n_assert(start <= this->count);
     IndexT index;
@@ -1381,10 +1308,10 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::FindIndex(const TYPE& elm, const IndexT 
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 template<typename ...ELEM_TYPE>
 inline void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Append(const TYPE& first, const ELEM_TYPE&... elements)
+Array<TYPE, SMALL_VECTOR_SIZE>::Append(const TYPE& first, const ELEM_TYPE&... elements)
 {
     // The plus one is for the first element
     const int size = sizeof...(elements) + 1;
@@ -1411,10 +1338,10 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Append(const TYPE& first, const ELEM_TYP
     @param  elm     element to find
     @return         index to element, or InvalidIndex if not found
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 template<typename KEYTYPE> 
 inline IndexT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::FindIndex(typename std::enable_if<true, const KEYTYPE&>::type elm, const IndexT start) const
+Array<TYPE, SMALL_VECTOR_SIZE>::FindIndex(typename std::enable_if<true, const KEYTYPE&>::type elm, const IndexT start) const
 {
     n_assert(start <= this->count);
     IndexT index;
@@ -1437,9 +1364,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::FindIndex(typename std::enable_if<true, 
     @param  num     num elements to fill
     @param  elm     fill value
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Fill(IndexT first, SizeT num, const TYPE& elm)
+Array<TYPE, SMALL_VECTOR_SIZE>::Fill(IndexT first, SizeT num, const TYPE& elm)
 {
     if ((first + num) > this->count)
     {
@@ -1461,11 +1388,11 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Fill(IndexT first, SizeT num, const TYPE
 
     @todo this method is broken, check test case to see why!
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Difference(const Array<TYPE, SMALL_VECTOR_SIZE, PINNED>& rhs)
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+Array<TYPE, SMALL_VECTOR_SIZE>
+Array<TYPE, SMALL_VECTOR_SIZE>::Difference(const Array<TYPE, SMALL_VECTOR_SIZE>& rhs)
 {
-    Array<TYPE, SMALL_VECTOR_SIZE, PINNED> diff;
+    Array<TYPE, SMALL_VECTOR_SIZE> diff;
     IndexT i;
     SizeT num = rhs.Size();
     for (i = 0; i < num; i++)
@@ -1482,9 +1409,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Difference(const Array<TYPE, SMALL_VECTO
 /**
     Sorts the array. This just calls the STL sort algorithm.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Sort()
+Array<TYPE, SMALL_VECTOR_SIZE>::Sort()
 {
     std::sort(this->Begin(), this->End());
 }
@@ -1492,9 +1419,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Sort()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Util::Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::SortWithFunc(bool (*func)(const TYPE& lhs, const TYPE& rhs))
+Util::Array<TYPE, SMALL_VECTOR_SIZE>::SortWithFunc(bool (*func)(const TYPE& lhs, const TYPE& rhs))
 {
     std::sort(this->Begin(), this->End(), func);
 }
@@ -1504,9 +1431,9 @@ Util::Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::SortWithFunc(bool (*func)(const TY
     Does a binary search on the array, returns the index of the identical
     element, or InvalidIndex if not found
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 IndexT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::BinarySearchIndex(const TYPE& elm) const
+Array<TYPE, SMALL_VECTOR_SIZE>::BinarySearchIndex(const TYPE& elm) const
 {
     SizeT num = this->Size();
     if (num > 0)
@@ -1564,9 +1491,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::BinarySearchIndex(const TYPE& elm) const
     by using typename to put the template type in a non-deducable context.
     The enable_if does nothing except allow us to use typename.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 template<typename KEYTYPE> inline IndexT 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::BinarySearchIndex(typename std::enable_if<true, const KEYTYPE&>::type elm) const
+Array<TYPE, SMALL_VECTOR_SIZE>::BinarySearchIndex(typename std::enable_if<true, const KEYTYPE&>::type elm) const
 {
     SizeT num = this->Size();
     if (num > 0)
@@ -1618,15 +1545,15 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::BinarySearchIndex(typename std::enable_i
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Resize(SizeT num)
+Array<TYPE, SMALL_VECTOR_SIZE>::Resize(SizeT num)
 {
     if (num < this->count)
     {
         this->DestroyRange(num, this->count);
     }
-    else if (num > capacity)
+    else if (num > this->capacity)
     {
         this->GrowTo(num);
     }
@@ -1637,7 +1564,7 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Resize(SizeT num)
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 void
 Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::clear() noexcept
 {
@@ -1647,31 +1574,18 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::clear() noexcept
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
+template<class TYPE, int SMALL_VECTOR_SIZE>
 inline void 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Fit()
+Array<TYPE, SMALL_VECTOR_SIZE>::Fit()
 {
-    if constexpr (PINNED)
+    TYPE* newArray = ArrayAlloc<TYPE>(this->count);
+    if (this->elements)
     {
-        // The start offset of the memory has to be aligned to the page size
-        SizeT numUsedBytes = Math::align(this->count * sizeof(TYPE), System::PageSize);
-        SizeT numNeededPages = numUsedBytes / System::PageSize;
-        SizeT numUsedPages = this->capacity * sizeof(TYPE) / System::PageSize;
-        SizeT numFreeablePages = numUsedPages - numNeededPages;
-        
-        Memory::DecommitVirtual(((byte*)this->elements) + numUsedBytes, numFreeablePages * System::PageSize);
+        this->MoveRange(newArray, this->elements, this->count);
+        if (this->elements != this->stackElements.data())
+            ArrayFree(this->capacity, this->elements);
     }
-    else
-    {
-        TYPE* newArray = ArrayAlloc<TYPE>(this->count);
-        if (this->elements)
-        {
-            this->MoveRange(newArray, this->elements, this->count);
-            if (this->elements != this->stackElements.data())
-                ArrayFree(this->capacity, this->elements);
-        }
-        this->elements = newArray;
-    }
+    this->elements = newArray;
 
     this->capacity = this->count;
 }
@@ -1679,20 +1593,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Fit()
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED>
-void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::SetSize(SizeT s)
-{
-    if (this->count != s)
-        this->Realloc(s, 8);
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 inline constexpr SizeT 
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::TypeSize() const
+Array<TYPE, SMALL_VECTOR_SIZE>::TypeSize() const
 {
     return sizeof(TYPE);
 }
@@ -1700,19 +1603,20 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::TypeSize() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 size_t
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::size() const
+Array<TYPE, SMALL_VECTOR_SIZE>::size() const
 {
     return this->count;
 }
 
+
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::begin() const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::begin() const
 {
     return this->elements;
 }
@@ -1720,9 +1624,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::begin() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
-typename Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::Iterator
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::end() const
+template<class TYPE, int SMALL_VECTOR_SIZE> 
+typename Array<TYPE, SMALL_VECTOR_SIZE>::Iterator
+Array<TYPE, SMALL_VECTOR_SIZE>::end() const
 {
     return this->elements + this->count;
 }
@@ -1730,9 +1634,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::end() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 void
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::resize(size_t s)
+Array<TYPE, SMALL_VECTOR_SIZE>::resize(size_t s)
 {
     if (static_cast<SizeT>(s) > this->capacity)
     {
@@ -1747,9 +1651,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::resize(size_t s)
     This tests, whether the array is sorted. This is a slow operation
     O(n).
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 bool
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::IsSorted() const
+Array<TYPE, SMALL_VECTOR_SIZE>::IsSorted() const
 {
     if (this->count > 1)
     {
@@ -1771,9 +1675,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::IsSorted() const
     starting at a given index. Performance is O(n). Returns the index
     at which the element was added.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 IndexT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::InsertAtEndOfIdenticalRange(IndexT startIndex, const TYPE& elm)
+Array<TYPE, SMALL_VECTOR_SIZE>::InsertAtEndOfIdenticalRange(IndexT startIndex, const TYPE& elm)
 {
     IndexT i = startIndex + 1;
     for (; i < this->count; i++)
@@ -1795,9 +1699,9 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::InsertAtEndOfIdenticalRange(IndexT start
     This inserts the element into a sorted array. Returns the index
     at which the element was inserted.
 */
-template<class TYPE, int SMALL_VECTOR_SIZE, bool PINNED> 
+template<class TYPE, int SMALL_VECTOR_SIZE> 
 IndexT
-Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::InsertSorted(const TYPE& elm)
+Array<TYPE, SMALL_VECTOR_SIZE>::InsertSorted(const TYPE& elm)
 {
     SizeT num = this->Size();
     if (num == 0)
@@ -1882,11 +1786,8 @@ Array<TYPE, SMALL_VECTOR_SIZE, PINNED>::InsertSorted(const TYPE& elm)
     return InvalidIndex;
 }
 
-template<class TYPE>
-using PinnedArray = Array<TYPE, 0, true>;
-
 template<class TYPE, int STACK_SIZE>
-using StackArray = Array<TYPE, STACK_SIZE, false>;
+using StackArray = Array<TYPE, STACK_SIZE>;
 
 } // namespace Util
 //------------------------------------------------------------------------------

--- a/code/foundation/util/arrayallocatorsafe.h
+++ b/code/foundation/util/arrayallocatorsafe.h
@@ -409,7 +409,7 @@ bool
 ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::TryAcquire(const uint32_t index)
 {
     Threading::ThreadId myThread = Threading::Thread::GetMyThreadId();
-    Threading::ThreadId currentThread = Threading::Interlocked::CompareExchange((volatile long*)&this->owners[index], myThread, Threading::InvalidThreadId);
+    Threading::ThreadId currentThread = Threading::Interlocked::CompareExchange((volatile int*)&this->owners[index], myThread, Threading::InvalidThreadId);
     return currentThread == Threading::InvalidThreadId;
 }
 
@@ -425,7 +425,7 @@ ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Acquire(const uint32_t index)
         return;
 
     // Spinlock
-    while (Threading::Interlocked::CompareExchange((volatile long*)&this->owners[index], myThread, Threading::InvalidThreadId) != Threading::InvalidThreadId)
+    while (Threading::Interlocked::CompareExchange((volatile int*)&this->owners[index], myThread, Threading::InvalidThreadId) != Threading::InvalidThreadId)
     {
         Threading::Thread::YieldThread();
     };

--- a/code/foundation/util/arrayallocatorsafe.h
+++ b/code/foundation/util/arrayallocatorsafe.h
@@ -22,48 +22,45 @@
     (C) 2019-2020 Individual contributors, see AUTHORS file
 */
 //------------------------------------------------------------------------------
-#include "core/types.h"
-#include "util/array.h"
+#include "types.h"
+#include "util/pinnedarray.h"
 #include "threading/readwritelock.h"
+#include "threading/spinlock.h"
 #include <tuple>
 #include "tupleutility.h"
 #include "ids/id.h"
 
 // use this macro to safetly access an array allocator from within a scope
-#define __Lock(name, access) auto __allocator_lock_##name##__ = Util::AllocatorLock(&name, access);
+#define __Lock(name, element) auto __allocator_lock_##name##__ = Util::AllocatorLock(&name, element);
 
 // use this macro when we need to retrieve an allocator and lock it with an explicit name
-#define __LockName(allocator, name, access) auto __allocator_lock_##name##__ = Util::AllocatorLock(allocator, access);
+#define __LockName(allocator, name, element) auto __allocator_lock_##name##__ = Util::AllocatorLock(allocator, element);
 
 namespace Util
 {
 
-enum class ArrayAllocatorAccess
-{
-    Read,
-    Write
-};
-
 template<class T>
 struct AllocatorLock
 {
-    AllocatorLock(T* allocator, ArrayAllocatorAccess access)
+    AllocatorLock(T* allocator, uint32_t element)
         : allocator(allocator)
-        , access(access)
+        , element(element)
     {
-        this->allocator->Lock(this->access);
+        this->didAcquire = this->allocator->Acquire(this->element);
     };
 
     ~AllocatorLock()
     {
-        this->allocator->Unlock(this->access);
+        if (this->didAcquire)
+            this->allocator->Release(this->element);
     }
 
-    ArrayAllocatorAccess access;
+    bool didAcquire;
+    uint32_t element;
     T* allocator;
 };
 
-template <class ... TYPES>
+template <uint MAX_ALLOCS = 0xFFFF, class ... TYPES>
 class ArrayAllocatorSafe
 {
 public:
@@ -71,19 +68,19 @@ public:
     ArrayAllocatorSafe();
 
     /// move constructor
-    ArrayAllocatorSafe(ArrayAllocatorSafe<TYPES...>&& rhs);
+    ArrayAllocatorSafe(ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>&& rhs);
 
     /// copy constructor
-    ArrayAllocatorSafe(const ArrayAllocatorSafe<TYPES...>& rhs);
+    ArrayAllocatorSafe(const ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>& rhs);
 
     /// destructor
     ~ArrayAllocatorSafe();
 
     /// assign operator
-    void operator=(const ArrayAllocatorSafe<TYPES...>& rhs);
+    void operator=(const ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>& rhs);
 
     /// move operator
-    void operator=(ArrayAllocatorSafe<TYPES...>&& rhs);
+    void operator=(ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>&& rhs);
 
     /// allocate a new resource
     uint32_t Alloc();
@@ -97,6 +94,10 @@ public:
     /// get single item from resource
     template <int MEMBER>
     tuple_array_t<MEMBER, TYPES...>& Get(const uint32_t index);
+
+    /// Get const explicitly
+    template <int MEMBER>
+    const tuple_array_t<MEMBER, TYPES...>& ConstGet(const uint32_t index) const;
 
     /// same as 32 bit get, but const
     template <int MEMBER>
@@ -130,30 +131,28 @@ public:
     /// This will update the size to reflect the first member array size in objects.
     void UpdateSize();
 
-    /// Lock allocator
-    void Lock(const ArrayAllocatorAccess access = ArrayAllocatorAccess::Write);
-    /// Unlock allocator
-    void Unlock(const ArrayAllocatorAccess access = ArrayAllocatorAccess::Write);
-
-    /// get single item unsafe (use with extreme caution)
-    template<int MEMBER> Util::tuple_array_t<MEMBER, TYPES...>& GetUnsafe(const uint32_t index);
-    /// get single item unsafe (use with extreme caution)
-    template<int MEMBER> void SetUnsafe(const uint32_t index, const tuple_array_t<MEMBER, TYPES...>& type);
+    /// Spinlock to acquire 
+    void TryAcquire(const uint32_t index);
+    /// Acquire element, asserts if false and returns true if this call acquired
+    bool Acquire(const uint32_t index);
+    /// Release an object, the next thread that acquires may use this instance as it fits
+    void Release(const uint32_t index);
 
 protected:
-
-    Threading::ReadWriteLock lock;
-    volatile int numReaders;
-    volatile int writer;
+     
     uint32_t size;
-    std::tuple<Util::Array<TYPES>...> objects;
+    std::tuple<Util::PinnedArray<MAX_ALLOCS, TYPES>...> objects;
+    Util::Array<Threading::ThreadId> owners;
+
+    Threading::Spinlock allocationLock;
 };
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ... TYPES>
-inline ArrayAllocatorSafe<TYPES...>::ArrayAllocatorSafe() :
+template<uint MAX_ALLOCS, class ...TYPES> 
+inline 
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::ArrayAllocatorSafe() :
     size(0)
 {
     // empty
@@ -162,38 +161,39 @@ inline ArrayAllocatorSafe<TYPES...>::ArrayAllocatorSafe() :
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
-inline ArrayAllocatorSafe<TYPES...>::ArrayAllocatorSafe(ArrayAllocatorSafe<TYPES...>&& rhs)
+template<uint MAX_ALLOCS, class ...TYPES> 
+inline 
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::ArrayAllocatorSafe(ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>&& rhs)
 {
-    this->lock.LockWrite();
-    rhs.lock.LockRead();
+    this->allocationLock.Lock();
+    rhs.allocationLock.Lock();
     this->objects = rhs.objects;
     this->size = rhs.size;
-    this->lock.UnlockWrite();
-    rhs.lock.UnlockRead();
-    
-    rhs.lock.LockWrite();
     rhs.Clear();
-    rhs.lock.UnlockWrite();
+
+    this->allocationLock.Unlock();
+    rhs.allocationLock.Unlock();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
-inline ArrayAllocatorSafe<TYPES...>::ArrayAllocatorSafe(const ArrayAllocatorSafe<TYPES...>& rhs)
+template<uint MAX_ALLOCS, class ...TYPES> 
+inline
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::ArrayAllocatorSafe(const ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>& rhs)
 {
-    this->lock.LockWrite();
+    this->allocationLock.Lock();
     this->objects = rhs.objects;
     this->size = rhs.size;
-    this->lock.UnlockWrite();
+    this->allocationLock.Unlock();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
-inline ArrayAllocatorSafe<TYPES...>::~ArrayAllocatorSafe()
+template<uint MAX_ALLOCS, class ...TYPES> 
+inline
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::~ArrayAllocatorSafe()
 {
     // empty
 }
@@ -201,78 +201,83 @@ inline ArrayAllocatorSafe<TYPES...>::~ArrayAllocatorSafe()
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
-inline void
-ArrayAllocatorSafe<TYPES...>::operator=(const ArrayAllocatorSafe<TYPES...>& rhs)
+template<uint MAX_ALLOCS, class ...TYPES> 
+inline void 
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::operator=(const ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>& rhs)
 {
-    this->lock.LockWrite();
+    this->allocationLock.Lock();
     this->objects = rhs.objects;
     this->size = rhs.size;
-    this->lock.UnlockWrite();
+    this->allocationLock.Unlock();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 inline void
-ArrayAllocatorSafe<TYPES...>::operator=(ArrayAllocatorSafe<TYPES...>&& rhs)
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::operator=(ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>&& rhs)
 {
-    this->lock.LockWrite();
-    rhs.lock.LockRead();
+    this->allocationLock.Lock();
+    rhs.allocationLock.Lock();
     this->objects = rhs.objects;
     this->size = rhs.size;
-    this->lock.UnlockWrite();
-    rhs.lock.UnlockRead();
-
-    rhs.lock.LockWrite();
     rhs.Clear();
-    rhs.lock.UnlockWrite();
+
+    this->allocationLock.Unlock();
+    rhs.allocationLock.Unlock();
 }
 
 //------------------------------------------------------------------------------
 /**
+    Allocs an object AND acquires it
 */
-template<class ...TYPES>
-inline uint32_t ArrayAllocatorSafe<TYPES...>::Alloc()
+template<uint MAX_ALLOCS, class ...TYPES>
+inline uint32_t
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Alloc()
 {
-    this->lock.LockWrite();
+    this->allocationLock.Lock();
     alloc_for_each_in_tuple(this->objects);
     auto i = this->size++;
-    this->lock.UnlockWrite();
+    this->owners.Append(Threading::Thread::GetMyThreadId());
+    this->allocationLock.Unlock();
     return i;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
-inline void ArrayAllocatorSafe<TYPES...>::EraseIndex(const uint32_t id)
+template<uint MAX_ALLOCS, class ...TYPES>
+inline void
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::EraseIndex(const uint32_t id)
 {
-    this->lock.LockWrite();
+    n_assert(this->owners[id] == Threading::Thread::GetMyThreadId());
+    this->allocationLock.Lock();
     erase_index_for_each_in_tuple(this->objects, id);
+    this->allocationLock.Unlock();
     this->size--;
-    this->lock.UnlockWrite();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
-inline void ArrayAllocatorSafe<TYPES...>::EraseIndexSwap(const uint32_t id)
+template<uint MAX_ALLOCS, class ...TYPES>
+inline void
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::EraseIndexSwap(const uint32_t id)
 {
-    this->lock.LockWrite();
+    n_assert(this->owners[id] == Threading::Thread::GetMyThreadId());
+    this->allocationLock.Lock();
     erase_index_swap_for_each_in_tuple(this->objects, id);
+    this->allocationLock.Unlock();
     this->size--;
-    this->lock.UnlockWrite();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 inline const uint32_t
-ArrayAllocatorSafe<TYPES...>::Size() const
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Size() const
 {
     n_assert2(this->numReaders > 0, "Size requires a read lock");
     return this->size;
@@ -281,169 +286,160 @@ ArrayAllocatorSafe<TYPES...>::Size() const
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 inline void
-ArrayAllocatorSafe<TYPES...>::Reserve(uint32_t num)
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Reserve(uint32_t num)
 {
-    this->lock.LockWrite();
+    this->allocationLock.Lock();
     reserve_for_each_in_tuple(this->objects, num);
-    this->lock.UnlockWrite();
+    this->allocationLock.Unlock();
     // Size is still the same.
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 inline void
-ArrayAllocatorSafe<TYPES...>::Clear()
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Clear()
 {
-    this->lock.LockWrite();
+    this->allocationLock.Enter();
     clear_for_each_in_tuple(this->objects);
     this->size = 0;
-    this->lock.UnlockWrite();
+    this->allocationLock.Leave();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 template<int MEMBER>
 inline tuple_array_t<MEMBER, TYPES...>&
-ArrayAllocatorSafe<TYPES...>::Get(const uint32_t index)
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Get(const uint32_t index)
 {
-    n_assert2(this->writer == 1, "Non-const Get requires a write lock");
+    n_assert(this->owners[index] == Threading::Thread::GetMyThreadId());
     return std::get<MEMBER>(this->objects)[index];
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 template<int MEMBER>
 inline const tuple_array_t<MEMBER, TYPES...>&
-ArrayAllocatorSafe<TYPES...>::Get(const uint32_t index) const
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::ConstGet(const uint32_t index) const
 {
-    n_assert2(this->numReaders > 0, "Const Get requires a read lock");
+    // Allow const get when no thread is owning the element as well
+    n_assert(this->owners[index] == Threading::Thread::GetMyThreadId() || this->owners[index] == Threading::InvalidThreadId);
     return std::get<MEMBER>(this->objects)[index];
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
+template<int MEMBER>
+inline const tuple_array_t<MEMBER, TYPES...>&
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Get(const uint32_t index) const
+{
+    // Allow const get when no thread is owning the element as well
+    n_assert(this->owners[index] == Threading::Thread::GetMyThreadId() || this->owners[index] == Threading::InvalidThreadId);
+    return std::get<MEMBER>(this->objects)[index];
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<uint MAX_ALLOCS, class ...TYPES>
 template<int MEMBER>
 inline void 
-ArrayAllocatorSafe<TYPES...>::Set(const uint32_t index, const tuple_array_t<MEMBER, TYPES...>& type)
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Set(const uint32_t index, const tuple_array_t<MEMBER, TYPES...>& type)
 {
-    n_assert2(this->writer == 1, "Set requires a write lock");
+    n_assert(this->owners[index] == Threading::Thread::GetMyThreadId());
     std::get<MEMBER>(this->objects)[index] = type;
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 template<int MEMBER>
 inline const Util::Array<tuple_array_t<MEMBER, TYPES...>>&
-ArrayAllocatorSafe<TYPES...>::GetArray() const
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::GetArray() const
 {
-    n_assert2(this->numReaders > 0, "const GetArray requires a read lock");
     return std::get<MEMBER>(this->objects);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
 template<int MEMBER>
 inline Util::Array<tuple_array_t<MEMBER, TYPES...>>&
-ArrayAllocatorSafe<TYPES...>::GetArray()
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::GetArray()
 {
-    n_assert2(this->writer == 1, "Non-const GetArray requires a write lock");
     return std::get<MEMBER>(this->objects);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES> void
-ArrayAllocatorSafe<TYPES...>::Set(const uint32_t index, TYPES... values)
+template<uint MAX_ALLOCS, class ...TYPES> 
+void
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Set(const uint32_t index, TYPES... values)
 {
-    n_assert(this->writer == 1);
     set_for_each_in_tuple(this->objects, index, values...);
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES> void
-ArrayAllocatorSafe<TYPES...>::UpdateSize()
+template<uint MAX_ALLOCS, class ...TYPES>
+void
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::UpdateSize()
 {
-    n_assert(this->writer == 1);
     this->size = this->GetArray<0>().Size();
 }
 
 //------------------------------------------------------------------------------
 /**
 */
-template<class ...TYPES>
+template<uint MAX_ALLOCS, class ...TYPES>
+void 
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::TryAcquire(const uint32_t index)
+{
+    Threading::ThreadId myThread = Threading::Thread::GetMyThreadId();
+    if (this->owners[index] == myThread)
+        return;
+
+    // Spinlock
+    while (Threading::Interlocked::CompareExchange((volatile long*)&this->owners[index], myThread, Threading::InvalidThreadId) != Threading::InvalidThreadId)
+    {
+        Threading::Thread::YieldThread();
+    };
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<uint MAX_ALLOCS, class ...TYPES>
+inline bool 
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Acquire(const uint32_t index)
+{
+    Threading::ThreadId myThread = Threading::Thread::GetMyThreadId();
+    Threading::ThreadId currentThread = Threading::Interlocked::CompareExchange((volatile long*)&this->owners[index], myThread, Threading::InvalidThreadId);
+    return currentThread == Threading::InvalidThreadId;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<uint MAX_ALLOCS, class ...TYPES>
 inline void 
-ArrayAllocatorSafe<TYPES...>::Lock(const ArrayAllocatorAccess access)
+ArrayAllocatorSafe<MAX_ALLOCS, TYPES...>::Release(const uint32_t index)
 {
-    if (access == ArrayAllocatorAccess::Read)
-    {
-        this->lock.LockRead();
-        Threading::Interlocked::Increment(&this->numReaders);
-    }
-    else
-    {
-        this->lock.LockWrite();
-        Threading::Interlocked::Exchange(&this->writer, 1);
-    }
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-template<class ...TYPES>
-inline void 
-ArrayAllocatorSafe<TYPES...>::Unlock(const ArrayAllocatorAccess access)
-{
-    if (access == ArrayAllocatorAccess::Read)
-    {
-        this->lock.UnlockRead();
-        Threading::Interlocked::Decrement(&this->numReaders);
-    }
-    else
-    {
-        this->lock.UnlockWrite();
-        Threading::Interlocked::Exchange(&this->writer, 1);
-    }
-}
-
-//------------------------------------------------------------------------------
-/**
-    Get single item unsafetly, use with caution
-*/
-template<class ... TYPES>
-template<int MEMBER>
-Util::tuple_array_t<MEMBER, TYPES...>&
-ArrayAllocatorSafe<TYPES...>::GetUnsafe(const uint32_t index)
-{
-    return std::get<MEMBER>(this->objects)[index];
-}
-
-//------------------------------------------------------------------------------
-/**
-    Get single item unsafetly, use with caution
-*/
-template<class ... TYPES>
-template<int MEMBER>
-void
-ArrayAllocatorSafe<TYPES...>::SetUnsafe(const uint32_t index, const tuple_array_t<MEMBER, TYPES...>& type)
-{
-    std::get<MEMBER>(this->objects)[index] = type;
+    n_assert(this->owners[index] == Threading::Thread::GetMyThreadId());
+    this->owners[index] = Threading::InvalidThreadId;
 }
 
 } // namespace Util

--- a/code/foundation/util/pinnedarray.h
+++ b/code/foundation/util/pinnedarray.h
@@ -1,0 +1,813 @@
+#pragma once
+//------------------------------------------------------------------------------
+/**
+    A pinned array is an array which manages its own virtual memory
+
+    @copyright
+    (C) 2022 Individual contributors, see AUTHORS file
+*/
+//------------------------------------------------------------------------------
+#include "array.h"
+
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
+
+namespace Util
+{
+
+template<int MAX_ALLOCS, class TYPE>
+class PinnedArray : public Array<TYPE>
+{
+
+public:
+
+    /// Default constructor
+    PinnedArray();
+    /// Construct from other pinned array
+    PinnedArray(const PinnedArray<MAX_ALLOCS, TYPE>& rhs);
+    /// Construct from capacity and grow
+    PinnedArray(SizeT capacity, SizeT grow);
+    /// Construct from initial commit size, grow and value
+    PinnedArray(SizeT initialSize, SizeT grow, const TYPE& initialValue);
+    /// Construct from pointer and size
+    PinnedArray(const TYPE* const buf, SizeT num);
+    /// Construct from initializer list
+    PinnedArray(std::initializer_list<TYPE> list);
+    /// Destructor
+    ~PinnedArray();
+
+    /// assignment operator
+    void operator=(const PinnedArray<MAX_ALLOCS, TYPE>& rhs);
+    /// move operator
+    void operator=(PinnedArray<MAX_ALLOCS, TYPE>&& rhs) noexcept;
+
+    /// Append multiple elements to the end of the array
+    template <typename ...ELEM_TYPE>
+    void Append(const TYPE& first, const ELEM_TYPE&... elements);
+    /// Append single element
+    void Append(const TYPE& elm);
+    /// Append single element as rhs
+    void Append(const TYPE&& elm);
+    /// Emplace element and return reference to it
+    TYPE& Emplace();
+    /// insert element before element at index
+    void Insert(IndexT index, const TYPE& elm);
+    /// insert element into sorted array, return index where element was included
+    IndexT InsertSorted(const TYPE& elm);
+    /// insert element at the first non-identical position, return index of inclusion position
+    IndexT InsertAtEndOfIdenticalRange(IndexT startIndex, const TYPE& elm);
+
+    /// Append contents of another array
+    void AppendArray(const PinnedArray<MAX_ALLOCS, TYPE>& src);
+    /// Append contents of C array
+    void AppendArray(const TYPE* arr, const SizeT count);
+    /// Emplace an array of elements and return pointer
+    TYPE* EmplaceArray(const SizeT count);
+
+    /// Fill array with element
+    void Fill(IndexT first, SizeT num, const TYPE& elm);
+
+    /// Reserve an amount of memory (commits to memory)
+    void Reserve(const SizeT count);
+    /// Reallocate and clear
+    void Realloc(SizeT capacity, SizeT grow);
+    /// Resize to fit, destroys elements outside of new size
+    void Resize(SizeT num);
+
+    /// Free memory
+    void Free();
+
+    /// Fit array to capacity
+    void Fit();
+private:
+    /// Grow array using growth parameter
+    void Grow();
+    /// Grow array by size
+    void GrowTo(SizeT newCapacity);
+    /// Delete array
+    void Delete();
+    /// Copy from array
+    void Copy(const PinnedArray<MAX_ALLOCS, TYPE>& src);
+    /// move elements, grows array if needed
+    void Move(IndexT fromIndex, IndexT toIndex);
+};
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline 
+PinnedArray<MAX_ALLOCS, TYPE>::PinnedArray()
+{
+    this->grow = 16;
+    this->capacity = 0;
+    this->count = 0;
+    this->elements = nullptr;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline 
+PinnedArray<MAX_ALLOCS, TYPE>::PinnedArray(const PinnedArray<MAX_ALLOCS, TYPE>& rhs)
+{
+    this->Copy(rhs);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline
+PinnedArray<MAX_ALLOCS, TYPE>::PinnedArray(SizeT capacity, SizeT grow)
+{
+    this->grow = grow;
+    this->capacity = 0;
+    this->count = 0;
+    this->elements = nullptr;
+    if (0 == this->grow)
+    {
+        this->grow = 16;
+    }
+    this->GrowTo(capacity);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline 
+PinnedArray<MAX_ALLOCS, TYPE>::PinnedArray(SizeT initialSize, SizeT grow, const TYPE& initialValue)
+{
+    this->grow = grow;
+    this->capacity = 0;
+    this->count = 0;
+    this->elements = nullptr;
+    if (0 == this->grow)
+    {
+        this->grow = 16;
+    }
+
+    this->GrowTo(initialSize);
+    this->count = initialSize;
+    IndexT i;
+    for (i = 0; i < initialSize; i++)
+    {
+        this->elements[i] = initialValue;
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline 
+PinnedArray<MAX_ALLOCS, TYPE>::PinnedArray(const TYPE* const buf, SizeT num)
+{
+    this->grow = 16;
+    this->capacity = 0;
+    this->count = 0;
+    this->elements = nullptr;
+
+    static_assert(std::is_trivially_copyable<TYPE>::value, "TYPE is not trivially copyable; Util::Array cannot be constructed from pointer of TYPE.");
+    this->GrowTo(num);
+    this->count = num;
+    const SizeT bytes = num * sizeof(TYPE);
+    Memory::Copy(buf, this->elements, bytes);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline 
+PinnedArray<MAX_ALLOCS, TYPE>::PinnedArray(std::initializer_list<TYPE> list)
+{
+    this->grow = 16;
+    this->capacity = 0;
+    this->count = 0;
+    this->elements = nullptr;
+
+    this->GrowTo((SizeT)list.size());
+    this->count = (SizeT)list.size();
+    IndexT i;
+    for (i = 0; i < this->count; i++)
+    {
+        this->elements[i] = list.begin()[i];
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline 
+PinnedArray<MAX_ALLOCS, TYPE>::~PinnedArray()
+{
+    this->Delete();
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::operator=(const PinnedArray<MAX_ALLOCS, TYPE>& rhs)
+{
+    if (this != &rhs)
+    {
+        if ((this->capacity > 0) && (rhs.count <= this->capacity))
+        {
+            // source array fits into our capacity, copy in place
+            n_assert(0 != this->elements);
+
+            this->CopyRange(this->elements, rhs.elements, rhs.count);
+            if (rhs.count < this->count)
+            {
+                this->DestroyRange(rhs.count, this->count);
+            }
+            this->grow = rhs.grow;
+            this->count = rhs.count;
+        }
+        else
+        {
+            // source array doesn't fit into our capacity, need to reallocate
+            this->Delete();
+            this->Copy(rhs);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::operator=(PinnedArray<MAX_ALLOCS, TYPE>&& rhs) noexcept
+{
+    if (this != &rhs)
+    {
+        this->Delete();
+
+        // If rhs is not using stack, simply reassign pointers
+        if (rhs.elements != rhs.stackElements.data())
+        {
+            this->elements = rhs.elements;
+            rhs.elements = nullptr;
+        }
+        else
+        {
+            // Otherwise, move every element over to the stack of this array
+            this->MoveRange(this->elements, rhs.elements, rhs.count);
+        }
+
+        this->grow = rhs.grow;
+        this->count = rhs.count;
+        this->capacity = rhs.capacity;
+        rhs.count = 0;
+        rhs.capacity = 0;
+    }
+}
+
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+template<typename ...ELEM_TYPE>
+inline void
+PinnedArray<MAX_ALLOCS, TYPE>::Append(const TYPE& first, const ELEM_TYPE & ...elements)
+{
+    // The plus one is for the first element
+    const int size = sizeof...(elements) + 1;
+    this->Reserve(size);
+    TYPE res[size] = { first, elements... };
+    for (IndexT i = 0; i < size; i++)
+    {
+        this->elements[this->count++] = res[i];
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Append(const TYPE& elm)
+{
+    // grow allocated space if exhausted
+    if (this->count == this->capacity)
+    {
+        this->Grow();
+    }
+#if NEBULA_BOUNDSCHECKS
+    n_assert(this->elements);
+#endif
+    this->elements[this->count++] = std::move(elm);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Append(const TYPE&& elm)
+{
+    // grow allocated space if exhausted
+    if (this->count == this->capacity)
+    {
+        this->Grow();
+    }
+#if NEBULA_BOUNDSCHECKS
+    n_assert(this->elements);
+#endif
+    this->elements[this->count++] = std::move(elm);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline TYPE& 
+PinnedArray<MAX_ALLOCS, TYPE>::Emplace()
+{
+    // grow allocated space if exhausted
+    if (this->count == this->capacity)
+    {
+        this->Grow();
+    }
+#if NEBULA_BOUNDSCHECKS
+    n_assert(this->elements);
+#endif
+    this->elements[this->count] = TYPE();
+    return this->elements[this->count++];
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Insert(IndexT index, const TYPE& elm)
+{
+#if NEBULA_BOUNDSCHECKS
+    n_assert(index <= this->count && (index >= 0));
+#endif
+    if (index == this->count)
+    { 
+        // special case: append element to back
+        this->Append(elm);
+    }
+    else
+    {
+        this->Move(index, index + 1);
+        this->elements[index] = elm;
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline IndexT PinnedArray<MAX_ALLOCS, TYPE>::InsertSorted(const TYPE& elm)
+{
+    SizeT num = this->Size();
+    if (num == 0)
+    {
+        // array is currently empty
+        this->Append(elm);
+        return this->Size() - 1;
+    }
+    else
+    {
+        IndexT half;
+        IndexT lo = 0;
+        IndexT hi = num - 1;
+        IndexT mid;
+        while (lo <= hi)
+        {
+            if (0 != (half = num / 2))
+            {
+                mid = lo + ((num & 1) ? half : (half - 1));
+                if (elm < this->elements[mid])
+                {
+                    hi = mid - 1;
+                    num = num & 1 ? half : half - 1;
+                }
+                else if (elm > this->elements[mid])
+                {
+                    lo = mid + 1;
+                    num = half;
+                }
+                else
+                {
+                    // element already exists at [mid], append the
+                    // new element to the end of the range
+                    return this->InsertAtEndOfIdenticalRange(mid, elm);
+                }
+            }
+            else if (0 != num)
+            {
+                if (elm < this->elements[lo])
+                {
+                    this->Insert(lo, elm);
+                    return lo;
+                }
+                else if (elm > this->elements[lo])
+                {
+                    this->Insert(lo + 1, elm);
+                    return lo + 1;
+                }
+                else
+                {
+                    // element already exists at [low], append 
+                    // the new element to the end of the range
+                    return this->InsertAtEndOfIdenticalRange(lo, elm);
+                }
+            }
+            else
+            {
+#if NEBULA_BOUNDSCHECKS
+                n_assert(0 == lo);
+#endif
+                this->Insert(lo, elm);
+                return lo;
+            }
+        }
+        if (elm < this->elements[lo])
+        {
+            this->Insert(lo, elm);
+            return lo;
+        }
+        else if (elm > this->elements[lo])
+        {
+            this->Insert(lo + 1, elm);
+            return lo + 1;
+        }
+        else
+        {
+            // can't happen(?)
+        }
+    }
+    // can't happen
+    n_error("Array::InsertSorted: Can't happen!");
+    return InvalidIndex;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline IndexT PinnedArray<MAX_ALLOCS, TYPE>::InsertAtEndOfIdenticalRange(IndexT startIndex, const TYPE& elm)
+{
+    IndexT i = startIndex + 1;
+    for (; i < this->count; i++)
+    {
+        if (this->elements[i] != elm)
+        {
+            this->Insert(i, elm);
+            return i;
+        }
+    }
+
+    // fallthrough: new element needs to be appended to end
+    this->Append(elm);
+    return (this->Size() - 1);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::AppendArray(const PinnedArray<MAX_ALLOCS, TYPE>& src)
+{
+    SizeT neededCapacity = this->count + src.count;
+    if (neededCapacity > this->capacity)
+    {
+        this->GrowTo(neededCapacity);
+    }
+
+    // forward elements from array
+    IndexT i;
+    for (i = 0; i < src.count; i++)
+    {
+        this->elements[this->count + i] = src.elements[i];
+    }
+    this->count += src.count;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::AppendArray(const TYPE* arr, const SizeT count)
+{
+    SizeT neededCapacity = this->count + count;
+    if (neededCapacity > this->capacity)
+    {
+        this->GrowTo(neededCapacity);
+    }
+
+    // forward elements from array
+    IndexT i;
+    for (i = 0; i < count; i++)
+    {
+        this->elements[this->count + i] = arr[i];
+    }
+    this->count += count;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline TYPE* 
+PinnedArray<MAX_ALLOCS, TYPE>::EmplaceArray(const SizeT count)
+{
+    SizeT neededCapacity = this->count + count;
+    if (neededCapacity > this->capacity)
+    {
+        this->GrowTo(neededCapacity);
+    }
+
+    // forward elements from array
+    IndexT i;
+    for (i = 0; i < count; i++)
+    {
+        this->elements[this->count + i] = TYPE();
+    }
+    TYPE* first = this->elements[this->count];
+    this->count += count;
+    return first;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Fill(IndexT first, SizeT num, const TYPE& elm)
+{
+    if ((first + num) > this->count)
+    {
+        this->GrowTo(first + num);
+        this->count = first + num;
+    }
+
+    IndexT i;
+    for (i = first; i < (first + num); i++)
+    {
+        this->elements[i] = elm;
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Reserve(const SizeT count)
+{
+#if NEBULA_BOUNDSCHECKS
+    n_assert(count >= 0);
+#endif
+
+    SizeT neededCapacity = this->count + count;
+    if (neededCapacity > this->capacity)
+    {
+        this->GrowTo(neededCapacity);
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Realloc(SizeT capacity, SizeT grow)
+{
+    this->Delete();
+    this->grow = grow;
+    this->capacity = capacity;
+    this->count = capacity;
+    if (this->capacity > 0)
+    {
+        this->GrowTo(this->capacity);
+    }
+    else
+    {
+        this->elements = 0;
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Resize(SizeT num)
+{
+    if (num < this->count)
+    {
+        this->DestroyRange(num, this->count);
+    }
+    else if (num > this->capacity)
+    {
+        this->GrowTo(num);
+    }
+
+    this->count = num;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Free()
+{
+    this->Delete();
+    this->grow = 16;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Fit()
+{
+    // The start offset of the memory has to be aligned to the page size
+    SizeT numUsedBytes = Math::align(this->count * sizeof(TYPE), System::PageSize);
+    SizeT numNeededPages = numUsedBytes / System::PageSize;
+    SizeT numUsedPages = this->capacity * sizeof(TYPE) / System::PageSize;
+    SizeT numFreeablePages = numUsedPages - numNeededPages;
+
+    Memory::DecommitVirtual(((byte*)this->elements) + numUsedBytes, numFreeablePages * System::PageSize);
+    this->capacity = this->count;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Grow()
+{
+#if NEBULA_BOUNDSCHECKS
+    n_assert(this->grow > 0);
+#endif
+
+    SizeT growToSize;
+    if (0 == this->capacity)
+    {
+        growToSize = this->grow;
+    }
+    else
+    {
+        // grow by half of the current capacity, but never more then MaxGrowSize
+        SizeT growBy = this->capacity >> 1;
+        if (growBy == 0)
+        {
+            growBy = Array<TYPE>::MinGrowSize;
+        }
+        else if (growBy > Array<TYPE>::MaxGrowSize)
+        {
+            growBy = Array<TYPE>::MaxGrowSize;
+        }
+        growToSize = this->capacity + growBy;
+    }
+    this->GrowTo(growToSize);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::GrowTo(SizeT newCapacity)
+{
+    if (this->elements == nullptr)
+    {
+        SizeT pageSize = System::PageSize;
+        SizeT reservationSize = Math::align(MAX_ALLOCS * sizeof(TYPE), pageSize);
+        this->elements = (TYPE*)Memory::AllocVirtual(reservationSize);
+    }
+
+    SizeT pageSize = System::PageSize;
+
+    // Total amount of bytes needed to fill new capacity
+    SizeT totalByteSize = newCapacity * sizeof(TYPE);
+
+    // Rounded up to the page size so we don't waste memory we allocate anyways
+    SizeT totalBytesNeeded = Math::align(totalByteSize, pageSize);
+    n_assert(totalBytesNeeded <= MAX_ALLOCS * sizeof(TYPE));
+    SizeT roundedUpNewCapacity = totalBytesNeeded / sizeof(TYPE);
+    SizeT offset = this->capacity * sizeof(TYPE);
+    if (totalBytesNeeded > offset)
+    {
+        // The amount of bytes we need to commit is the difference between the new and the old capacity
+        SizeT commitSize = (roundedUpNewCapacity - this->capacity) * sizeof(TYPE);
+        this->capacity = roundedUpNewCapacity;
+        Memory::CommitVirtual(((byte*)this->elements) + offset, commitSize);
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Delete()
+{
+    this->grow = 16;
+
+    if (this->capacity > 0)
+    {
+        // If in small vector, run destructor
+        this->DestroyRange(0, this->count);
+        Memory::FreeVirtual(this->elements, this->capacity * sizeof(TYPE));
+    }
+    this->elements = nullptr;
+    this->capacity = 0;
+    this->count = 0;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Copy(const PinnedArray<MAX_ALLOCS, TYPE>& src)
+{
+#if NEBULA_BOUNDSCHECKS
+// Make sure array is either empty, or stack array before copy
+    n_assert(this->stackElements.data() == this->elements);
+#endif
+
+    this->GrowTo(src.capacity);
+    this->grow = src.grow;
+    this->count = src.count;
+    IndexT i;
+    for (i = 0; i < this->count; i++)
+    {
+        this->elements[i] = src.elements[i];
+    }
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<int MAX_ALLOCS, class TYPE>
+inline void 
+PinnedArray<MAX_ALLOCS, TYPE>::Move(IndexT fromIndex, IndexT toIndex)
+{
+#if NEBULA_BOUNDSCHECKS
+    n_assert(this->elements);
+    n_assert(fromIndex < this->count);
+#endif
+
+// nothing to move?
+    if (fromIndex == toIndex)
+    {
+        return;
+    }
+
+    // compute number of elements to move
+    SizeT num = this->count - fromIndex;
+
+    // check if array needs to grow
+    SizeT neededSize = toIndex + num;
+    while (neededSize > this->capacity)
+    {
+        this->Grow();
+    }
+
+    if (fromIndex > toIndex)
+    {
+        // this is a backward move
+        this->MoveRange(&this->elements[toIndex], &this->elements[fromIndex], num);
+        this->DestroyRange(fromIndex + num - 1, this->count);
+    }
+    else
+    {
+        // this is a forward move
+        int i;  // NOTE: this must remain signed for the following loop to work!!!
+        for (i = num - 1; i >= 0; --i)
+        {
+            this->elements[toIndex + i] = this->elements[fromIndex + i];
+        }
+
+        // destroy freed elements
+        this->DestroyRange(fromIndex, toIndex);
+    }
+
+    // adjust array size
+    this->count = toIndex + num;
+}
+
+} // namespace Util

--- a/code/foundation/util/tupleutility.h
+++ b/code/foundation/util/tupleutility.h
@@ -84,8 +84,19 @@ struct get_template_type<C<T>>
 /**
     Get inner type of two types
 */
-template <template <typename, int, bool> class C, typename T, int I, bool B>
-struct get_template_type<C<T, I, B>>
+template <template <typename, int> class C, typename T, int I>
+struct get_template_type<C<T, I>>
+{
+    using type = T;
+};
+
+
+//------------------------------------------------------------------------------
+/**
+    Get inner type of two types
+*/
+template <template <int, typename> class C, int I, typename T>
+struct get_template_type<C<I, T>>
 {
     using type = T;
 };
@@ -99,12 +110,23 @@ struct get_template_type<const C<T>&>
 {
     using type = T;
 };
+
 //------------------------------------------------------------------------------
 /**
     Get inner type of two types
 */
-template <template <typename, int, bool> class C, typename T, int I, bool B>
-struct get_template_type<C<T, I, B>&>
+template <template <int, typename> class C, int I, typename T>
+struct get_template_type<C<I, T>&>
+{
+    using type = T;
+};
+
+//------------------------------------------------------------------------------
+/**
+    Get inner type of two types
+*/
+template <template <typename, int> class C, typename T, int I>
+struct get_template_type<C<T, I>&>
 {
     using type = T;
 };

--- a/code/physics/physics/streamactorpool.cc
+++ b/code/physics/physics/streamactorpool.cc
@@ -58,7 +58,7 @@ StreamActorPool::Setup()
 ActorId
 StreamActorPool::CreateActorInstance(ActorResourceId id, Math::mat4 const& trans, ActorType type, uint64_t userData, IndexT scene)
 {
-    __LockName(&this->allocator, lock, Util::ArrayAllocatorAccess::Write);
+    __LockName(&this->allocator, lock, id.resourceId);
     ActorInfo& info = this->allocator.Get<0>(id.resourceId);
 
     physx::PxRigidActor * newActor = state.CreateActor(type, trans);
@@ -96,7 +96,7 @@ StreamActorPool::DiscardActorInstance(ActorId id)
     Actor& actor = ActorContext::GetActor(id);
     if (actor.res != ActorResourceId::Invalid())
     {
-        __LockName(&this->allocator, lock, Util::ArrayAllocatorAccess::Write);
+        __LockName(&this->allocator, lock, id.id);
         ActorInfo& info = this->allocator.Get<0>(actor.res.resourceId);
         info.instanceCount--;
     }
@@ -413,13 +413,13 @@ StreamActorPool::LoadFromStream(const Ids::Id32 entry, const Util::StringAtom & 
         }        
     }
 
-    __Lock(allocator, Util::ArrayAllocatorAccess::Write);
     Ids::Id32 id = allocator.Alloc();
     allocator.Set<Actor_Info>(id, actorInfo);
 
     ActorResourceId ret;
     ret.resourceId = id;
     ret.resourceType = 0;
+    allocator.Release(id);
     return ret;
 }
 
@@ -429,7 +429,7 @@ StreamActorPool::LoadFromStream(const Ids::Id32 entry, const Util::StringAtom & 
 void
 StreamActorPool::Unload(const Resources::ResourceId id)
 {
-    __LockName(&this->allocator, lock, Util::ArrayAllocatorAccess::Write);
+    __LockName(&this->allocator, lock, id.resourceId);
     ActorInfo& info = this->allocator.Get<0>(id.resourceId);
     n_assert2(info.instanceCount == 0, "Actor has active Instances");
     const Util::StringAtom tag = this->GetTag(id);

--- a/code/physics/physics/streamactorpool.h
+++ b/code/physics/physics/streamactorpool.h
@@ -69,7 +69,7 @@ private:
     {
         Actor_Info
     };
-    Ids::IdAllocatorSafe<ActorInfo> allocator;
+    Ids::IdAllocatorSafe<0xFFF, ActorInfo> allocator;
 };
 
 extern StreamActorPool *actorPool;

--- a/code/render/coregraphics/buffer.h
+++ b/code/render/coregraphics/buffer.h
@@ -21,6 +21,9 @@ namespace CoreGraphics
 struct CmdBufferId;
 ID_24_8_TYPE(BufferId);
 
+void BufferIdAcquire(const BufferId id); 
+void BufferIdRelease(const BufferId id);;
+
 enum BufferAccessMode
 {
     DeviceLocal,		// Buffer can only be used by the GPU

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -140,6 +140,8 @@ struct CmdBufferMarkerBundle
 };
 
 ID_24_8_TYPE(CmdBufferId);
+void CmdBufferIdAcquire(const CmdBufferId id); 
+void CmdBufferIdRelease(const CmdBufferId id);
 
 /// create new command buffer
 const CmdBufferId CreateCmdBuffer(const CmdBufferCreateInfo& info);
@@ -384,6 +386,7 @@ struct CmdMarkerScope
 #else
     #define N_CMD_SCOPE(x, y, z)
 #endif
+
 
 } // namespace CoreGraphics
 

--- a/code/render/coregraphics/mesh.h
+++ b/code/render/coregraphics/mesh.h
@@ -89,11 +89,13 @@ struct __Mesh
 };
 
 typedef Ids::IdAllocatorSafe<
+    0xFFFF,
     Resources::ResourceName,
     __Mesh
 > MeshAllocator;
 extern MeshAllocator meshAllocator;
 
+_DECLARE_LOCK(Mesh, meshAllocator);
 
 extern MeshId RectangleMesh;
 extern MeshId DiskMesh;

--- a/code/render/coregraphics/meshloader.cc
+++ b/code/render/coregraphics/meshloader.cc
@@ -156,9 +156,12 @@ MeshLoader::SetupMeshFromNvx(const Ptr<IO::Stream>& stream, const MeshResourceId
 
         // Upload vertex data
         {
-            // Get upload buffer
-            uint offset = CoreGraphics::Upload(vertexData, header->vertexDataSize);
             CoreGraphics::BufferId uploadBuf = CoreGraphics::GetUploadBuffer();
+            BufferIdAcquire(uploadBuf);
+            BufferIdAcquire(vbo);
+
+            // Get upload buffer
+            uint offset = CoreGraphics::Upload(vertexData, header->vertexDataSize);           
 
             // Allocate vertices from global repository 
             baseVertexOffset = CoreGraphics::AllocateVertices(header->vertexDataSize);
@@ -170,13 +173,19 @@ MeshLoader::SetupMeshFromNvx(const Ptr<IO::Stream>& stream, const MeshResourceId
             CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockGraphicsSetupCommandBuffer();
             CoreGraphics::CmdCopy(cmdBuf, uploadBuf, { from }, vbo, { to }, header->vertexDataSize);
             CoreGraphics::UnlockGraphicsSetupCommandBuffer();
+
+            BufferIdRelease(uploadBuf);
+            BufferIdRelease(vbo);
         }
 
         // Upload index data
         {
+            CoreGraphics::BufferId uploadBuf = CoreGraphics::GetUploadBuffer();
+            BufferIdAcquire(uploadBuf);
+            BufferIdAcquire(ibo);
+
             // Get upload buffer
             uint offset = CoreGraphics::Upload(indexData, header->indexDataSize);
-            CoreGraphics::BufferId uploadBuf = CoreGraphics::GetUploadBuffer();
 
             // Allocate vertices from global repository 
             baseIndexOffset = CoreGraphics::AllocateIndices(header->indexDataSize);
@@ -188,6 +197,9 @@ MeshLoader::SetupMeshFromNvx(const Ptr<IO::Stream>& stream, const MeshResourceId
             CoreGraphics::CmdBufferId cmdBuf = CoreGraphics::LockGraphicsSetupCommandBuffer();
             CoreGraphics::CmdCopy(cmdBuf, uploadBuf, { from }, ibo, { to }, header->indexDataSize);
             CoreGraphics::UnlockGraphicsSetupCommandBuffer();
+
+            BufferIdRelease(uploadBuf);
+            BufferIdRelease(ibo);
         }
 
         for (IndexT i = 0; i < header->numGroups; i++)

--- a/code/render/coregraphics/texture.cc
+++ b/code/render/coregraphics/texture.cc
@@ -126,6 +126,9 @@ void
 TextureUpdate(const CoreGraphics::CmdBufferId cmd, CoreGraphics::QueueType queue, CoreGraphics::TextureId tex, const SizeT width, SizeT height, SizeT mip, SizeT layer, SizeT size, const void* data)
 {
     SizeT alignment = CoreGraphics::PixelFormat::ToTexelSize(TextureGetPixelFormat(tex));
+    CoreGraphics::BufferId buf = CoreGraphics::GetUploadBuffer();
+    BufferIdAcquire(buf);
+
     uint offset = CoreGraphics::Upload(data, size, alignment);
 
     // Then run a copy on the command buffer
@@ -137,7 +140,9 @@ TextureUpdate(const CoreGraphics::CmdBufferId cmd, CoreGraphics::QueueType queue
     texCopy.layer = layer;
     texCopy.mip = mip;
     texCopy.region.set(0, 0, width, height);
-    CoreGraphics::CmdCopy(cmd, CoreGraphics::GetUploadBuffer(), { bufCopy }, tex, { texCopy });
+    CoreGraphics::CmdCopy(cmd, buf, { bufCopy }, tex, { texCopy });
+
+    BufferIdRelease(buf);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/texture.h
+++ b/code/render/coregraphics/texture.h
@@ -22,6 +22,8 @@ struct TextureSubresourceInfo;
 
 /// texture type
 RESOURCE_ID_TYPE(TextureId);
+void TextureIdAcquire(const TextureId id); 
+void TextureIdRelease(const TextureId id);;
 
 /// texture types
 enum TextureType

--- a/code/render/coregraphics/textureloader.cc
+++ b/code/render/coregraphics/textureloader.cc
@@ -188,7 +188,7 @@ TextureLoader::LoadFromStream(Ids::Id32 entry, const Util::StringAtom& tag, cons
         CoreGraphics::CmdEndMarker(handoverCmdBuf);
         CoreGraphics::UnlockGraphicsSetupCommandBuffer();
 
-
+        TextureIdRelease(texture);
         return texture;
     }
     stream->MemoryUnmap();

--- a/code/render/coregraphics/vk/vkbuffer.h
+++ b/code/render/coregraphics/vk/vkbuffer.h
@@ -34,7 +34,6 @@ struct VkBufferRuntimeInfo
 struct VkBufferMapInfo
 {
     void* mappedMemory;
-    uint mapCount;
 };
 
 enum
@@ -46,9 +45,10 @@ enum
 
 
 typedef Ids::IdAllocatorSafe<
-    VkBufferLoadInfo,
-    VkBufferRuntimeInfo,
-    VkBufferMapInfo
+    0xFFFF
+    , VkBufferLoadInfo
+    , VkBufferRuntimeInfo
+    , VkBufferMapInfo
 > VkBufferAllocator;
 extern VkBufferAllocator bufferAllocator;
 

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -25,7 +25,7 @@
 namespace Vulkan
 {
 
-VkCommandBufferAllocator commandBuffers(0x00FFFFFF);
+VkCommandBufferAllocator commandBuffers;
 VkCommandBufferPoolAllocator commandBufferPools(0x00FFFFFF);
 Threading::CriticalSection commandBufferCritSect;
 
@@ -57,7 +57,7 @@ CmdBufferGetVk(const CoreGraphics::CmdBufferId id)
     n_assert(id.id8 == CoreGraphics::IdType::CommandBufferIdType);
 #endif
     if (id == CoreGraphics::InvalidCmdBufferId) return VK_NULL_HANDLE;
-    else                                            return commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    else                                        return commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
 }
 
 //------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ CmdBufferGetVk(const CoreGraphics::CmdBufferId id)
 const VkCommandPool
 CmdBufferGetVkPool(const CoreGraphics::CmdBufferId id)
 {
-    return commandBuffers.GetUnsafe<CmdBuffer_VkCommandPool>(id.id24);;
+    return commandBuffers.Get<CmdBuffer_VkCommandPool>(id.id24);;
 }
 
 //------------------------------------------------------------------------------
@@ -75,7 +75,7 @@ CmdBufferGetVkPool(const CoreGraphics::CmdBufferId id)
 const VkDevice
 CmdBufferGetVkDevice(const CoreGraphics::CmdBufferId id)
 {
-    return commandBuffers.GetUnsafe<CmdBuffer_VkDevice>(id.id24);;
+    return commandBuffers.Get<CmdBuffer_VkDevice>(id.id24);;
 }
 
 } // Vulkan
@@ -84,6 +84,8 @@ namespace CoreGraphics
 {
 
 using namespace Vulkan;
+
+_IMPL_ACQUIRE_RELEASE(CmdBufferId, commandBuffers);
 
 //------------------------------------------------------------------------------
 /**
@@ -144,13 +146,13 @@ CreateCmdBuffer(const CmdBufferCreateInfo& info)
     };
     VkDevice dev = CmdBufferPoolGetVkDevice(info.pool);
     Ids::Id32 id = commandBuffers.Alloc();
-    VkResult res = vkAllocateCommandBuffers(dev, &vkInfo, &commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id));
+    VkResult res = vkAllocateCommandBuffers(dev, &vkInfo, &commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id));
     n_assert(res == VK_SUCCESS);
-    commandBuffers.SetUnsafe<CmdBuffer_VkCommandPool>(id, pool);
-    commandBuffers.SetUnsafe<CmdBuffer_VkDevice>(id, dev);
-    commandBuffers.SetUnsafe<CmdBuffer_Usage>(id, info.usage);
+    commandBuffers.Set<CmdBuffer_VkCommandPool>(id, pool);
+    commandBuffers.Set<CmdBuffer_VkDevice>(id, dev);
+    commandBuffers.Set<CmdBuffer_Usage>(id, info.usage);
 
-    QueryBundle& queryBundles = commandBuffers.GetUnsafe<CmdBuffer_Query>(id);
+    QueryBundle& queryBundles = commandBuffers.Get<CmdBuffer_Query>(id);
 
     uint bits = (uint)info.queryTypes;
     for (IndexT i = 0; i < CoreGraphics::CmdBufferQueryBits::NumBits; i++)
@@ -187,7 +189,7 @@ CreateCmdBuffer(const CmdBufferCreateInfo& info)
         queryBundles.enabled[i] = true;
     }
 
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id);
     pipelineBundle.blendInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
     pipelineBundle.blendInfo.pNext = nullptr;
     pipelineBundle.blendInfo.flags = 0;
@@ -206,9 +208,9 @@ CreateCmdBuffer(const CmdBufferCreateInfo& info)
     pipelineBundle.computeLayout = VK_NULL_HANDLE;
     pipelineBundle.graphicsLayout = VK_NULL_HANDLE;
 
-    ViewportBundle& viewports = commandBuffers.GetUnsafe<CmdBuffer_PendingViewports>(id);
+    ViewportBundle& viewports = commandBuffers.Get<CmdBuffer_PendingViewports>(id);
     viewports.viewports.Resize(8);
-    ScissorBundle& scissors = commandBuffers.GetUnsafe<CmdBuffer_PendingScissors>(id);
+    ScissorBundle& scissors = commandBuffers.Get<CmdBuffer_PendingScissors>(id);
     scissors.scissors.Resize(8);
 
     CmdBufferId ret;
@@ -227,7 +229,7 @@ DestroyCmdBuffer(const CmdBufferId id)
     n_assert(id.id8 == CommandBufferIdType);
 #endif
 
-    __Lock(commandBuffers, Util::ArrayAllocatorAccess::Write);
+    __Lock(commandBuffers, id.id24);
 
 #if NEBULA_ENABLE_PROFILING
     QueryBundle& queryBundles = commandBuffers.Get<CmdBuffer_Query>(id.id24);
@@ -261,15 +263,15 @@ CmdBeginRecord(const CmdBufferId id, const CmdBufferBeginInfo& info)
         flags,
         nullptr     // fixme, this part can optimize if used properly!
     };
-    VkResult res = vkBeginCommandBuffer(commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24), &begin);
+    VkResult res = vkBeginCommandBuffer(commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24), &begin);
     n_assert(res == VK_SUCCESS);
 
     // Also write first timestamp
-    QueryBundle& queryBundle = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
+    QueryBundle& queryBundle = commandBuffers.Get<CmdBuffer_Query>(id.id24);
     VkQueryPool pool = Vulkan::GetQueryPool(CoreGraphics::TimestampsQueryType);
     if (queryBundle.enabled[CoreGraphics::TimestampsQueryType])
     {
-        vkCmdWriteTimestamp(commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, pool, queryBundle.offset[CoreGraphics::TimestampsQueryType]);
+        vkCmdWriteTimestamp(commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, pool, queryBundle.offset[CoreGraphics::TimestampsQueryType]);
         queryBundle.queryCount[CoreGraphics::TimestampsQueryType]++;
     }
 }
@@ -284,7 +286,7 @@ CmdEndRecord(const CmdBufferId id)
     n_assert(id.id8 == CommandBufferIdType);
 #endif
 
-    VkResult res = vkEndCommandBuffer(commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24));
+    VkResult res = vkEndCommandBuffer(commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24));
     n_assert(res == VK_SUCCESS);
 }
 
@@ -299,7 +301,7 @@ CmdReset(const CmdBufferId id, const CmdBufferClearInfo& info)
 #endif
     VkCommandBufferResetFlags flags = 0;
     flags |= info.allowRelease ? VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT : 0;
-    VkResult res = vkResetCommandBuffer(commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24), flags);
+    VkResult res = vkResetCommandBuffer(commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24), flags);
     n_assert(res == VK_SUCCESS);
 }
 
@@ -310,10 +312,10 @@ void
 CmdSetVertexBuffer(const CmdBufferId id, IndexT streamIndex, const CoreGraphics::BufferId& buffer, SizeT bufferOffset)
 {
 #if _DEBUG
-    CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
+    CoreGraphics::QueueType usage = commandBuffers.Get<CmdBuffer_Usage>(id.id24);
     n_assert(usage == QueueType::GraphicsQueueType);
 #endif
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
     VkDeviceSize offset = bufferOffset;
     vkCmdBindVertexBuffers(cmdBuf, streamIndex, 1, &buf, &offset);
@@ -326,12 +328,12 @@ void
 CmdSetVertexLayout(const CmdBufferId id, const CoreGraphics::VertexLayoutId& vl)
 {
 #if _DEBUG
-    CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
+    CoreGraphics::QueueType usage = commandBuffers.Get<CmdBuffer_Usage>(id.id24);
     n_assert(usage == QueueType::GraphicsQueueType);
 #endif
-    CmdPipelineBuildBits& bits = commandBuffers.GetUnsafe<CmdBuffer_PipelineBuildBits>(id.id24);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
+    CmdPipelineBuildBits& bits = commandBuffers.Get<CmdBuffer_PipelineBuildBits>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
     const VertexLayoutVkBindInfo& bindInfo = VertexLayoutGetVkBindInfo(vl);
 
     vkCmdSetVertexInputEXT(cmdBuf, bindInfo.binds.Size(), bindInfo.binds.Begin(), bindInfo.attrs.Size(), bindInfo.attrs.Begin());
@@ -345,10 +347,10 @@ void
 CmdSetIndexBuffer(const CmdBufferId id, const IndexType::Code indexType, const CoreGraphics::BufferId& buffer, SizeT bufferOffset)
 {
 #if _DEBUG
-    CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
+    CoreGraphics::QueueType usage = commandBuffers.Get<CmdBuffer_Usage>(id.id24);
     n_assert(usage == QueueType::GraphicsQueueType);
 #endif
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
     VkDeviceSize offset = bufferOffset;
     VkIndexType vkIdxType = indexType == IndexType::Index16 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
@@ -362,10 +364,10 @@ void
 CmdSetIndexBuffer(const CmdBufferId id, const CoreGraphics::BufferId& buffer, CoreGraphics::IndexType::Code indexSize, SizeT bufferOffset)
 {
 #if _DEBUG
-    CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
+    CoreGraphics::QueueType usage = commandBuffers.Get<CmdBuffer_Usage>(id.id24);
     n_assert(usage == QueueType::GraphicsQueueType);
 #endif
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkBuffer buf = Vulkan::BufferGetVk(buffer);
     VkDeviceSize offset = bufferOffset;
     VkIndexType vkIdxType = indexSize == IndexType::Index16 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
@@ -379,12 +381,12 @@ void
 CmdSetPrimitiveTopology(const CmdBufferId id, const CoreGraphics::PrimitiveTopology::Code topo)
 {
 #if _DEBUG
-    CoreGraphics::QueueType usage = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
+    CoreGraphics::QueueType usage = commandBuffers.Get<CmdBuffer_Usage>(id.id24);
     n_assert(usage == QueueType::GraphicsQueueType);
 #endif
 
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkPrimitiveTopology comp = VkTypes::AsVkPrimitiveType(topo);
     pipelineBundle.inputAssembly.topo = comp;
     pipelineBundle.inputAssembly.primRestart = false;
@@ -398,8 +400,8 @@ CmdSetPrimitiveTopology(const CmdBufferId id, const CoreGraphics::PrimitiveTopol
 void
 CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pro, bool bindGlobals)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
     VkShaderProgramRuntimeInfo& info = shaderAlloc.Get<Shader_ProgramAllocator>(pro.shaderId).Get<ShaderProgram_RuntimeInfo>(pro.programId);
 
     IndexT buffer = CoreGraphics::GetBufferedFrameIndex();
@@ -411,7 +413,7 @@ CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pr
         vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_COMPUTE, info.pipeline);
         if (bindGlobals && pipelineChange)
         {
-            QueueType queue = commandBuffers.GetUnsafe<CmdBuffer_Usage>(id.id24);
+            QueueType queue = commandBuffers.Get<CmdBuffer_Usage>(id.id24);
             if (queue == GraphicsQueueType)
             {
                 CoreGraphics::CmdSetResourceTable(id, Graphics::GetTickResourceTableGraphics(buffer), NEBULA_TICK_GROUP, CoreGraphics::ShaderPipeline::ComputePipeline, nullptr);
@@ -426,7 +428,7 @@ CmdSetShaderProgram(const CmdBufferId id, const CoreGraphics::ShaderProgramId pr
     }
     else
     {
-        CmdPipelineBuildBits& bits = commandBuffers.GetUnsafe<CmdBuffer_PipelineBuildBits>(id.id24);
+        CmdPipelineBuildBits& bits = commandBuffers.Get<CmdBuffer_PipelineBuildBits>(id.id24);
         bits |= CoreGraphics::CmdPipelineBuildBits::ShaderInfoSet;
         bits &= ~CoreGraphics::CmdPipelineBuildBits::PipelineBuilt;
 
@@ -485,9 +487,9 @@ CmdSetResourceTable(const CmdBufferId id, const CoreGraphics::ResourceTableId ta
 void
 CmdSetResourceTable(const CmdBufferId id, const CoreGraphics::ResourceTableId table, const IndexT slot, CoreGraphics::ShaderPipeline pipeline, uint32 numOffsets, uint32* offsets)
 {
-    const VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
+    const VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
     VkDescriptorSet set = Vulkan::ResourceTableGetVkDescriptorSet(table);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkPipelineBindPoint bindPoint;
     switch (pipeline)
     {
@@ -527,8 +529,8 @@ CmdPushConstants(const CmdBufferId id, ShaderPipeline pipeline, uint offset, uin
 void
 CmdPushGraphicsConstants(const CmdBufferId id, uint offset, uint size, const void* data)
 {
-    const VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    const VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdPushConstants(cmdBuf, pipelineBundle.graphicsLayout, VK_SHADER_STAGE_ALL_GRAPHICS, offset, size, data);
 }
 
@@ -538,8 +540,8 @@ CmdPushGraphicsConstants(const CmdBufferId id, uint offset, uint size, const voi
 void
 CmdPushComputeConstants(const CmdBufferId id, uint offset, uint size, const void* data)
 {
-    const VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    const VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdPushConstants(cmdBuf, pipelineBundle.computeLayout, VK_SHADER_STAGE_COMPUTE_BIT, offset, size, data);
 }
 
@@ -549,26 +551,26 @@ CmdPushComputeConstants(const CmdBufferId id, uint offset, uint size, const void
 void
 CmdSetGraphicsPipeline(const CmdBufferId id)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
 
-    CmdPipelineBuildBits& bits = commandBuffers.GetUnsafe<CmdBuffer_PipelineBuildBits>(id.id24);
+    CmdPipelineBuildBits& bits = commandBuffers.Get<CmdBuffer_PipelineBuildBits>(id.id24);
     n_assert((bits & CmdPipelineBuildBits::AllInfoSet) != 0);
     if (!AllBits(bits, CmdPipelineBuildBits::PipelineBuilt))
     {
-        const VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
+        const VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
         VkPipeline pipeline = CoreGraphics::GetOrCreatePipeline(pipelineBundle.pass, pipelineBundle.pipelineInfo.subpass, pipelineBundle.program, pipelineBundle.inputAssembly, pipelineBundle.pipelineInfo);
         bits |= CmdPipelineBuildBits::PipelineBuilt;
         vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
     }
 
     // Set viewport and scissors since Vulkan requires them to be set after the pipeline
-    ViewportBundle& viewports = commandBuffers.GetUnsafe<CmdBuffer_PendingViewports>(id.id24);
+    ViewportBundle& viewports = commandBuffers.Get<CmdBuffer_PendingViewports>(id.id24);
     if (viewports.numPending > 0)
     {
         vkCmdSetViewport(cmdBuf, 0, viewports.numPending, viewports.viewports.Begin());
         viewports.numPending = 0;
     }
-    ScissorBundle& rects = commandBuffers.GetUnsafe<CmdBuffer_PendingScissors>(id.id24);
+    ScissorBundle& rects = commandBuffers.Get<CmdBuffer_PendingScissors>(id.id24);
     if (rects.numPending > 0)
     {
         vkCmdSetScissor(cmdBuf, 0, rects.numPending, rects.scissors.Begin());
@@ -582,10 +584,10 @@ CmdSetGraphicsPipeline(const CmdBufferId id)
 void
 CmdSetGraphicsPipeline(const CmdBufferId buf, const PipelineId pipeline)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(buf.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(buf.id24);
     Pipeline& pipelineObj = pipelineAllocator.Get<Pipeline_Object>(pipeline.id24);
     vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineObj.pipeline);
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(buf.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(buf.id24);
 
     bool pipelineChange = pipelineBundle.graphicsLayout != pipelineObj.layout;
     pipelineBundle.graphicsLayout = pipelineObj.layout;
@@ -598,13 +600,13 @@ CmdSetGraphicsPipeline(const CmdBufferId buf, const PipelineId pipeline)
     }
 
     // Set viewport and scissors since Vulkan requires them to be set after the pipeline
-    ViewportBundle& viewports = commandBuffers.GetUnsafe<CmdBuffer_PendingViewports>(buf.id24);
+    ViewportBundle& viewports = commandBuffers.Get<CmdBuffer_PendingViewports>(buf.id24);
     if (viewports.numPending > 0)
     {
         vkCmdSetViewport(cmdBuf, 0, viewports.numPending, viewports.viewports.Begin());
         viewports.numPending = 0;
     }
-    ScissorBundle& rects = commandBuffers.GetUnsafe<CmdBuffer_PendingScissors>(buf.id24);
+    ScissorBundle& rects = commandBuffers.Get<CmdBuffer_PendingScissors>(buf.id24);
     if (rects.numPending > 0)
     {
         vkCmdSetScissor(cmdBuf, 0, rects.numPending, rects.scissors.Begin());
@@ -707,7 +709,7 @@ CmdBarrier(
 void
 CmdBarrier(const CmdBufferId id, const CoreGraphics::BarrierId barrier)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     const VkBarrierInfo& info = BarrierGetVk(barrier);
     vkCmdPipelineBarrier(cmdBuf,
         info.srcFlags,
@@ -724,7 +726,7 @@ CmdBarrier(const CmdBufferId id, const CoreGraphics::BarrierId barrier)
 void
 CmdSignalEvent(const CmdBufferId id, const CoreGraphics::EventId ev, const CoreGraphics::PipelineStage stage)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     const VkEventInfo& info = EventGetVk(ev);
     vkCmdSetEvent(cmdBuf, info.event, VkTypes::AsVkPipelineStage(stage));
 }
@@ -735,7 +737,7 @@ CmdSignalEvent(const CmdBufferId id, const CoreGraphics::EventId ev, const CoreG
 void
 CmdWaitEvent(const CmdBufferId id, const EventId ev, const CoreGraphics::PipelineStage waitStage, const CoreGraphics::PipelineStage signalStage)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     const VkEventInfo& info = EventGetVk(ev);
     vkCmdWaitEvents(
         cmdBuf
@@ -758,7 +760,7 @@ CmdWaitEvent(const CmdBufferId id, const EventId ev, const CoreGraphics::Pipelin
 void
 CmdResetEvent(const CmdBufferId id, const CoreGraphics::EventId ev, const CoreGraphics::PipelineStage stage)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     const VkEventInfo& info = EventGetVk(ev);
     vkCmdResetEvent(cmdBuf, info.event, VkTypes::AsVkPipelineStage(stage));
 }
@@ -769,12 +771,12 @@ CmdResetEvent(const CmdBufferId id, const CoreGraphics::EventId ev, const CoreGr
 void
 CmdBeginPass(const CmdBufferId id, const PassId pass)
 {
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     const VkRenderPassBeginInfo& info = PassGetVkRenderPassBeginInfo(pass);
     const VkGraphicsPipelineCreateInfo& framebufferInfo = PassGetVkFramebufferInfo(pass);
 
-    CmdPipelineBuildBits& bits = commandBuffers.GetUnsafe<CmdBuffer_PipelineBuildBits>(id.id24);
+    CmdPipelineBuildBits& bits = commandBuffers.Get<CmdBuffer_PipelineBuildBits>(id.id24);
     bits |= CoreGraphics::CmdPipelineBuildBits::FramebufferLayoutInfoSet;
     bits &= ~CoreGraphics::CmdPipelineBuildBits::PipelineBuilt;
 
@@ -798,9 +800,9 @@ CmdBeginPass(const CmdBufferId id, const PassId pass)
 void
 CmdNextSubpass(const CmdBufferId id)
 {
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
     pipelineBundle.pipelineInfo.subpass++;
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdNextSubpass(cmdBuf, VK_SUBPASS_CONTENTS_INLINE);
 }
 
@@ -810,7 +812,7 @@ CmdNextSubpass(const CmdBufferId id)
 void
 CmdEndPass(const CmdBufferId id)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdEndRenderPass(cmdBuf);
 }
 
@@ -820,7 +822,7 @@ CmdEndPass(const CmdBufferId id)
 void
 CmdResetClipToPass(const CmdBufferId id)
 {
-    VkPipelineBundle& pipelineBundle = commandBuffers.GetUnsafe<CmdBuffer_VkPipelineBundle>(id.id24);
+    VkPipelineBundle& pipelineBundle = commandBuffers.Get<CmdBuffer_VkPipelineBundle>(id.id24);
 
     // Set viewports and scissors
     auto viewports = PassGetViewports(pipelineBundle.pass);
@@ -835,7 +837,7 @@ CmdResetClipToPass(const CmdBufferId id)
 void
 CmdDraw(const CmdBufferId id, const CoreGraphics::PrimitiveGroup& pg)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     if (pg.GetNumIndices() > 0)
         vkCmdDrawIndexed(cmdBuf, pg.GetNumIndices(), 1, pg.GetBaseIndex(), pg.GetBaseVertex(), 0);
     else
@@ -848,7 +850,7 @@ CmdDraw(const CmdBufferId id, const CoreGraphics::PrimitiveGroup& pg)
 void
 CmdDraw(const CmdBufferId id, SizeT numInstances, IndexT baseInstance, const CoreGraphics::PrimitiveGroup& pg)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     if (pg.GetNumIndices() > 0)
         vkCmdDrawIndexed(cmdBuf, pg.GetNumIndices(), numInstances, pg.GetBaseIndex(), pg.GetBaseVertex(), baseInstance);
     else
@@ -861,7 +863,7 @@ CmdDraw(const CmdBufferId id, SizeT numInstances, IndexT baseInstance, const Cor
 void
 CmdDrawIndirect(const CmdBufferId id, const CoreGraphics::BufferId buffer, IndexT bufferOffset, SizeT numDraws, SizeT stride)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdDrawIndirect(cmdBuf, BufferGetVk(buffer), bufferOffset, numDraws, stride);
 }
 
@@ -871,7 +873,7 @@ CmdDrawIndirect(const CmdBufferId id, const CoreGraphics::BufferId buffer, Index
 void
 CmdDrawIndirectIndexed(const CmdBufferId id, const CoreGraphics::BufferId buffer, IndexT bufferOffset, SizeT numDraws, SizeT stride)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdDrawIndexedIndirect(cmdBuf, BufferGetVk(buffer), bufferOffset, numDraws, stride);
 }
 
@@ -881,7 +883,7 @@ CmdDrawIndirectIndexed(const CmdBufferId id, const CoreGraphics::BufferId buffer
 void
 CmdDispatch(const CmdBufferId id, int dimX, int dimY, int dimZ)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdDispatch(cmdBuf, dimX, dimY, dimZ);
 }
 
@@ -891,7 +893,7 @@ CmdDispatch(const CmdBufferId id, int dimX, int dimY, int dimZ)
 void
 CmdResolve(const CmdBufferId id, const CoreGraphics::TextureId source, const CoreGraphics::TextureCopy sourceCopy, const CoreGraphics::TextureId dest, const CoreGraphics::TextureCopy destCopy)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkImage vkSrc = TextureGetVkImage(source);
     VkImage vkDst = TextureGetVkImage(dest);
 
@@ -943,7 +945,7 @@ CmdCopy(
         copy.extent = { (uint32_t)to[i].region.width(), (uint32_t)to[i].region.height(), 1 };
     }
 
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdCopyImage(cmdBuf, TextureGetVkImage(fromTexture), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, TextureGetVkImage(toTexture), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, copies.Size(), copies.Begin());
 }
 
@@ -974,7 +976,7 @@ CmdCopy(
         copy.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, (uint32_t)from[i].mip, (uint32_t)from[i].layer, 1 };
     }
 
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdCopyImageToBuffer(
         cmdBuf
         , TextureGetVkImage(fromTexture)
@@ -1009,7 +1011,7 @@ CmdCopy(
         copy.size = size;
     }
 
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdCopyBuffer(cmdBuf, BufferGetVk(fromBuffer), BufferGetVk(toBuffer), copies.Size(), copies.Begin());
 }
 
@@ -1040,7 +1042,7 @@ CmdCopy(
         copy.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, (uint32_t)to[i].mip, (uint32_t)to[i].layer, 1 };
     }
 
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdCopyBufferToImage(
         cmdBuf
         , BufferGetVk(fromBuffer)
@@ -1079,7 +1081,7 @@ CmdBlit(
     blit.dstOffsets[1] = { toRegion.right, toRegion.bottom, 1 };
     blit.dstSubresource = { VkTypes::AsVkImageAspectFlags(toBits), (uint32_t)toMip, (uint32_t)toLayer, 1 };
 
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdBlitImage(
         cmdBuf
         , TextureGetVkImage(from)
@@ -1097,7 +1099,7 @@ CmdBlit(
 void
 CmdSetViewports(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> viewports)
 {
-    ViewportBundle& pending = commandBuffers.GetUnsafe<CmdBuffer_PendingViewports>(id.id24);
+    ViewportBundle& pending = commandBuffers.Get<CmdBuffer_PendingViewports>(id.id24);
     pending.numPending = 0;
     for (Math::rectangle<int> viewport : viewports)
     {
@@ -1118,7 +1120,7 @@ CmdSetViewports(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> vie
 void
 CmdSetScissors(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> rects)
 {
-    ScissorBundle& pending = commandBuffers.GetUnsafe<CmdBuffer_PendingScissors>(id.id24);
+    ScissorBundle& pending = commandBuffers.Get<CmdBuffer_PendingScissors>(id.id24);
     pending.numPending = 0;
     for (Math::rectangle<int> rect : rects)
     {
@@ -1137,7 +1139,7 @@ CmdSetScissors(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> rect
 void
 CmdSetViewport(const CmdBufferId id, const Math::rectangle<int>& rect, int index)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkViewport vp;
     vp.width = (float)rect.width();
     vp.height = (float)rect.height();
@@ -1154,7 +1156,7 @@ CmdSetViewport(const CmdBufferId id, const Math::rectangle<int>& rect, int index
 void
 CmdSetScissorRect(const CmdBufferId id, const Math::rectangle<int>& rect, int index)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     VkRect2D sc;
     sc.extent.width = rect.width();
     sc.extent.height = rect.height();
@@ -1169,7 +1171,7 @@ CmdSetScissorRect(const CmdBufferId id, const Math::rectangle<int>& rect, int in
 void
 CmdSetStencilRef(const CmdBufferId id, const uint frontRef, const uint backRef)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     if (frontRef == backRef)
     {
         vkCmdSetStencilReference(cmdBuf, VK_STENCIL_FACE_FRONT_AND_BACK, frontRef);
@@ -1187,7 +1189,7 @@ CmdSetStencilRef(const CmdBufferId id, const uint frontRef, const uint backRef)
 void
 CmdSetStencilReadMask(const CmdBufferId id, const uint readMask)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdSetStencilCompareMask(cmdBuf, VK_STENCIL_FACE_FRONT_AND_BACK, readMask);
 }
 
@@ -1197,7 +1199,7 @@ CmdSetStencilReadMask(const CmdBufferId id, const uint readMask)
 void
 CmdSetStencilWriteMask(const CmdBufferId id, const uint writeMask)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdSetStencilWriteMask(cmdBuf, VK_STENCIL_FACE_FRONT_AND_BACK, writeMask);
 }
 
@@ -1207,7 +1209,7 @@ CmdSetStencilWriteMask(const CmdBufferId id, const uint writeMask)
 void
 CmdUpdateBuffer(const CmdBufferId id, const CoreGraphics::BufferId buffer, uint offset, uint size, const void* data)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     vkCmdUpdateBuffer(cmdBuf, Vulkan::BufferGetVk(buffer), offset, size, data);
 }
 
@@ -1217,8 +1219,8 @@ CmdUpdateBuffer(const CmdBufferId id, const CoreGraphics::BufferId buffer, uint 
 void
 CmdStartOcclusionQueries(const CmdBufferId id)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
-    QueryBundle& queryBundle = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
+    QueryBundle& queryBundle = commandBuffers.Get<CmdBuffer_Query>(id.id24);
     VkQueryPool pool = Vulkan::GetQueryPool(CoreGraphics::OcclusionQueryType);
     n_assert(queryBundle.enabled[CoreGraphics::OcclusionQueryType]);
     vkCmdBeginQuery(cmdBuf, pool, queryBundle.offset[CoreGraphics::OcclusionQueryType] + queryBundle.queryCount[CoreGraphics::OcclusionQueryType], 0x0);
@@ -1230,8 +1232,8 @@ CmdStartOcclusionQueries(const CmdBufferId id)
 void
 CmdEndOcclusionQueries(const CmdBufferId id)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
-    QueryBundle& queryBundle = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
+    QueryBundle& queryBundle = commandBuffers.Get<CmdBuffer_Query>(id.id24);
     VkQueryPool pool = Vulkan::GetQueryPool(CoreGraphics::OcclusionQueryType);
     n_assert(queryBundle.enabled[CoreGraphics::OcclusionQueryType]);
     vkCmdEndQuery(cmdBuf, pool, queryBundle.offset[CoreGraphics::OcclusionQueryType] + queryBundle.queryCount[CoreGraphics::OcclusionQueryType]++);
@@ -1243,8 +1245,8 @@ CmdEndOcclusionQueries(const CmdBufferId id)
 void
 CmdStartPipelineQueries(const CmdBufferId id)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
-    QueryBundle& queryBundle = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
+    QueryBundle& queryBundle = commandBuffers.Get<CmdBuffer_Query>(id.id24);
     VkQueryPool pool = Vulkan::GetQueryPool(CoreGraphics::StatisticsQueryType);
     n_assert(queryBundle.enabled[CoreGraphics::StatisticsQueryType]);
     vkCmdBeginQuery(cmdBuf, pool, queryBundle.offset[CoreGraphics::StatisticsQueryType] + queryBundle.queryCount[CoreGraphics::StatisticsQueryType], 0x0);
@@ -1256,8 +1258,8 @@ CmdStartPipelineQueries(const CmdBufferId id)
 void
 CmdEndPipelineQueries(const CmdBufferId id)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
-    QueryBundle& queryBundle = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
+    QueryBundle& queryBundle = commandBuffers.Get<CmdBuffer_Query>(id.id24);
     VkQueryPool pool = Vulkan::GetQueryPool(CoreGraphics::StatisticsQueryType);
     n_assert(queryBundle.enabled[CoreGraphics::StatisticsQueryType]);
     vkCmdEndQuery(cmdBuf, pool, queryBundle.offset[CoreGraphics::StatisticsQueryType] + queryBundle.queryCount[CoreGraphics::StatisticsQueryType]++);
@@ -1270,7 +1272,7 @@ CmdEndPipelineQueries(const CmdBufferId id)
 void
 CmdBeginMarker(const CmdBufferId id, const Math::vec4& color, const char* name)
 {
-    __Lock(commandBuffers, Util::ArrayAllocatorAccess::Write);
+    __Lock(commandBuffers, id.id24);
     VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
 
 #if NEBULA_ENABLE_PROFILING
@@ -1308,7 +1310,7 @@ CmdBeginMarker(const CmdBufferId id, const Math::vec4& color, const char* name)
 void
 CmdEndMarker(const CmdBufferId id)
 {
-    __Lock(commandBuffers, Util::ArrayAllocatorAccess::Write);
+    __Lock(commandBuffers, id.id24);
     VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
 
 #if NEBULA_ENABLE_PROFILING
@@ -1338,7 +1340,7 @@ CmdEndMarker(const CmdBufferId id)
 void
 CmdInsertMarker(const CmdBufferId id, const Math::vec4& color, const char* name)
 {
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
 
     alignas(16) float col[4];
     color.store(col);
@@ -1358,8 +1360,8 @@ CmdInsertMarker(const CmdBufferId id, const Math::vec4& color, const char* name)
 void
 CmdFinishQueries(const CmdBufferId id)
 {
-    QueryBundle& queryBundle = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
-    VkCommandBuffer cmdBuf = commandBuffers.GetUnsafe<CmdBuffer_VkCommandBuffer>(id.id24);
+    QueryBundle& queryBundle = commandBuffers.Get<CmdBuffer_Query>(id.id24);
+    VkCommandBuffer cmdBuf = commandBuffers.Get<CmdBuffer_VkCommandBuffer>(id.id24);
     for (IndexT i = 0; i < CoreGraphics::QueryType::NumQueryTypes; i++)
     {
         if (queryBundle.queryCount[i] != 0)
@@ -1377,7 +1379,7 @@ CmdFinishQueries(const CmdBufferId id)
 Util::Array<CoreGraphics::FrameProfilingMarker>
 CmdCopyProfilingMarkers(const CmdBufferId id)
 {
-    CoreGraphics::CmdBufferMarkerBundle& markers = commandBuffers.GetUnsafe<CmdBuffer_ProfilingMarkers>(id.id24);
+    CoreGraphics::CmdBufferMarkerBundle& markers = commandBuffers.Get<CmdBuffer_ProfilingMarkers>(id.id24);
     return markers.finishedMarkers;
 }
 
@@ -1387,7 +1389,7 @@ CmdCopyProfilingMarkers(const CmdBufferId id)
 uint
 CmdGetMarkerOffset(const CmdBufferId id)
 {
-    CoreGraphics::QueryBundle& queries = commandBuffers.GetUnsafe<CmdBuffer_Query>(id.id24);
+    CoreGraphics::QueryBundle& queries = commandBuffers.Get<CmdBuffer_Query>(id.id24);
     n_assert(queries.enabled[CoreGraphics::QueryType::TimestampsQueryType]);
     return queries.offset[CoreGraphics::QueryType::TimestampsQueryType];
 }

--- a/code/render/coregraphics/vk/vkcommandbuffer.h
+++ b/code/render/coregraphics/vk/vkcommandbuffer.h
@@ -104,7 +104,8 @@ struct ScissorBundle
 };
 
 typedef Ids::IdAllocatorSafe<
-    VkDevice
+    0xFFF
+    , VkDevice
     , VkCommandBuffer
     , VkCommandPool
     , CoreGraphics::CmdPipelineBuildBits

--- a/code/render/coregraphics/vk/vkmemory.cc
+++ b/code/render/coregraphics/vk/vkmemory.cc
@@ -213,7 +213,7 @@ AllocateMemory(const VkDevice dev, const VkBuffer& buf, MemoryPoolType type)
     vkGetBufferMemoryRequirements(dev, buf, &req);
     VkPhysicalDeviceProperties props = Vulkan::GetCurrentProperties();
 
-    VkMemoryPropertyFlags flags;
+    VkMemoryPropertyFlags flags = 0;
 
     switch (type)
     {

--- a/code/render/coregraphics/vk/vkshaderserver.cc
+++ b/code/render/coregraphics/vk/vkshaderserver.cc
@@ -97,12 +97,12 @@ VkShaderServer::UpdateResources()
     {
         const _PendingView& pend = pendingViewsThisFrame[i];
 
-        textureAllocator.Lock(Util::ArrayAllocatorAccess::Write);
+        textureAllocator.TryAcquire(pend.tex.resourceId);
         VkTextureRuntimeInfo& info = textureAllocator.Get<Texture_RuntimeInfo>(pend.tex.resourceId);
         VkImageView oldView = info.view;
         VkResult res = vkCreateImageView(GetCurrentDevice(), &pend.createInfo, nullptr, &info.view);
         n_assert(res == VK_SUCCESS);
-        textureAllocator.Unlock(Util::ArrayAllocatorAccess::Write);
+        textureAllocator.Release(pend.tex.resourceId);
 
         _PendingViewDelete pendingDelete;
         pendingDelete.view = oldView;

--- a/code/render/coregraphics/vk/vktexture.h
+++ b/code/render/coregraphics/vk/vktexture.h
@@ -71,10 +71,11 @@ enum
 
 /// we need a thread-safe allocator since it will be used by both the memory and stream pool
 typedef Ids::IdAllocatorSafe<
-    VkTextureRuntimeInfo,                   // runtime info (for binding)
-    VkTextureLoadInfo,                      // loading info (mostly used during the load/unload phase)
-    VkTextureMappingInfo,                   // used when image is mapped to memory
-    VkTextureWindowInfo
+    0xFFFF
+    , VkTextureRuntimeInfo                   // runtime info (for binding)
+    , VkTextureLoadInfo                      // loading info (mostly used during the load/unload phase)
+    , VkTextureMappingInfo                   // used when image is mapped to memory
+    , VkTextureWindowInfo
 > VkTextureAllocator;
 extern VkTextureAllocator textureAllocator;
 
@@ -84,7 +85,8 @@ enum
     , TextureExtension_StencilBind
 };
 typedef Ids::IdAllocatorSafe<
-    CoreGraphics::TextureViewId
+    0xFFFF
+    , CoreGraphics::TextureViewId
     , IndexT
 > VkTextureStencilExtensionAllocator;
 extern VkTextureStencilExtensionAllocator textureStencilExtensionAllocator;
@@ -94,7 +96,8 @@ enum
     TextureExtension_SwapInfo
 };
 typedef Ids::IdAllocatorSafe<
-    VkTextureSwapInfo
+    0xFF
+    , VkTextureSwapInfo
 > VkTextureSwapExtensionAllocator;
 extern VkTextureSwapExtensionAllocator textureSwapExtensionAllocator;
 
@@ -115,11 +118,12 @@ enum
     TextureExtension_SparseOpaqueAllocs
 };
 typedef Ids::IdAllocatorSafe<
-    TextureSparsePageTable,
-    VkSparseImageMemoryRequirements,
-    Util::Array<VkSparseMemoryBind>,
-    Util::Array<VkSparseImageMemoryBind>,
-    Util::Array<CoreGraphics::Alloc>
+    0xFF
+    , TextureSparsePageTable
+    , VkSparseImageMemoryRequirements
+    , Util::Array<VkSparseMemoryBind>
+    , Util::Array<VkSparseImageMemoryBind>
+    , Util::Array<CoreGraphics::Alloc>
 > VkTextureSparseExtensionAllocator;
 extern VkTextureSparseExtensionAllocator textureSparseExtensionAllocator;
 

--- a/tests/testfoundation/pinnedarraytest.cc
+++ b/tests/testfoundation/pinnedarraytest.cc
@@ -3,7 +3,7 @@
 //  (C) 2006 Radon Labs GmbH
 //------------------------------------------------------------------------------
 #include "stdneb.h"
-#include "util/array.h"
+#include "util/pinnedarray.h"
 #include "pinnedarraytest.h"
 
 namespace Test
@@ -19,7 +19,7 @@ using namespace Util;
 void
 PinnedArrayTest::Run()
 {
-    PinnedArray<int> array0(10e6), array1(10e6), array2(10e6);
+    PinnedArray<0xFFFF, int> array0, array1, array2;
 
     array0.Append(1);
     array0.Append(2);

--- a/tests/testfoundation/stackarraytest.h
+++ b/tests/testfoundation/stackarraytest.h
@@ -1,11 +1,11 @@
 #pragma once
 //------------------------------------------------------------------------------
 /**
-    @class Test::PinnedArrayTest
+    @class Test::StackArrayTest
 
-    Tests Nebula's pinned array class.
+    Tests Nebula's array with item stack.
 
-    (C) 2006 Radon Labs GmbH
+    (C) 2023 Individual contributors, see AUTHORS file
 */
 #include "testbase/testcase.h"
 


### PR DESCRIPTION
Change behavior of "safe" allocators. 
- Now uses pinned arrays, which ensures pointer and reference validity when growing/shrinking
- Writer threads should always acquire an element of an allocator before manipulating it, this ensures reader threads can wait. There is however no mechanism in the opposite direction yet.

PinnedArray is now detached from Array such that we can provide a compile time argument for max allocation size and not bloat Array too much. 