### PR TITLE
Change how render pass attachment store/load/discard bits are defined.

### DIFF
--- a/code/render/coregraphics/pass.h
+++ b/code/render/coregraphics/pass.h
@@ -22,7 +22,7 @@ struct ResourceTableId;
 struct TextureView;
 ID_24_8_TYPE(PassId);
 
-enum class AttachmentFlagBits : uint8
+enum class AttachmentFlagBits : uint16
 {
     NoFlags = 0,
     Clear               = N_BIT(0),
@@ -30,10 +30,30 @@ enum class AttachmentFlagBits : uint8
     Load                = N_BIT(2),
     LoadStencil         = N_BIT(3),
     Store               = N_BIT(4),
-    StoreStencil        = N_BIT(6)
+    StoreStencil        = N_BIT(6),
+    Discard             = N_BIT(7),
+    DiscardStencil      = N_BIT(8),
 };
 __ImplementEnumBitOperators(AttachmentFlagBits);
 __ImplementEnumComparisonOperators(AttachmentFlagBits);
+
+static AttachmentFlagBits 
+AttachmentFlagsFromString(const Util::String& string)
+{
+    Util::Array<Util::String> bits = string.Tokenize("|");
+
+    AttachmentFlagBits ret = AttachmentFlagBits::NoFlags;
+    for (IndexT i = 0; i < bits.Size(); i++)
+    {
+        if (bits[i] == "Load")                  ret |= AttachmentFlagBits::Load;
+        else if (bits[i] == "LoadStencil")      ret |= AttachmentFlagBits::LoadStencil;
+        else if (bits[i] == "Store")            ret |= AttachmentFlagBits::Store;
+        else if (bits[i] == "StoreStencil")     ret |= AttachmentFlagBits::StoreStencil;
+        else if (bits[i] == "Discard")          ret |= AttachmentFlagBits::Discard;
+        else if (bits[i] == "DiscardStenci;")   ret |= AttachmentFlagBits::DiscardStencil;
+    }
+    return ret;
+};
 
 struct Subpass
 {

--- a/code/render/coregraphics/vk/vkpass.cc
+++ b/code/render/coregraphics/vk/vkpass.cc
@@ -363,6 +363,7 @@ GetSubpassInfo(
 
     VkAttachmentStoreOp storeOps[] =
     {
+        VK_ATTACHMENT_STORE_OP_NONE,
         VK_ATTACHMENT_STORE_OP_DONT_CARE,
         VK_ATTACHMENT_STORE_OP_STORE,
     };
@@ -377,10 +378,59 @@ GetSubpassInfo(
 
         VkFormat fmt = VkTypes::AsVkFormat(TextureGetPixelFormat(tex));
         VkAttachmentDescription& attachment = outAttachments[i];
-        IndexT loadIdx = AllBits(loadInfo.attachmentFlags[i], AttachmentFlagBits::Load) ? 2 : AllBits(loadInfo.attachmentFlags[i], AttachmentFlagBits::Clear) ? 1 : 0;
-        IndexT storeIdx = AllBits(loadInfo.attachmentFlags[i], AttachmentFlagBits::Store) ? 1 : 0;
-        IndexT stencilLoadIdx = AllBits(loadInfo.attachmentFlags[i], AttachmentFlagBits::LoadStencil) ? 2 : AllBits(loadInfo.attachmentFlags[i], AttachmentFlagBits::ClearStencil) ? 1 : 0;
-        IndexT stencilStoreIdx = AllBits(loadInfo.attachmentFlags[i], AttachmentFlagBits::StoreStencil) ? 1 : 0;
+        IndexT loadIdx = 0;
+        switch (loadInfo.attachmentFlags[i] & (AttachmentFlagBits::Load | AttachmentFlagBits::Clear))
+        {
+            case AttachmentFlagBits::Load:
+                loadIdx = 2;
+                break;
+            case AttachmentFlagBits::Clear:
+                loadIdx = 1;
+                break;
+            default:
+                loadIdx = 0;
+                break;
+        }
+        IndexT stencilLoadIdx = 0;
+        switch (loadInfo.attachmentFlags[i] & (AttachmentFlagBits::LoadStencil | AttachmentFlagBits::ClearStencil))
+        {
+            case AttachmentFlagBits::LoadStencil:
+                stencilLoadIdx = 2;
+                break;
+            case AttachmentFlagBits::ClearStencil:
+                stencilLoadIdx = 1;
+                break;
+            default:
+                stencilLoadIdx = 0;
+                break;
+        }
+        IndexT storeIdx = 0;
+        switch (loadInfo.attachmentFlags[i] & (AttachmentFlagBits::Store | AttachmentFlagBits::Discard))
+        {
+            case AttachmentFlagBits::Store:
+                storeIdx = 2;
+                break;
+            case AttachmentFlagBits::Discard:
+                storeIdx = 1;
+                break;
+            default:
+                storeIdx = 0;
+                break;
+        }
+        IndexT stencilStoreIdx = 0;
+        switch (loadInfo.attachmentFlags[i] & (AttachmentFlagBits::StoreStencil | AttachmentFlagBits::DiscardStencil))
+        {
+            case AttachmentFlagBits::StoreStencil:
+                stencilStoreIdx = 2;
+                break;
+            case AttachmentFlagBits::DiscardStencil:
+                stencilStoreIdx = 1;
+                break;
+            default:
+                stencilStoreIdx = 0;
+                break;
+        }
+
         attachment.flags = 0;
         if (loadInfo.attachmentIsDepthStencil[i])
         {

--- a/syswork/frame/win32/vkdefault.json
+++ b/syswork/frame/win32/vkdefault.json
@@ -240,7 +240,7 @@
                                 {
                                     "name": "SunShadowDepth",
                                     "clear_depth": 1,
-                                    "store": true
+                                    "flags": "Store"
                                 }
                             ],
 
@@ -269,7 +269,7 @@
                                 {
                                     "name": "LocalLightShadow",
                                     "clear_depth": 1,
-                                    "store": true
+                                    "flags": "Store"
                                 }
                             ],
                             
@@ -334,12 +334,12 @@
                                 {
                                     "name": "TerrainPosBuffer",
                                     "clear": [ 0, 0, 0, 255 ],
-                                    "store": true
+                                    "flags": "Store"
                                 },
                                 {
                                     "name": "ZBuffer",
                                     "clear_depth": 1,
-                                    "store": true
+                                    "flags": "Store"
                                 }
                             ],
 
@@ -375,8 +375,7 @@
                                     "name": "ZBuffer",
                                     "clear_depth": 1,
                                     "clear_stencil": 0,
-                                    "store": true,
-                                    "store_stencil": true
+                                    "flags": "Store|StoreStencil"
                                 }
                             ],
 
@@ -429,23 +428,21 @@
                             "attachments": [
                                 {
                                     "name": "ZBuffer",
-                                    "store": true,
-                                    "load": true,
-                                    "load_stencil": true
+                                    "flags":  "Store|Load|LoadStencil"
                                 },
                                 {
                                     "name": "LightBuffer",
                                     "clear": [ 0, 0, 0, 0 ],
-                                    "store": true
+                                    "flags": "Store"
                                 },
                                 {
                                     "name": "NormalBuffer",
-                                    "store": true,
+                                    "flags": "Store",
                                     "clear": [ 0, 0, 0, 0 ]
                                 },
                                 {
                                     "name": "SpecularBuffer",
-                                    "store": true,
+                                    "flags": "Store",
                                     "clear": [ 0, 0, 0, 0 ]
                                 }
 
@@ -569,13 +566,11 @@
                             "attachments": [
                                 {
                                     "name": "ColorBuffer",
-                                    "load": true,
-                                    "store": true
+                                    "flags": "Load|Store"
                                 },
                                 {
                                     "name": "ZBuffer",
-                                    "load": true,
-                                    "store": false
+                                    "flags": "Load"
                                 }
                             ],
 
@@ -704,13 +699,11 @@
                             "attachments": [
                                 {
                                     "name": "ColorBuffer",
-                                    "load": true,
-                                    "store": true
+                                    "flags": "Load|Store"
                                 },
                                 {
                                     "name": "ZBuffer",
-                                    "store": false,
-                                    "load": true
+                                    "flags":  "Load|Discard"
                                 }
                             ],
 


### PR DESCRIPTION
- Add discard bit.
- Change frame script schema to accept a string list (concatenated with |) to define if the attachment should load, store and/or discard. Clear is set by the clear value. 
- Add support for Vulkan 1.3 render pass store op which doesn't allow the GPU to discard the contents after the pass ends.