### PR TITLE
Fix primitive node picking non existant primitive and mesh indexes

### DIFF
--- a/code/render/coregraphics/meshloader.h
+++ b/code/render/coregraphics/meshloader.h
@@ -37,7 +37,6 @@ private:
 
     /// setup mesh from nvx3 file in memory
     void SetupMeshFromNvx(const Ptr<IO::Stream>& stream, const MeshResourceId entry);
-
 };
 
 } // namespace CoreGraphics

--- a/code/render/models/nodes/primitivenode.cc
+++ b/code/render/models/nodes/primitivenode.cc
@@ -45,13 +45,23 @@ PrimitiveNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag, con
 
         // Load directly, since the model is already loaded on a thread, this is fine
         //this->primitiveGroupIndex = 0;
-        this->res = Resources::CreateResource(meshName, tag, nullptr, nullptr, true);
+        this->res = Resources::CreateResource(
+            meshName,
+            tag,
+            [this](Resources::ResourceId)
+            {
+                this->loadSuccess = true;
+            },
+            nullptr,
+            true
+        );
 
     }
     else if (FourCC('MSHI') == fourcc)
     {
         CoreGraphics::MeshResourceId meshRes = this->res;
-        IndexT meshIndex = reader->ReadUInt();
+        uint index = reader->ReadUInt();
+        IndexT meshIndex = this->loadSuccess ? index : 0;
         this->mesh = MeshResourceGetMesh(meshRes, meshIndex);
 
         this->vbo = CoreGraphics::MeshGetVertexBuffer(this->mesh, 0);
@@ -66,7 +76,8 @@ PrimitiveNode::Load(const Util::FourCC& fourcc, const Util::StringAtom& tag, con
     else if (FourCC('PGRI') == fourcc)
     {
         // primitive group index
-        this->primitiveGroupIndex = reader->ReadUInt();
+        uint index = reader->ReadUInt();
+        this->primitiveGroupIndex = this->loadSuccess ? index : 0;
         this->primGroup = CoreGraphics::MeshGetPrimitiveGroups(this->mesh)[this->primitiveGroupIndex];
     }
     else

--- a/code/render/models/nodes/primitivenode.h
+++ b/code/render/models/nodes/primitivenode.h
@@ -39,6 +39,7 @@ protected:
     Resources::ResourceId res;
     CoreGraphics::MeshId mesh;
     uint16_t primitiveGroupIndex;
+    bool loadSuccess = false;
 
     CoreGraphics::BufferId vbo, ibo;
     IndexT baseVboOffset, attributesVboOffset, iboOffset;

--- a/code/resource/resources/resourceloader.h
+++ b/code/resource/resources/resourceloader.h
@@ -184,7 +184,7 @@ protected:
     Util::FixedArray<_PlaceholderResource> placeholders;
 
     /// get placeholder based on resource name
-    virtual Resources::ResourceId GetPlaceholder(const Resources::ResourceName& name);
+    Resources::ResourceId GetPlaceholder(const Resources::ResourceName& name);
 
     /// these types need to be properly initiated in a subclass Setup function
     Util::StringAtom placeholderResourceName;


### PR DESCRIPTION
Handle primitive node not picking a non-existant primitive group and mesh index which can happen if the resource load fails (mesh) but the model continues to load.