### PR TITLE
Fix bad use of resize

### DIFF
--- a/code/render/models/modelcontext.cc
+++ b/code/render/models/modelcontext.cc
@@ -120,9 +120,12 @@ ModelContext::Setup(const Graphics::GraphicsEntityId gfxId, const Resources::Res
         transformRange.allocation = TransformInstanceAllocator.Alloc(transformNodes.Size());
         transformRange.begin = transformRange.allocation.offset;
         transformRange.end = transformRange.allocation.offset + transformNodes.Size();
-        NodeInstances.transformable.nodeParents.Resize(transformRange.end);
-        NodeInstances.transformable.origTransforms.Resize(transformRange.end);
-        NodeInstances.transformable.nodeTransforms.Resize(transformRange.end);
+        if (NodeInstances.transformable.nodeParents.Size() < transformRange.end)
+        {
+            NodeInstances.transformable.nodeParents.Resize(transformRange.end);
+            NodeInstances.transformable.origTransforms.Resize(transformRange.end);
+            NodeInstances.transformable.nodeTransforms.Resize(transformRange.end);
+        }
         
         for (SizeT i = 0; i < transformNodes.Size(); i++)
         {
@@ -150,26 +153,29 @@ ModelContext::Setup(const Graphics::GraphicsEntityId gfxId, const Resources::Res
         stateRange.begin = stateRange.allocation.offset;
         stateRange.end = stateRange.allocation.offset + renderNodes.Size();
 
-        NodeInstances.renderable.nodeStates.Resize(stateRange.end);
-        NodeInstances.renderable.nodeTransformIndex.Resize(stateRange.end);
-        NodeInstances.renderable.nodeBoundingBoxes.Resize(stateRange.end);
-        NodeInstances.renderable.origBoundingBoxes.Resize(stateRange.end);
-        NodeInstances.renderable.nodeLodDistances.Resize(stateRange.end);
-        NodeInstances.renderable.nodeLods.Resize(stateRange.end);
-        NodeInstances.renderable.textureLods.Resize(stateRange.end);
-        NodeInstances.renderable.nodeFlags.Resize(stateRange.end);
-        NodeInstances.renderable.nodeMaterials.Resize(stateRange.end);
-        NodeInstances.renderable.nodeShaderConfigs.Resize(stateRange.end);
-        NodeInstances.renderable.nodeTypes.Resize(stateRange.end);
-        NodeInstances.renderable.nodes.Resize(stateRange.end);
-        NodeInstances.renderable.nodeMeshes.Resize(stateRange.end);
-        NodeInstances.renderable.nodePrimitiveGroupIndex.Resize(stateRange.end);
-        NodeInstances.renderable.nodeDrawModifiers.Resize(stateRange.end); // Base 1 instance 0 offset
-        NodeInstances.renderable.nodeSortId.Resize(stateRange.end);
+        if (NodeInstances.renderable.nodeStates.Size() < stateRange.end)
+        {
+            NodeInstances.renderable.nodeStates.Resize(stateRange.end);
+            NodeInstances.renderable.nodeTransformIndex.Resize(stateRange.end);
+            NodeInstances.renderable.nodeBoundingBoxes.Resize(stateRange.end);
+            NodeInstances.renderable.origBoundingBoxes.Resize(stateRange.end);
+            NodeInstances.renderable.nodeLodDistances.Resize(stateRange.end);
+            NodeInstances.renderable.nodeLods.Resize(stateRange.end);
+            NodeInstances.renderable.textureLods.Resize(stateRange.end);
+            NodeInstances.renderable.nodeFlags.Resize(stateRange.end);
+            NodeInstances.renderable.nodeMaterials.Resize(stateRange.end);
+            NodeInstances.renderable.nodeShaderConfigs.Resize(stateRange.end);
+            NodeInstances.renderable.nodeTypes.Resize(stateRange.end);
+            NodeInstances.renderable.nodes.Resize(stateRange.end);
+            NodeInstances.renderable.nodeMeshes.Resize(stateRange.end);
+            NodeInstances.renderable.nodePrimitiveGroupIndex.Resize(stateRange.end);
+            NodeInstances.renderable.nodeDrawModifiers.Resize(stateRange.end); // Base 1 instance 0 offset
+            NodeInstances.renderable.nodeSortId.Resize(stateRange.end);
 
 #if NEBULA_GRAPHICS_DEBUG
-        NodeInstances.renderable.nodeNames.Resize(stateRange.end);
+            NodeInstances.renderable.nodeNames.Resize(stateRange.end);
 #endif
+        }
         for (SizeT i = 0; i < renderNodes.Size(); i++)
         {
             Models::PrimitiveNode* sNode = reinterpret_cast<Models::PrimitiveNode*>(renderNodes[i]);
@@ -343,7 +349,6 @@ ModelContext::ChangeModel(const Graphics::GraphicsEntityId gfxId, const Resource
 
     if (rid != InvalidResourceId) // decrement model resource
         Models::DestroyModel(rid);
-
 
     // Currently super broken, needs to be identical to the Setup functions
     auto successCallback = [cid, gfxId, finishedCallback](Resources::ResourceId mid)

--- a/code/render/models/modelcontext.h
+++ b/code/render/models/modelcontext.h
@@ -246,6 +246,8 @@ ModelContext::Dealloc(Graphics::ContextEntityId id)
         Resources::DiscardResource(rid);
     rid = Resources::InvalidResourceId;
 
+    modelContextAllocator.Get<Model_NodeInstanceRoots>(id.id).Clear();
+    modelContextAllocator.Get<Model_NodeLookup>(id.id).Clear();
     TransformInstanceAllocator.Dealloc(modelContextAllocator.Get<Model_NodeInstanceTransform>(id.id).allocation);
     RenderInstanceAllocator.Dealloc(modelContextAllocator.Get<Model_NodeInstanceStates>(id.id).allocation);
 


### PR DESCRIPTION
Also clear root node array and node lookup table when deallocating a model