### PR TITLE
Fix various validation errors

### DIFF
--- a/code/foundation/util/bit.h
+++ b/code/foundation/util/bit.h
@@ -133,6 +133,16 @@ CountBits(uint32 i)
     return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 }
 
+//------------------------------------------------------------------------------
+/**
+    Combine hashes
+*/
+template<typename T>
+inline void HashCombine(uint32_t& s, const T& v)
+{
+    std::hash<T> h;
+    s ^= h(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
+}
+
 } // namespace Util
 
-    

--- a/code/render/coregraphics/sampler.h
+++ b/code/render/coregraphics/sampler.h
@@ -10,6 +10,7 @@
 */
 //------------------------------------------------------------------------------
 #include "ids/id.h"
+#include "util/bit.h"
 namespace CoreGraphics
 {
 
@@ -76,6 +77,27 @@ struct SamplerCreateInfo
     float                       maxLod;
     SamplerBorderMode           borderColor;
     bool                        unnormalizedCoordinates;
+
+    const uint32_t HashCode() const
+    {
+        uint32_t res = 0;
+        Util::HashCombine(res, this->magFilter);
+        Util::HashCombine(res, this->minFilter);
+        Util::HashCombine(res, this->mipmapMode);
+        Util::HashCombine(res, this->addressModeU);
+        Util::HashCombine(res, this->addressModeV);
+        Util::HashCombine(res, this->addressModeW);
+        Util::HashCombine(res, this->mipLodBias);
+        Util::HashCombine(res, this->anisotropyEnable);
+        Util::HashCombine(res, this->maxAnisotropy);
+        Util::HashCombine(res, this->compareEnable);
+        Util::HashCombine(res, this->compareOp);
+        Util::HashCombine(res, this->minLod);
+        Util::HashCombine(res, this->maxLod);
+        Util::HashCombine(res, this->borderColor);
+        Util::HashCombine(res, this->unnormalizedCoordinates);
+        return res;
+    }
 };
 
 /// create sampler

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -496,17 +496,6 @@ NebulaVulkanErrorDebugCallback(
     const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
     void* userData)
 {
-    const int ignore[] =
-    {
-        602160055
-    };
-
-    for (IndexT i = 0; i < sizeof(ignore) / sizeof(int); i++)
-    {
-        if (callbackData->messageIdNumber == ignore[i])
-            return VK_FALSE;
-    }
-
     n_warning("%s\n", callbackData->pMessage);
     return VK_FALSE;
 }

--- a/code/render/coregraphics/vk/vkresourcetable.cc
+++ b/code/render/coregraphics/vk/vkresourcetable.cc
@@ -15,10 +15,12 @@
 namespace Vulkan
 {
 
+extern PFN_vkSetDebugUtilsObjectNameEXT VkDebugObjectName;
+
 VkResourceTableAllocator resourceTableAllocator;
 VkResourceTableLayoutAllocator resourceTableLayoutAllocator;
 VkResourcePipelineAllocator resourcePipelineAllocator;
-VkDescriptorSetLayout emptySetLayout;
+VkDescriptorSetLayout EmptySetLayout;
 
 //------------------------------------------------------------------------------
 /**
@@ -61,8 +63,22 @@ SetupEmptyDescriptorSetLayout()
         0,
         nullptr
     };
-    VkResult res = vkCreateDescriptorSetLayout(Vulkan::GetCurrentDevice(), &info, nullptr, &emptySetLayout);
+    VkResult res = vkCreateDescriptorSetLayout(Vulkan::GetCurrentDevice(), &info, nullptr, &EmptySetLayout);
     n_assert(res == VK_SUCCESS);
+
+#if NEBULA_GRAPHICS_DEBUG
+    VkDebugUtilsObjectNameInfoEXT dbgInfo =
+    {
+        VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
+        nullptr,
+        VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT,
+        (uint64_t)EmptySetLayout,
+        "Placeholder Resource Table Layout"
+    };
+    VkDevice dev = GetCurrentDevice();
+    res = VkDebugObjectName(dev, &dbgInfo);
+    n_assert(res == VK_SUCCESS);
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -1189,7 +1205,7 @@ CreateResourcePipeline(const ResourcePipelineCreateInfo& info)
     {
         while (info.indices[i] != layouts.Size())
         {
-            layouts.Append(emptySetLayout);
+            layouts.Append(EmptySetLayout);
         }
         layouts.Append(resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(info.tables[i].id24));
     }

--- a/code/render/coregraphics/vk/vkresourcetable.h
+++ b/code/render/coregraphics/vk/vkresourcetable.h
@@ -92,7 +92,7 @@ typedef Ids::IdAllocator<
     Util::Array<uint>
 > VkResourceTableLayoutAllocator;
 extern VkResourceTableLayoutAllocator resourceTableLayoutAllocator;
-extern VkDescriptorSetLayout emptySetLayout;
+extern VkDescriptorSetLayout EmptySetLayout;
 
 /// run this before using any resource tables
 void SetupEmptyDescriptorSetLayout();

--- a/code/render/coregraphics/vk/vksampler.h
+++ b/code/render/coregraphics/vk/vksampler.h
@@ -15,7 +15,8 @@ namespace Vulkan
 
 typedef Ids::IdAllocator<
     VkDevice,
-    VkSampler
+    VkSampler,
+    uint32_t
 > VkSamplerAllocator;
 extern VkSamplerAllocator samplerAllocator;
 

--- a/code/render/coregraphics/vk/vkshader.cc
+++ b/code/render/coregraphics/vk/vkshader.cc
@@ -108,6 +108,15 @@ ShaderSetup(
             if ((vis & PixelShaderVisibility) == PixelShaderVisibility)         { numPerStageUniformBuffers[PixelShader]++; slotsUsed++; }
             if ((vis & ComputeShaderVisibility) == ComputeShaderVisibility)     { numPerStageUniformBuffers[ComputeShader]++; slotsUsed++; }
         }
+        else
+        {
+            numPerStageUniformBuffers[VertexShader]++;
+            numPerStageUniformBuffers[HullShader]++;
+            numPerStageUniformBuffers[DomainShader]++;
+            numPerStageUniformBuffers[GeometryShader]++;
+            numPerStageUniformBuffers[PixelShader]++;
+            numPerStageUniformBuffers[ComputeShader]++;
+        }
 
         if (block->variables.empty()) continue;
         if (AnyFX::HasFlags(block->qualifiers, AnyFX::Qualifiers::Push))
@@ -190,6 +199,15 @@ ShaderSetup(
             if ((vis & PixelShaderVisibility) == PixelShaderVisibility)         { numPerStageStorageBuffers[PixelShader]++; slotsUsed++; }
             if ((vis & ComputeShaderVisibility) == ComputeShaderVisibility)     { numPerStageStorageBuffers[ComputeShader]++; slotsUsed++; }
         }
+        else
+        {
+            numPerStageStorageBuffers[VertexShader]++;
+            numPerStageStorageBuffers[HullShader]++;
+            numPerStageStorageBuffers[DomainShader]++;
+            numPerStageStorageBuffers[GeometryShader]++;
+            numPerStageStorageBuffers[PixelShader]++;
+            numPerStageStorageBuffers[ComputeShader]++;
+        }
 
         if (buffer->set == NEBULA_DYNAMIC_OFFSET_GROUP || buffer->set == NEBULA_INSTANCE_GROUP)
         {
@@ -260,6 +278,15 @@ ShaderSetup(
                 if ((vis & PixelShaderVisibility) == PixelShaderVisibility)         { numPerStageSamplers[PixelShader]++; };
                 if ((vis & ComputeShaderVisibility) == ComputeShaderVisibility)     { numPerStageSamplers[ComputeShader]++; };
                 smla.visibility = vis;
+            }
+            else
+            {
+                numPerStageSamplers[VertexShader]++;
+                numPerStageSamplers[HullShader]++;
+                numPerStageSamplers[DomainShader]++;
+                numPerStageSamplers[GeometryShader]++;
+                numPerStageSamplers[PixelShader]++;
+                numPerStageSamplers[ComputeShader]++;
             }
             smla.slot = sampler->bindingLayout.binding;
             smla.sampler = samp;
@@ -384,6 +411,10 @@ ShaderSetup(
             ResourceTableLayoutId layout = CreateResourceTableLayout(info);
             setLayouts[i] = Util::MakePair(layoutCreateInfos.KeyAtIndex(i), layout);
             setLayoutMap.Add(layoutCreateInfos.KeyAtIndex(i), i);
+
+#if NEBULA_GRAPHICS_DEBUG
+            ObjectSetName(layout, Util::String::Sprintf("%s - Resource Table Layout %d", name.Value(), i).AsCharPtr());
+#endif
         }
     }
 

--- a/code/render/posteffects/downsamplingcontext.cc
+++ b/code/render/posteffects/downsamplingcontext.cc
@@ -240,7 +240,7 @@ DownsamplingContext::Setup(const Ptr<Frame::FrameScript>& script)
     colorDownsamplePass->func = [](const CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
         TextureDimensions dims = TextureGetDimensions(state.lightBuffer);
-        CmdSetShaderProgram(cmdBuf, state.downsampleColorProgram);
+        CmdSetShaderProgram(cmdBuf, state.downsampleColorProgram, false);
         CmdSetResourceTable(cmdBuf, state.colorDownsampleResourceTable, NEBULA_BATCH_GROUP, ComputePipeline, nullptr);
         uint dispatchX = (dims.width - 1) / 64;
         uint dispatchY = (dims.height - 1) / 64;
@@ -262,7 +262,7 @@ DownsamplingContext::Setup(const Ptr<Frame::FrameScript>& script)
     depthDownsamplePass->func = [](const CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
         TextureDimensions dims = TextureGetDimensions(state.depthBuffer);
-        CmdSetShaderProgram(cmdBuf, state.downsampleDepthProgram);
+        CmdSetShaderProgram(cmdBuf, state.downsampleDepthProgram, false);
         CmdSetResourceTable(cmdBuf, state.depthDownsampleResourceTable, NEBULA_BATCH_GROUP, ComputePipeline, nullptr);
         uint dispatchX = (dims.width - 1) / 64;
         uint dispatchY = (dims.height - 1) / 64;
@@ -290,7 +290,7 @@ DownsamplingContext::Setup(const Ptr<Frame::FrameScript>& script)
     extractPass->func = [](const CmdBufferId cmdBuf, const IndexT frame, const IndexT bufferIndex)
     {
         TextureDimensions dims = TextureGetDimensions(state.depthBuffer);
-        CmdSetShaderProgram(cmdBuf, state.extractProgram);
+        CmdSetShaderProgram(cmdBuf, state.extractProgram, false);
         CmdSetResourceTable(cmdBuf, state.extractResourceTable, NEBULA_BATCH_GROUP, ComputePipeline, nullptr);
         uint dispatchX = (dims.width - 1) / 64;
         CmdDispatch(cmdBuf, dispatchX + 1, dims.height, 1);

--- a/syswork/shaders/vk/downsample/depth_extract_cs.fx
+++ b/syswork/shaders/vk/downsample/depth_extract_cs.fx
@@ -1,4 +1,8 @@
-
+//------------------------------------------------------------------------------
+//  depth_extract_cs.fxh
+//  Read depth
+//  (C) 2021 Individual contributors, see AUTHORS file
+//------------------------------------------------------------------------------
 sampler2D ZBufferInput;
 write r32f image2D DepthOutput;
 


### PR DESCRIPTION
- Samplers are now hashed, preventing us from recreating the same sampler multiple times. 
- Downsampling context avoids global binds when running the shaders, as that throws a validation error as well as it is redundant.
- The shader also properly counts the amount of resources being bound to all shader stages when no visibility is given. 
- Added a hash combine method so we can do more complicated hashes in the future.