### PR TITLE
Fix size classification allocator

### DIFF
--- a/code/render/coregraphics/memory.h
+++ b/code/render/coregraphics/memory.h
@@ -80,6 +80,8 @@ struct MemoryPool
 
 private:
 
+    static constexpr uint DedicatedBlockNodeIndex = 0xFFFFFFFF;
+
     // allocate conservatively
     Alloc Allocate(DeviceSize alignment, DeviceSize size);
     // create new memory block


### PR DESCRIPTION
Allocations would round down the bucket and bin they needed, resulting in cases where the allocation didn't fit in memory. 