### PR TITLE
Physics heightfields

### DIFF
--- a/code/physics/physicsinterface.h
+++ b/code/physics/physicsinterface.h
@@ -73,6 +73,7 @@ struct Scene
     physx::PxDefaultCpuDispatcher *dispatcher;
     UpdateFunctionType updateFunction = nullptr;
     Timing::Time time;
+    bool isSimulating = false;
 };
 
 /// initialize the physics subsystem and create a default scene

--- a/fips-files/configs/win64-vstudio-debug.yml
+++ b/fips-files/configs/win64-vstudio-debug.yml
@@ -6,5 +6,8 @@ build_type: Debug
 defines:
     N_USE_VULKAN: ON
     __X64__: ON
+    FIPS_MSVC_LTCG: OFF
     N_DEBUG_SYMBOLS: ON
     PX_TARGET: win.x86_64.vc143.mt
+    SOLOUD_BACKEND_WASAPI: ON
+    SOLOUD_BACKEND_NULL: OFF

--- a/fips-files/configs/win64-vstudio-release.yml
+++ b/fips-files/configs/win64-vstudio-release.yml
@@ -5,5 +5,8 @@ build_tool: cmake
 build_type: Release
 defines:
     N_USE_VULKAN: ON
+    FIPS_MSVC_LTCG: OFF
     __X64__: ON
     PX_TARGET: win.x86_64.vc143.mt
+    SOLOUD_BACKEND_WASAPI: ON
+    SOLOUD_BACKEND_NULL: OFF

--- a/syswork/data/flatbuffer/physics/actor.fbs
+++ b/syswork/data/flatbuffer/physics/actor.fbs
@@ -38,9 +38,17 @@ table BoxCollider
      extents : Flat.Vec3 (native_inline);
 }
 
+table HeightFieldCollider
+{
+    height_range : float;
+    target_size_x : float;
+    target_size_y : float;
+    file : string;
+}
+
 union ColliderData
 {
-    BoxCollider, SphereCollider, CapsuleCollider, MeshCollider
+    BoxCollider, SphereCollider, CapsuleCollider, MeshCollider, HeightFieldCollider
 }
 
 table Collider

--- a/syswork/data/flatbuffer/physics/material.fbs
+++ b/syswork/data/flatbuffer/physics/material.fbs
@@ -19,8 +19,7 @@ enum MeshTopology :  byte
     Convex = 0,    
     ConvexHull = 1,
     Triangles = 2,
-    HeightField = 3,
-    ApproxSkin = 4,
+    ApproxSkin = 3
 }
 
 enum ColliderType : byte
@@ -29,7 +28,8 @@ enum ColliderType : byte
     Cube = 1,    
     Capsule = 2,
     Plane = 3,
-    Mesh = 4
+    Mesh = 4,
+    HeightField = 5
 }
 
 table MaterialDefinition


### PR DESCRIPTION
- update vs build settings to disable LTCG and select WASAPI soloud backend by default
- add support for loading physx heightfields from R16_UNORM textures
- made physics run with actual physics framerate instead