### PR TITLE
Fix skeleton transforms incorrectly transforming the w component.

### DIFF
--- a/syswork/shaders/vk/lib/geometrybase.fxh
+++ b/syswork/shaders/vk/lib/geometrybase.fxh
@@ -500,8 +500,8 @@ vsSkinned(
     vec4 modelSpace = Model * skinnedPos;
     gl_Position = ViewProjection * modelSpace;
     
-    Tangent 	  = (Model * skinnedTangent).xyz;
-    Normal 		  = (Model * skinnedNormal).xyz;
+    Tangent 	  = normalize((Model * skinnedTangent).xyz);
+    Normal 		  = normalize((Model * skinnedNormal).xyz);
     Sign          = tangent.w;
 
     UV            = UnpackUV(uv);
@@ -535,8 +535,8 @@ vsSkinnedTessellated(
     Position = Model * skinnedPos;
     UV = UnpackUV(uv);
 
-    Tangent     = (Model * skinnedTangent).xyz;
-    Normal      = (Model * skinnedNormal).xyz;
+    Tangent     = normalize((Model * skinnedTangent).xyz);
+    Normal      = normalize((Model * skinnedNormal).xyz);
     Sign        = tangent.w;
 
     float vertexDistance = distance( Position.xyz, EyePos.xyz );

--- a/toolkit/toolkitutil/model/import/fbx/node/nfbxmeshnode.cc
+++ b/toolkit/toolkitutil/model/import/fbx/node/nfbxmeshnode.cc
@@ -133,7 +133,7 @@ NFbxMeshNode::ExtractMesh(
     {
         FbxVector4 v = fbxMesh->GetControlPointAt(i);
         v.FixIncorrectValue();
-        controlPoints[i] = FbxToMath(v) * AdjustedScale;
+        controlPoints[i] = FbxToMath(v) * vec4(AdjustedScale, AdjustedScale, AdjustedScale, 1);
         componentMask |= MeshBuilderVertex::Position;
     }
 
@@ -349,8 +349,7 @@ NFbxMeshNode::ExtractSkin(SceneNode* node, Util::FixedArray<Math::uint4>& indice
             FbxAMatrix inversedPose = linkMatrix.Inverse();
             inversedPose = inversedPose * transformMatrix * geometricTransform;
             jointNode->skeleton.bindMatrix = FbxToMath(inversedPose);
-            jointNode->skeleton.bindMatrix.position *= AdjustedScale;
-
+            jointNode->skeleton.bindMatrix.position *= Math::vec4(AdjustedScale, AdjustedScale, AdjustedScale, 1);
 
             int clusterVertexIndexCount = cluster->GetControlPointIndicesCount();
             for (int vertexIndex = 0; vertexIndex < clusterVertexIndexCount; vertexIndex++)

--- a/toolkit/toolkitutil/model/import/fbx/node/nfbxnode.cc
+++ b/toolkit/toolkitutil/model/import/fbx/node/nfbxnode.cc
@@ -414,7 +414,7 @@ NFbxNode::ExtractAnimationCurves(SceneNode* node, FbxNode* fbxNode, Util::Array<
     // Extract keys
     extractPosScale(defaultTrans, translationSet, AdjustedScale, node->fbx.translationKeyTimes, keys, keyTimes, translationCurve);
     extractRotQuat(defaultRot, rotationSet, node->fbx.rotationKeyTimes, keys, keyTimes, rotationCurve);
-    extractPosScale(defaultScale, scaleSet, AdjustedScale, node->fbx.scaleKeyTimes, keys, keyTimes, scaleCurve);
+    extractPosScale(defaultScale, scaleSet, 1.0f, node->fbx.scaleKeyTimes, keys, keyTimes, scaleCurve);
 }
 
 } // namespace ToolkitUtil


### PR DESCRIPTION
BREAKING fix, requires content reexport. 

Also normalize tangents and normals in skinned vs.