### PR TITLE
physics cleanup fixes

### DIFF
--- a/code/addons/physicsfeature/managers/physicsmanager.cc
+++ b/code/addons/physicsfeature/managers/physicsmanager.cc
@@ -17,12 +17,6 @@ namespace PhysicsFeature
 
 __ImplementSingleton(PhysicsManager)
 
-struct PhysicsActor
-{
-    Physics::ActorId value;
-    DECLARE_COMPONENT;
-};
-
 DEFINE_COMPONENT(PhysicsActor);
 
 //------------------------------------------------------------------------------

--- a/code/addons/physicsfeature/managers/physicsmanager.h
+++ b/code/addons/physicsfeature/managers/physicsmanager.h
@@ -11,9 +11,18 @@
 #include "core/singleton.h"
 #include "game/manager.h"
 #include "game/category.h"
+#include "game/component.h"
+#include "physicsinterface.h"
+#include "memdb/typeregistry.h"
 
 namespace PhysicsFeature
 {
+
+struct PhysicsActor
+{
+    Physics::ActorId value;
+    DECLARE_COMPONENT;
+};
 
 class PhysicsManager
 {

--- a/code/addons/physicsfeature/physicsfeatureunit.cc
+++ b/code/addons/physicsfeature/physicsfeatureunit.cc
@@ -107,8 +107,25 @@ PhysicsFeatureUnit::OnActivate()
 void
 PhysicsFeatureUnit::OnDeactivate()
 {   
-    FeatureUnit::OnDeactivate();    
+    FeatureUnit::OnDeactivate();
+    for (auto const& scene : this->physicsWorlds)
+    {
+        Physics::DestroyScene(scene.Value());
+    }
     Physics::ShutDown();
+}
+
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+PhysicsFeatureUnit::OnBeforeCleanup(Game::World* world)
+{
+    n_assert(this->physicsWorlds.Contains(world));
+    IndexT scene = this->physicsWorlds[world];
+    Physics::FlushSimulation(scene);
+    FeatureUnit::OnBeforeCleanup(world);
 }
 
 //------------------------------------------------------------------------------

--- a/code/addons/physicsfeature/physicsfeatureunit.h
+++ b/code/addons/physicsfeature/physicsfeatureunit.h
@@ -32,6 +32,8 @@ public:
     void OnActivate();
     /// Called upon deactivation of feature unit
     void OnDeactivate();
+    /// called from within GameServer::NotifyBeforeCleanup()
+    void OnBeforeCleanup(Game::World* world);
 
     /// called on begin of frame
     virtual void OnBeginFrame();

--- a/code/physics/physics/physxstate.cc
+++ b/code/physics/physics/physxstate.cc
@@ -37,8 +37,7 @@ PhysxState::Setup()
     this->foundation = PxCreateFoundation(PX_PHYSICS_VERSION, this->allocator, this->errorCallback);
     n_assert2(this->foundation, "PxCreateFoundation failed!");
 
-    this->pvd = PxCreatePvd(*this->foundation);   
-    
+    this->pvd = PxCreatePvd(*this->foundation);    
 
     this->physics = PxCreatePhysics(PX_PHYSICS_VERSION, *this->foundation, PxTolerancesScale(), false, this->pvd);
     n_assert2(this->physics, "PxCreatePhysics failed!");
@@ -53,6 +52,28 @@ PhysxState::Setup()
 
     // preallocate actors
     ActorContext::actors.Reserve(1024);
+}
+
+
+//------------------------------------------------------------------------------
+/**
+*/
+void PhysxState::Shutdown()
+{
+   
+    PxCloseExtensions();
+    this->cooking->release();
+    this->cooking = nullptr;
+    this->physics->release();
+    this->physics = nullptr;
+    if (this->pvd != nullptr)
+    {
+        this->DisconnectPVD();
+        this->pvd->release();
+        this->pvd = nullptr;
+    }
+    this->foundation->release();
+    this->foundation = nullptr;
 }
 
 //------------------------------------------------------------------------------
@@ -300,6 +321,16 @@ PhysxState::EndSimulating(IndexT sceneId)
     N_MARKER_END();
 }
 
+//------------------------------------------------------------------------------
+/**
+*/
+void
+PhysxState::FlushSimulation(IndexT sceneId)
+{
+    n_assert(this->activeSceneIds.FindIndex(sceneId) != InvalidIndex);
+    Physics::Scene& scene = this->activeScenes[sceneId];
+    scene.scene->fetchResults(true);
+}
 
 PhysxState state;
 }

--- a/code/physics/physics/physxstate.h
+++ b/code/physics/physics/physxstate.h
@@ -58,8 +58,11 @@ public:
 
     /// explicit call to simulate, will process async in the background
     void BeginSimulating(Timing::Time delta, IndexT scene);
-    // explicit call to fetch the results of the simulation
+    /// explicit call to fetch the results of the simulation
     void EndSimulating(IndexT scene);
+
+    /// will block until a potential simulation step is done
+    void FlushSimulation(IndexT scene);
 
     /// create new empty actor
     physx::PxRigidActor* CreateActor(ActorType type, Math::mat4 const & transform);

--- a/code/physics/physics/streamactorpool.cc
+++ b/code/physics/physics/streamactorpool.cc
@@ -445,8 +445,7 @@ StreamActorPool::LoadFromStream(const Ids::Id32 entry, const Util::StringAtom & 
 
     ActorResourceId ret;
     ret.resourceId = id;
-    ret.resourceType = 0;
-    allocator.Release(id);
+    ret.resourceType = Physics::ActorIdType;
     return ret;
 }
 
@@ -465,10 +464,7 @@ StreamActorPool::Unload(const Resources::ResourceId id)
     {
         i->release();
     }
-    for (auto s : info.shapes)
-    {
-        s->release();        
-    }    
+    info.shapes.Clear();
     allocator.Dealloc(id.resourceId);
 }
 

--- a/code/physics/physicsinterface.cc
+++ b/code/physics/physicsinterface.cc
@@ -85,10 +85,7 @@ Setup()
 */
 void ShutDown()
 {
-    PxCloseExtensions();
-    state.cooking->release();
-    state.physics->release();
-    state.foundation->release();
+    state.Shutdown();
 }
 
 //------------------------------------------------------------------------------
@@ -331,6 +328,14 @@ EndSimulating(IndexT scene)
     state.EndSimulating(scene);
 }
 
+//------------------------------------------------------------------------------
+/**
+*/
+void
+FlushSimulation(IndexT scene)
+{
+    state.FlushSimulation(scene);
+}
 
 //------------------------------------------------------------------------------
 /**

--- a/code/physics/physicsinterface.h
+++ b/code/physics/physicsinterface.h
@@ -83,9 +83,12 @@ void ShutDown();
 /// perform sync simulation step(s)
 void Update(Timing::Time delta);
 
-// explicit calls to simulate and fetch results. Do not mix with Update!
+/// explicit calls to simulate and fetch results. Do not mix with Update!
 void BeginSimulating(Timing::Time delta, IndexT scene);
 void EndSimulating(IndexT scene);
+
+/// this will block until simulation has ended for cleanups e.g.
+void FlushSimulation(IndexT scene);
 
 ///
 IndexT CreateScene();


### PR DESCRIPTION
- expose physicsactor to application layer
- stop simulation before closing down and cleaning up
- general shutdown cleanups in physics