### PR TITLE
Terrain raytracing

### DIFF
--- a/code/physics/physics/streamactorpool.cc
+++ b/code/physics/physics/streamactorpool.cc
@@ -17,6 +17,7 @@
 #include "coregraphics/nvx3fileformatstructs.h"
 #include "coregraphics/primitivegroup.h"
 #include "coregraphics/load/glimltypes.h"
+#include "coregraphics/indextype.h"
 
 __ImplementClass(Physics::StreamActorPool, 'PSAP', Resources::ResourceLoader);
 

--- a/code/render/coregraphics/accelerationstructure.h
+++ b/code/render/coregraphics/accelerationstructure.h
@@ -81,6 +81,8 @@ BlasInstanceId CreateBlasInstance(const BlasInstanceCreateInfo& info);
 void DestroyBlasInstance(const BlasInstanceId id);
 /// Update blas instance and write to buffer
 void BlasInstanceUpdate(const BlasInstanceId id, const Math::mat4& transform, CoreGraphics::BufferId buf, uint offset);
+/// Update blas instance and write to buffer
+void BlasInstanceUpdate(const BlasInstanceId id, CoreGraphics::BufferId buf, uint offset);
 /// Get instance size (platform dependent)
 const SizeT BlasInstanceGetSize();
 

--- a/code/render/coregraphics/accelerationstructure.h
+++ b/code/render/coregraphics/accelerationstructure.h
@@ -83,6 +83,8 @@ void DestroyBlasInstance(const BlasInstanceId id);
 void BlasInstanceUpdate(const BlasInstanceId id, const Math::mat4& transform, CoreGraphics::BufferId buf, uint offset);
 /// Update blas instance and write to buffer
 void BlasInstanceUpdate(const BlasInstanceId id, CoreGraphics::BufferId buf, uint offset);
+/// Set blas instance mask, setting it to 0x0 will disable it
+void BlasInstanceSetMask(const BlasInstanceId id, uint mask);
 /// Get instance size (platform dependent)
 const SizeT BlasInstanceGetSize();
 

--- a/code/render/coregraphics/mesh.h
+++ b/code/render/coregraphics/mesh.h
@@ -16,9 +16,9 @@
 #include "coregraphics/buffer.h"
 #include "coregraphics/primitivetopology.h"
 #include "coregraphics/primitivegroup.h"
+#include "coregraphics/vertexlayout.h"
 namespace CoreGraphics
 {
-
 struct VertexAlloc
 {
     uint size, offset, node;

--- a/code/render/coregraphics/nvx3fileformatstructs.h
+++ b/code/render/coregraphics/nvx3fileformatstructs.h
@@ -9,6 +9,7 @@
     (C) 2013-2018 Individual contributors, see AUTHORS file
 */
 #include "core/types.h"
+#include "coregraphics/indextype.h"
 #include "coregraphics/gpubuffertypes.h"
 #include "coregraphics/vertexlayout.h"
 

--- a/code/render/coregraphics/primitivegroup.h
+++ b/code/render/coregraphics/primitivegroup.h
@@ -11,7 +11,6 @@
     (C) 2013-2020 Individual contributors, see AUTHORS file
 */    
 #include "coregraphics/primitivetopology.h"
-#include "coregraphics/vertexlayout.h"
 #include "math/bbox.h"
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vertexlayout.h
+++ b/code/render/coregraphics/vertexlayout.h
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 #include "ids/id.h"
 #include "coregraphics/vertexcomponent.h"
-#include "math/half.h"
+#include "resources/resourceid.h"
 namespace CoreGraphics
 {
 

--- a/code/render/coregraphics/vertexlayout.h
+++ b/code/render/coregraphics/vertexlayout.h
@@ -9,7 +9,6 @@
 //------------------------------------------------------------------------------
 #include "ids/id.h"
 #include "coregraphics/vertexcomponent.h"
-#include "coregraphics/shader.h"
 #include "math/half.h"
 namespace CoreGraphics
 {
@@ -29,7 +28,6 @@ struct VertexLayoutInfo
     Util::StringAtom signature;
     SizeT vertexByteSize;
     Util::Array<VertexComponent> comps;
-    ShaderProgramId shader;
 };
 
 /// create new vertex layout

--- a/code/render/coregraphics/vk/vkaccelerationstructure.cc
+++ b/code/render/coregraphics/vk/vkaccelerationstructure.cc
@@ -333,6 +333,8 @@ CreateBlasInstance(const BlasInstanceCreateInfo& info)
 void
 DestroyBlasInstance(const BlasInstanceId id)
 {
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    setup.mask = 0x0; // Disable instance such that TLAS building will ignore it
     blasInstanceAllocator.Dealloc(id.id24);
 }
 
@@ -359,6 +361,16 @@ BlasInstanceUpdate(const BlasInstanceId id, CoreGraphics::BufferId buf, uint off
     VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
     char* ptr = (char*)CoreGraphics::BufferMap(buf) + offset;
     memcpy(ptr, &setup, sizeof(setup));
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void
+BlasInstanceSetMask(const BlasInstanceId id, uint mask)
+{
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    setup.mask = mask;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vk/vkaccelerationstructure.cc
+++ b/code/render/coregraphics/vk/vkaccelerationstructure.cc
@@ -141,8 +141,8 @@ CreateBlas(const BlasCreateInfo& info)
 
     BufferIdLock _1(info.vbo);
     BufferIdLock _2(info.ibo);
-    VkDeviceAddress vboAddr = BufferGetDeviceAddress(CoreGraphics::GetVertexBuffer());
-    VkDeviceAddress iboAddr = BufferGetDeviceAddress(CoreGraphics::GetIndexBuffer());
+    VkDeviceAddress vboAddr = BufferGetDeviceAddress(info.vbo);
+    VkDeviceAddress iboAddr = BufferGetDeviceAddress(info.ibo);
     VkFormat positionsFormat = VkTypes::AsVkVertexType(info.positionsFormat);
 
     // Assert the vertex format is supported by raytracing

--- a/code/render/coregraphics/vk/vkaccelerationstructure.cc
+++ b/code/render/coregraphics/vk/vkaccelerationstructure.cc
@@ -347,7 +347,17 @@ BlasInstanceUpdate(const BlasInstanceId id, const Math::mat4& transform, CoreGra
     trans.store3(&setup.transform.matrix[0][0]);
 
     char* ptr = (char*)CoreGraphics::BufferMap(buf) + offset;
+    memcpy(ptr, &setup, sizeof(setup));
+}
 
+//------------------------------------------------------------------------------
+/**
+*/
+void
+BlasInstanceUpdate(const BlasInstanceId id, CoreGraphics::BufferId buf, uint offset)
+{
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    char* ptr = (char*)CoreGraphics::BufferMap(buf) + offset;
     memcpy(ptr, &setup, sizeof(setup));
 }
 
@@ -410,13 +420,14 @@ CreateTlas(const TlasCreateInfo& info)
         .scratchData = VkDeviceOrHostAddressKHR{ .hostAddress = nullptr }
     };
 
-    scene.rangeInfos.Append(
-    {
-        .primitiveCount = (uint)info.numInstances,
-        .primitiveOffset = 0, // Primitive offset is defined in the mesh
-        .firstVertex = 0,
-        .transformOffset = 0
-    });
+    scene.rangeInfos = {
+        {
+            .primitiveCount = (uint)info.numInstances,
+            .primitiveOffset = 0, // Primitive offset is defined in the mesh
+            .firstVertex = 0,
+            .transformOffset = 0
+        }
+    };
 
     // Get build sizes
     scene.buildSizes =

--- a/code/render/coregraphics/vk/vkvertexlayout.cc
+++ b/code/render/coregraphics/vk/vkvertexlayout.cc
@@ -103,7 +103,6 @@ CreateVertexLayout(const VertexLayoutCreateInfo& info)
 
     loadInfo.signature = Util::StringAtom(sig);
     loadInfo.vertexByteSize = size;
-    loadInfo.shader = Ids::InvalidId64;
     loadInfo.comps = info.comps;
     vertexLayoutAllocator.Set<VertexSignature_LayoutInfo>(id, loadInfo);
 

--- a/code/render/graphics/bindlessregistry.cc
+++ b/code/render/graphics/bindlessregistry.cc
@@ -50,6 +50,14 @@ RegisterTexture(const CoreGraphics::TextureId& tex, CoreGraphics::TextureType ty
     IndexT var;
     switch (type)
     {
+    case CoreGraphics::Texture1D:
+        n_assert(!state.texturePool.IsFull());
+        var = Shared::Table_Tick::Textures1D_SLOT;
+        break;
+    case CoreGraphics::Texture1DArray:
+        n_assert(!state.texturePool.IsFull());
+        var = Shared::Table_Tick::Textures1DArray_SLOT;
+        break;
     case CoreGraphics::Texture2D:
         n_assert(!state.texturePool.IsFull());
         var = Shared::Table_Tick::Textures2D_SLOT;
@@ -65,6 +73,10 @@ RegisterTexture(const CoreGraphics::TextureId& tex, CoreGraphics::TextureType ty
     case CoreGraphics::TextureCube:
         n_assert(!state.texturePool.IsFull());
         var = Shared::Table_Tick::TexturesCube_SLOT;
+        break;
+    case CoreGraphics::TextureCubeArray:
+        n_assert(!state.texturePool.IsFull());
+        var = Shared::Table_Tick::TexturesCubeArray_SLOT;
         break;
     default:
         n_error("Should not happen");
@@ -99,6 +111,12 @@ ReregisterTexture(const CoreGraphics::TextureId& tex, CoreGraphics::TextureType 
     IndexT var = -1;
     switch (type)
     {
+    case CoreGraphics::Texture1D:
+        var = Shared::Table_Tick::Textures1D_SLOT;
+        break;
+    case CoreGraphics::Texture1DArray:
+        var = Shared::Table_Tick::Textures1DArray_SLOT;
+        break;
     case CoreGraphics::Texture2D:
         var = Shared::Table_Tick::Textures2D_SLOT;
         break;
@@ -110,6 +128,9 @@ ReregisterTexture(const CoreGraphics::TextureId& tex, CoreGraphics::TextureType 
         break;
     case CoreGraphics::TextureCube:
         var = Shared::Table_Tick::TexturesCube_SLOT;
+        break;
+    case CoreGraphics::TextureCubeArray:
+        var = Shared::Table_Tick::TexturesCubeArray_SLOT;
         break;
     default: n_error("unhandled enum"); break;
     }
@@ -140,6 +161,12 @@ UnregisterTexture(const BindlessIndex id, const CoreGraphics::TextureType type)
     IndexT var = -1;
     switch (type)
     {
+    case CoreGraphics::Texture1D:
+        var = Shared::Table_Tick::Textures1D_SLOT;
+        break;
+    case CoreGraphics::Texture1DArray:
+        var = Shared::Table_Tick::Textures1DArray_SLOT;
+        break;
     case CoreGraphics::Texture2D:
         var = Shared::Table_Tick::Textures2D_SLOT;
         break;
@@ -151,6 +178,9 @@ UnregisterTexture(const BindlessIndex id, const CoreGraphics::TextureType type)
         break;
     case CoreGraphics::TextureCube:
         var = Shared::Table_Tick::TexturesCube_SLOT;
+        break;
+    case CoreGraphics::TextureCubeArray:
+        var = Shared::Table_Tick::TexturesCubeArray_SLOT;
         break;
     default: n_error("unhandled enum"); break;
     }    

--- a/code/render/graphics/graphicsserver.cc
+++ b/code/render/graphics/graphicsserver.cc
@@ -128,7 +128,7 @@ GraphicsServer::Open()
 
         texInfo.tag = "system";
         texInfo.format = CoreGraphics::PixelFormat::R8;
-        texInfo.bindless = false;
+        texInfo.bindless = true;
         texInfo.dataSize = sizeof(unsigned char) * 6;
 
         texInfo.type = CoreGraphics::TextureType::Texture1D;

--- a/code/render/materials/materialloader.cc
+++ b/code/render/materials/materialloader.cc
@@ -234,12 +234,12 @@ LoadVec4(const Ptr<IO::BXmlReader>& reader, const char* name, float value[4], co
 /**
 */
 void
-LoadVec3(const Ptr<IO::BXmlReader>& reader, const char* name, float value[3], const Math::vec4& def)
+LoadVec3(const Ptr<IO::BXmlReader>& reader, const char* name, float value[3], const Math::vec3& def)
 {
     if (reader->SetToFirstChild(name))
     {
         Math::vec4 val = reader->GetVec4("value");
-        val.store(value);
+        val.store3(value);
     }
     else
     {
@@ -315,7 +315,7 @@ MaterialLoader::Setup()
         LoadTexture(reader, CoreGraphics::White2D, "AlbedoMap", tag.Value(), material.AlbedoMap, state.BRDFMaterials.dirty);
         LoadTexture(reader, CoreGraphics::Black2D, "ParameterMap", tag.Value(), material.ParameterMap, state.BRDFMaterials.dirty);
         LoadTexture(reader, CoreGraphics::Green2D, "NormalMap", tag.Value(), material.NormalMap, state.BRDFMaterials.dirty);
-        LoadVec3(reader, "MatAlbedoIntensity", material.MatAlbedoIntensity, Math::vec4(1));
+        LoadVec3(reader, "MatAlbedoIntensity", material.MatAlbedoIntensity, Math::vec3(1));
         LoadFloat(reader, "MatRoughnessIntensity", material.MatRoughnessIntensity, 1);
     };
     this->loaderMap.Add(MaterialProperties::BRDF, brdfLoader);
@@ -328,7 +328,7 @@ MaterialLoader::Setup()
         LoadTexture(reader, CoreGraphics::Green2D, "NormalMap", tag.Value(), material.NormalMap, state.BSDFMaterials.dirty);
         LoadTexture(reader, CoreGraphics::Black2D, "AbsorptionMap", tag.Value(), material.AbsorptionMap, state.BSDFMaterials.dirty);
         LoadTexture(reader, CoreGraphics::Black2D, "ScatterMap", tag.Value(), material.ScatterMap, state.BSDFMaterials.dirty);
-        LoadVec3(reader, "MatAlbedoIntensity", material.MatAlbedoIntensity, Math::vec4(1));
+        LoadVec3(reader, "MatAlbedoIntensity", material.MatAlbedoIntensity, Math::vec3(1));
         LoadFloat(reader, "MatRoughnessIntensity", material.MatRoughnessIntensity, 1);
     };
     this->loaderMap.Add(MaterialProperties::BSDF, bsdfLoader);
@@ -531,11 +531,9 @@ MaterialLoader::InitializeResource(const Ids::Id32 entry, const Util::StringAtom
         if (loaderIndex != InvalidIndex)
         {
             auto loader = this->loaderMap.ValueAtIndex(loaderIndex);
-            if (reader->SetToFirstChild("Params"))
-            {
-                loader(reader, id, tag);
-                state.dirtySet.bits = 0x3;
-            }
+            reader->SetToFirstChild("Params");
+            loader(reader, id, tag);
+            state.dirtySet.bits = 0x3;
             reader->SetToParent();
         }
 

--- a/code/render/raytracing/raytracingcontext.cc
+++ b/code/render/raytracing/raytracingcontext.cc
@@ -566,8 +566,8 @@ RaytracingContext::SetupTerrain(
         Raytracetest::Object constants;
         constants.Use16BitIndex = indexType == CoreGraphics::IndexType::Index16 ? 1 : 0;
         constants.MaterialOffset = Materials::MaterialLoader::RegisterTerrainMaterial(material);
-        constants.IndexPtr = CoreGraphics::BufferGetDeviceAddress(CoreGraphics::GetIndexBuffer()) + indices.offset;
-        constants.PositionsPtr = CoreGraphics::BufferGetDeviceAddress(CoreGraphics::GetVertexBuffer()) + vertices.offset + patchCounter * vertexOffsetStride;
+        constants.IndexPtr = CoreGraphics::BufferGetDeviceAddress(CoreGraphics::GetIndexBuffer()) + createInfo.indexOffset;
+        constants.PositionsPtr = CoreGraphics::BufferGetDeviceAddress(CoreGraphics::GetVertexBuffer()) + createInfo.vertexOffset;
         state.objects[i] = constants;
 
         state.numRegisteredInstances++;

--- a/code/render/raytracing/raytracingcontext.cc
+++ b/code/render/raytracing/raytracingcontext.cc
@@ -550,7 +550,7 @@ RaytracingContext::SetupTerrain(
         instanceCreateInfo.flags = CoreGraphics::BlasInstanceFlags::NoFlags;
         instanceCreateInfo.mask = 0xFF;
         instanceCreateInfo.shaderOffset = MaterialPropertyMappings[(uint)Materials::MaterialProperties::Terrain];
-        instanceCreateInfo.instanceIndex = 0;
+        instanceCreateInfo.instanceIndex = i;
         instanceCreateInfo.blas = blas;
         instanceCreateInfo.transform = transforms[patchCounter];
         state.blasInstances[i] = CoreGraphics::CreateBlasInstance(instanceCreateInfo);

--- a/code/render/raytracing/raytracingcontext.h
+++ b/code/render/raytracing/raytracingcontext.h
@@ -53,9 +53,9 @@ public:
         , const CoreGraphics::VertexAlloc& indices
         , const CoreGraphics::PrimitiveGroup& patchPrimGroup
         , SizeT vertexOffsetStride
+        , SizeT patchVertexStride
         , Util::Array<Math::mat4> transforms
         , MaterialInterface::TerrainMaterial material
-        
     );
 
     /// Build top level acceleration

--- a/code/render/raytracing/raytracingcontext.h
+++ b/code/render/raytracing/raytracingcontext.h
@@ -30,6 +30,12 @@ enum ObjectType
     ParticleObject
 };
 
+enum UpdateType
+{
+    Dynamic,
+    Static
+};
+
 class RaytracingContext : public Graphics::GraphicsContext
 {
     __DeclareContext();
@@ -44,18 +50,21 @@ public:
 
     /// Setup a model entity for ray tracing, assumes model context registration
     static void SetupModel(const Graphics::GraphicsEntityId id, CoreGraphics::BlasInstanceFlags flags, uchar mask);
+
     /// Setup a terrain system for ray tracing
-    static void SetupTerrain(
+    static void SetupMesh(
         const Graphics::GraphicsEntityId id
+        , const UpdateType objectType
         , const CoreGraphics::VertexComponent::Format format
         , const CoreGraphics::IndexType::Code indexType
         , const CoreGraphics::VertexAlloc& vertices
         , const CoreGraphics::VertexAlloc& indices
         , const CoreGraphics::PrimitiveGroup& patchPrimGroup
-        , SizeT vertexOffsetStride
-        , SizeT patchVertexStride
-        , Util::Array<Math::mat4> transforms
-        , MaterialInterface::TerrainMaterial material
+        , const SizeT vertexOffsetStride
+        , const SizeT patchVertexStride
+        , const Util::Array<Math::mat4> transforms
+        , const uint MaterialTableOffset
+        , const CoreGraphics::VertexLayoutType vertexLayout
     );
 
     /// Build top level acceleration
@@ -79,21 +88,17 @@ private:
     /// deallocate a slice
     static void Dealloc(Graphics::ContextEntityId id);
 
-    enum ObjectType
-    {
-        Dynamic,
-        Static
-    };
+
 
     enum
     {
         Raytracing_Allocation,
-        Raytracing_ObjectType,
+        Raytracing_UpdateType,
         Raytracing_NumStructures
     };
     typedef Ids::IdAllocator<
         Memory::RangeAllocation,
-        ObjectType,
+        Raytracing::UpdateType,
         uint
     > RaytracingAllocator;
     static RaytracingAllocator raytracingContextAllocator;

--- a/code/render/raytracing/raytracingcontext.h
+++ b/code/render/raytracing/raytracingcontext.h
@@ -10,8 +10,8 @@
 #include "graphics/graphicscontext.h"
 #include "coregraphics/accelerationstructure.h"
 #include "coregraphics/buffer.h"
-#include <array>
 #include "system_shaders/cluster_generate.h"
+#include "materials/shaderconfig.h"
 
 namespace Raytracing
 {
@@ -50,7 +50,6 @@ public:
 
     /// Setup a model entity for ray tracing, assumes model context registration
     static void SetupModel(const Graphics::GraphicsEntityId id, CoreGraphics::BlasInstanceFlags flags, uchar mask);
-
     /// Setup a terrain system for ray tracing
     static void SetupMesh(
         const Graphics::GraphicsEntityId id
@@ -63,9 +62,12 @@ public:
         , const SizeT vertexOffsetStride
         , const SizeT patchVertexStride
         , const Util::Array<Math::mat4> transforms
-        , const uint MaterialTableOffset
+        , const uint materialTableOffset
+        , const Materials::MaterialProperties shader
         , const CoreGraphics::VertexLayoutType vertexLayout
     );
+    /// Invalidate a BLAS (for example, when the mesh has morphed) associated with a graphics entity
+    static void InvalidateBLAS(const Graphics::GraphicsEntityId id);
 
     /// Build top level acceleration
     static void ReconstructTopLevelAcceleration(const Graphics::FrameContext& ctx);
@@ -94,12 +96,14 @@ private:
     {
         Raytracing_Allocation,
         Raytracing_UpdateType,
-        Raytracing_NumStructures
+        Raytracing_NumStructures,
+        Raytracing_Blases
     };
     typedef Ids::IdAllocator<
         Memory::RangeAllocation,
         Raytracing::UpdateType,
-        uint
+        uint,
+        Util::FixedArray<CoreGraphics::BlasId>
     > RaytracingAllocator;
     static RaytracingAllocator raytracingContextAllocator;
 };

--- a/code/render/raytracing/shaders/raytracetest.fx
+++ b/code/render/raytracing/shaders/raytracetest.fx
@@ -28,6 +28,7 @@ Raygen(
     Result.material = vec4(0, 0, 0, 0);
     Result.normal = vec3(0, 0, 0);
     Result.depth = 0;
+    Result.miss = 0;
 
     // Ray trace against BVH
     traceRayEXT(TLAS, gl_RayFlagsNoneEXT, 0xFF, 0, 0, 0, origin.xyz, 0.01f, direction.xyz, 10000.0f, 0);
@@ -35,7 +36,15 @@ Raygen(
     vec3 F0 = CalculateF0(Result.albedo.rgb, Result.material[MAT_METALLIC], vec3(0.04));
     vec3 WorldSpacePos = origin.xyz + direction.xyz * Result.depth;
     vec3 light = vec3(0);
-    light += CalculateLightRT(WorldSpacePos, Result.depth / 10000.0f, Result.albedo.rgb, Result.material, Result.normal);
+    if (Result.miss == 1)
+    {
+        vec3 dir = normalize(direction.xyz);
+        light += CalculateAtmosphericScattering(dir, GlobalLightDirWorldspace.xyz) * GlobalLightColor.rgb;
+    }
+    else
+    {
+        light += CalculateLightRT(WorldSpacePos, Result.depth / 10000.0f, Result.albedo.rgb, Result.material, Result.normal);
+    }
     //light += CalculateGlobalLight(Result.albedo, Result.material, F0, -normalize(target.xyz), Result.normal, WorldSpacePos);
     //vec3 dir = normalize(Result.normal);
     //vec3 atmo = CalculateAtmosphericScattering(dir, GlobalLightDirWorldspace.xyz) * GlobalLightColor.rgb;
@@ -51,9 +60,7 @@ Miss(
     [ray_payload] in HitResult Result
 )
 {
-    vec3 dir = normalize(gl_WorldRayDirectionEXT);
-    vec3 atmo = CalculateAtmosphericScattering(dir, GlobalLightDirWorldspace.xyz) * GlobalLightColor.rgb;
-    imageStore(RaytracingOutput, ivec2(gl_LaunchIDEXT.xy), vec4(atmo, 0.0f));
+    Result.miss = 1;
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/raytracing/shaders/raytracetest.fx
+++ b/code/render/raytracing/shaders/raytracetest.fx
@@ -40,7 +40,7 @@ Raygen(
     //vec3 dir = normalize(Result.normal);
     //vec3 atmo = CalculateAtmosphericScattering(dir, GlobalLightDirWorldspace.xyz) * GlobalLightColor.rgb;
 
-    imageStore(RaytracingOutput, ivec2(gl_LaunchIDEXT.xy), vec4(light, 0.0f));
+    imageStore(RaytracingOutput, ivec2(gl_LaunchIDEXT.xy), vec4(light / 10.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/raytracing/shaders/terrainhit.fx
+++ b/code/render/raytracing/shaders/terrainhit.fx
@@ -28,7 +28,7 @@ BoxHit(
     vec4 albedo = sample2DLod(mat.LowresAlbedoFallback, Basic2DSampler, uv, 0);
     vec4 material = sample2DLod(mat.LowresMaterialFallback, Basic2DSampler, uv, 0);
     Result.alpha = albedo.a;
-    Result.albedo = vec3(uv, 0);
+    Result.albedo = albedo.rgb;
     Result.material = material;
     Result.normal = tNormal;
     Result.depth = gl_HitTEXT;

--- a/code/render/raytracing/shaders/terrainhit.fx
+++ b/code/render/raytracing/shaders/terrainhit.fx
@@ -19,8 +19,8 @@ BoxHit(
     uvec3 indices;
     vec2 uv;
     mat3 tbn;
-    TerrainMaterial mat = TerrainMaterials + obj.MaterialOffset;
-    SampleTerrain(obj, gl_PrimitiveID, barycentricCoords, mat.WorldSize, indices, uv, tbn);
+    TerrainMaterial mat = TerrainMaterials[obj.MaterialOffset];
+    SampleTerrain(obj, gl_PrimitiveID, barycentricCoords, indices, uv, tbn);
 
     vec4 normals = sample2DLod(mat.LowresNormalFallback, Basic2DSampler, uv, 0);
     vec3 tNormal = TangentSpaceNormal(normals.xy, tbn);
@@ -28,7 +28,7 @@ BoxHit(
     vec4 albedo = sample2DLod(mat.LowresAlbedoFallback, Basic2DSampler, uv, 0);
     vec4 material = sample2DLod(mat.LowresMaterialFallback, Basic2DSampler, uv, 0);
     Result.alpha = albedo.a;
-    Result.albedo = albedo.rgb;
+    Result.albedo = vec3(uv, 0);
     Result.material = material;
     Result.normal = tNormal;
     Result.depth = gl_HitTEXT;

--- a/code/render/raytracing/shaders/terrainhit.fx
+++ b/code/render/raytracing/shaders/terrainhit.fx
@@ -19,9 +19,9 @@ BoxHit(
     uvec3 indices;
     vec2 uv;
     mat3 tbn;
-    SampleGeometry(obj, gl_PrimitiveID, barycentricCoords, indices, uv, tbn);
-
     TerrainMaterial mat = TerrainMaterials + obj.MaterialOffset;
+    SampleTerrain(obj, gl_PrimitiveID, barycentricCoords, mat.WorldSize, indices, uv, tbn);
+
     vec4 normals = sample2DLod(mat.LowresNormalFallback, Basic2DSampler, uv, 0);
     vec3 tNormal = TangentSpaceNormal(normals.xy, tbn);
 

--- a/code/render/terrain/shaders/terrain.fx
+++ b/code/render/terrain/shaders/terrain.fx
@@ -289,7 +289,7 @@ hsTerrain(
     , out vec3 Normal[]
 )
 {
-    Position[gl_InvocationID]   = Transform * position[gl_InvocationID];
+    Position[gl_InvocationID]   = position[gl_InvocationID];
     Normal[gl_InvocationID]     = normal[gl_InvocationID];
 
     // provoking vertex gets to decide tessellation factors

--- a/code/render/terrain/shaders/terrain.fx
+++ b/code/render/terrain/shaders/terrain.fx
@@ -211,7 +211,7 @@ shader
 void
 vsTerrain(
     [slot=0] in vec3 position
-    , [slot=1] in vec2 uv
+    , [slot=1] in ivec2 uv
     , out vec4 Position
     , out vec3 Normal
     , out float Tessellation
@@ -221,7 +221,7 @@ vsTerrain(
     vec3 offsetPos = position + vec3(terrainPatch.PosOffset.x, 0, terrainPatch.PosOffset.y);
     vec4 modelSpace = Transform * vec4(offsetPos, 1);
     Position = vec4(offsetPos, 1);
-    vec2 UV = uv + terrainPatch.UvOffset;
+    vec2 UV = UnpackUV(uv) + terrainPatch.UvOffset;
 
     float vertexDistance = distance( Position.xyz, EyePos.xyz);
     float factor = 1.0f - saturate((MinLODDistance - vertexDistance) / (MinLODDistance - MaxLODDistance));

--- a/code/render/terrain/shaders/terrain_mesh_generate.fx
+++ b/code/render/terrain/shaders/terrain_mesh_generate.fx
@@ -121,9 +121,9 @@ csMeshGenerate()
     vec3 P1 = (Transform * vec4(v1.position, 1)).xyz;
     vec3 P2 = (Transform * vec4(v2.position, 1)).xyz;
     vec3 P3 = (Transform * vec4(v3.position, 1)).xyz;
-    vec2 UV1 = (terrainPatch.PosOffset + P1.xz) / WorldSize - 0.5f;
-    vec2 UV2 = (terrainPatch.PosOffset + P2.xz) / WorldSize - 0.5f;
-    vec2 UV3 = (terrainPatch.PosOffset + P3.xz) / WorldSize - 0.5f;
+    vec2 UV1 = (terrainPatch.PosOffset + P1.xz) / WorldSize + 0.5f;
+    vec2 UV2 = (terrainPatch.PosOffset + P2.xz) / WorldSize + 0.5f;
+    vec2 UV3 = (terrainPatch.PosOffset + P3.xz) / WorldSize + 0.5f;
 
     vec2 pixelSize = textureSize(basic2D(HeightMap), 0);
     pixelSize = vec2(1.0f) / pixelSize;
@@ -141,11 +141,11 @@ csMeshGenerate()
     // First output base vertices
     OutputVertex o1, o2, o3;
     o1.position = P1;
-    o1.uv = CompressUV(vec2(1, 1)); //CompressUV(UV1);
+    o1.uv = CompressUV(UV1);
     o2.position = P2;
-    o2.uv = CompressUV(vec2(1, 0)); //CompressUV(UV2);
+    o2.uv = CompressUV(UV2);
     o3.position = P3;
-    o3.uv = CompressUV(vec2(0, 1)); //CompressUV(UV3);
+    o3.uv = CompressUV(UV3);
     OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.x] = o1;
     OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.y] = o2;
     OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.z] = o3;

--- a/code/render/terrain/shaders/terrain_mesh_generate.fx
+++ b/code/render/terrain/shaders/terrain_mesh_generate.fx
@@ -14,7 +14,7 @@ group(BATCH_GROUP) rw_buffer IndexInput
 struct InputVertex
 {
     vec3 position;
-    vec2 uv;
+    int uv;
 };
 
 group(BATCH_GROUP) rw_buffer VertexInput
@@ -36,11 +36,11 @@ group(BATCH_GROUP) rw_buffer VertexOutput
 group(BATCH_GROUP) constant GenerationConstants
 {
     mat4 Transform;
-
+    vec2 WorldSize;
     float MinHeight;
     float MaxHeight;
+
     uint VerticesPerPatch;
-    vec2 WorldSize;
     //uint NumSubdivisions;
     textureHandle HeightMap;
 };
@@ -121,9 +121,9 @@ csMeshGenerate()
     vec3 P1 = (Transform * vec4(v1.position, 1)).xyz;
     vec3 P2 = (Transform * vec4(v2.position, 1)).xyz;
     vec3 P3 = (Transform * vec4(v3.position, 1)).xyz;
-    vec2 UV1 = (terrainPatch.PosOffset + P1.xz) / WorldSize;
-    vec2 UV2 = (terrainPatch.PosOffset + P2.xz) / WorldSize;
-    vec2 UV3 = (terrainPatch.PosOffset + P3.xz) / WorldSize;
+    vec2 UV1 = (terrainPatch.PosOffset + P1.xz) / WorldSize - 0.5f;
+    vec2 UV2 = (terrainPatch.PosOffset + P2.xz) / WorldSize - 0.5f;
+    vec2 UV3 = (terrainPatch.PosOffset + P3.xz) / WorldSize - 0.5f;
 
     vec2 pixelSize = textureSize(basic2D(HeightMap), 0);
     pixelSize = vec2(1.0f) / pixelSize;
@@ -141,11 +141,11 @@ csMeshGenerate()
     // First output base vertices
     OutputVertex o1, o2, o3;
     o1.position = P1;
-    o1.uv = CompressUV(UV1);
+    o1.uv = CompressUV(vec2(1, 1)); //CompressUV(UV1);
     o2.position = P2;
-    o2.uv = CompressUV(UV2);
+    o2.uv = CompressUV(vec2(1, 0)); //CompressUV(UV2);
     o3.position = P3;
-    o3.uv = CompressUV(UV3);
+    o3.uv = CompressUV(vec2(0, 1)); //CompressUV(UV3);
     OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.x] = o1;
     OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.y] = o2;
     OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.z] = o3;

--- a/code/render/terrain/shaders/terrain_mesh_generate.fx
+++ b/code/render/terrain/shaders/terrain_mesh_generate.fx
@@ -5,14 +5,10 @@
 
 #include <lib/std.fxh>
 #include <lib/shared.fxh>
-struct Quad
-{
-    uvec4 indices;
-};
 
 group(BATCH_GROUP) rw_buffer IndexInput
 {
-    Quad Quads[];
+    uint Indices[];
 };
 
 struct InputVertex
@@ -26,15 +22,10 @@ group(BATCH_GROUP) rw_buffer VertexInput
     InputVertex InputVertices[];
 };
 
-group(BATCH_GROUP) rw_buffer IndexOutput
-{
-    uvec3 Indices[];
-};
-
 struct OutputVertex
 {
     vec3 position;
-    uint uv;
+    int uv;
 };
 
 group(BATCH_GROUP) rw_buffer VertexOutput
@@ -48,6 +39,8 @@ group(BATCH_GROUP) constant GenerationConstants
 
     float MinHeight;
     float MaxHeight;
+    uint VerticesPerPatch;
+    vec2 WorldSize;
     //uint NumSubdivisions;
     textureHandle HeightMap;
 };
@@ -66,12 +59,12 @@ group(BATCH_GROUP) rw_buffer TerrainPatchData[string Visibility = "CS";]
 //------------------------------------------------------------------------------
 /**
 */
-uint
+int
 CompressUV(vec2 uv)
 {
-    uint x = uint(uv.x * 1000);
-    uint y = uint(uv.y * 1000);
-    return (x & 0xFFFF) & ((y & 0xFFFF) << 16);
+    int x = int(uv.x * 1000);
+    int y = int(uv.y * 1000);
+    return (x & 0xFFFF) | ((y & 0xFFFF) << 16);
 }
 
 //------------------------------------------------------------------------------
@@ -116,20 +109,21 @@ csMeshGenerate()
 {
     TerrainPatch terrainPatch = Patches[gl_WorkGroupID.y];
 
-    Quad q = Quads[gl_GlobalInvocationID.x];
-    InputVertex v1 = InputVertices[q.indices.x];
-    InputVertex v2 = InputVertices[q.indices.y];
-    InputVertex v3 = InputVertices[q.indices.z];
-    InputVertex v4 = InputVertices[q.indices.w];
+    uvec3 indices = uvec3(
+        Indices[gl_GlobalInvocationID.x * 3]
+        , Indices[gl_GlobalInvocationID.x * 3 + 1]
+        , Indices[gl_GlobalInvocationID.x * 3 + 2]
+    );
+    InputVertex v1 = InputVertices[indices.x];
+    InputVertex v2 = InputVertices[indices.y];
+    InputVertex v3 = InputVertices[indices.z];
 
-    vec2 UV1 = v1.uv + terrainPatch.UvOffset;
-    vec2 UV2 = v2.uv + terrainPatch.UvOffset;
-    vec2 UV3 = v3.uv + terrainPatch.UvOffset;
-    vec2 UV4 = v4.uv + terrainPatch.UvOffset;
-    vec3 P1 = (Transform * vec4(v1.position + vec3(terrainPatch.PosOffset.x, 0, terrainPatch.PosOffset.y), 1)).xyz;
-    vec3 P2 = (Transform * vec4(v2.position + vec3(terrainPatch.PosOffset.x, 0, terrainPatch.PosOffset.y), 1)).xyz;
-    vec3 P3 = (Transform * vec4(v3.position + vec3(terrainPatch.PosOffset.x, 0, terrainPatch.PosOffset.y), 1)).xyz;
-    vec3 P4 = (Transform * vec4(v4.position + vec3(terrainPatch.PosOffset.x, 0, terrainPatch.PosOffset.y), 1)).xyz;
+    vec3 P1 = (Transform * vec4(v1.position, 1)).xyz;
+    vec3 P2 = (Transform * vec4(v2.position, 1)).xyz;
+    vec3 P3 = (Transform * vec4(v3.position, 1)).xyz;
+    vec2 UV1 = (terrainPatch.PosOffset + P1.xz) / WorldSize;
+    vec2 UV2 = (terrainPatch.PosOffset + P2.xz) / WorldSize;
+    vec2 UV3 = (terrainPatch.PosOffset + P3.xz) / WorldSize;
 
     vec2 pixelSize = textureSize(basic2D(HeightMap), 0);
     pixelSize = vec2(1.0f) / pixelSize;
@@ -145,17 +139,16 @@ csMeshGenerate()
     P3.y = MinHeight + h3 * (MaxHeight - MinHeight);
 
     // First output base vertices
-    OutputVertices[q.indices.x].position = P1;
-    OutputVertices[q.indices.x].uv = CompressUV(v1.uv);
-    OutputVertices[q.indices.y].position = P2;
-    OutputVertices[q.indices.y].uv = CompressUV(v2.uv);
-    OutputVertices[q.indices.z].position = P3;
-    OutputVertices[q.indices.z].uv = CompressUV(v3.uv);
-    OutputVertices[q.indices.w].position = P4;
-    OutputVertices[q.indices.w].uv = CompressUV(v4.uv);
-
-    Indices[gl_GlobalInvocationID.x * 2] = uvec3(q.indices.x, q.indices.y, q.indices.z);
-    Indices[gl_GlobalInvocationID.x * 2 + 1] = uvec3(q.indices.x, q.indices.z, q.indices.w);
+    OutputVertex o1, o2, o3;
+    o1.position = P1;
+    o1.uv = CompressUV(UV1);
+    o2.position = P2;
+    o2.uv = CompressUV(UV2);
+    o3.position = P3;
+    o3.uv = CompressUV(UV3);
+    OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.x] = o1;
+    OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.y] = o2;
+    OutputVertices[gl_WorkGroupID.y * VerticesPerPatch + indices.z] = o3;
 
     // Then subdivide, which will output indices
     //Subdivide(tri, 1);

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -21,7 +21,7 @@
 #include "texturetilecache.h"
 
 #include "resources/resourceserver.h"
-#include "gliml.h"
+#include "materials/materialloader.h"
 
 #include "terrain/shaders/terrain.h"
 #include "terrain/shaders/terrain_mesh_generate.h"
@@ -1564,8 +1564,10 @@ TerrainContext::SetupTerrain(
                 }
             }
 
-            Raytracing::RaytracingContext::SetupTerrain(
+            uint materialOffset = Materials::MaterialLoader::RegisterTerrainMaterial(mat);
+            Raytracing::RaytracingContext::SetupMesh(
                 entity
+                , Raytracing::UpdateType::Static
                 , CoreGraphics::VertexComponent::Float3
                 , CoreGraphics::IndexType::Index32
                 , raytracingState.vertexBuffer
@@ -1574,7 +1576,8 @@ TerrainContext::SetupTerrain(
                 , vertexElementSize
                 , vertexBufferByteSize
                 , patchTransforms
-                , mat);
+                , materialOffset
+                , CoreGraphics::VertexLayoutType::Normal);
         };
         raytracingState.setupBlasFrame = 0xFFFFFFFF;
     }

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -677,7 +677,7 @@ TerrainContext::Create(const TerrainSetupSettings& settings)
         };
 
         Frame::AddSubgraph("Terrain Raytracing Mesh Generate", { terrainMeshGenerate });
-    }
+    } 
 
     Frame::FrameCode* terrainPrepare = terrainState.frameOpAllocator.Alloc<Frame::FrameCode>();
     terrainPrepare->domain = CoreGraphics::BarrierDomain::Global;
@@ -1498,7 +1498,7 @@ TerrainContext::SetupTerrain(
 
                 // setup triangle tris
                 indices.Append(vidx1, vidx3, vidx4);
-                indices.Append(vidx1, vidx4, vidx2);
+                indices.Append(vidx4, vidx2, vidx1);
             }
         }
 
@@ -1574,7 +1574,6 @@ TerrainContext::SetupTerrain(
             mat.LowresAlbedoFallback = CoreGraphics::TextureGetBindlessHandle(terrainVirtualTileState.lowresAlbedo);
             mat.LowresMaterialFallback = CoreGraphics::TextureGetBindlessHandle(terrainVirtualTileState.lowresMaterial);
             mat.LowresNormalFallback = CoreGraphics::TextureGetBindlessHandle(terrainVirtualTileState.lowresNormal);
-            mat.WorldSize = worldSize;
 
             /// Setup with raytracing
             Util::Array<Math::mat4> patchTransforms;
@@ -1768,7 +1767,6 @@ TerrainContext::CullPatches(const Ptr<Graphics::View>& view, const Graphics::Fra
     N_SCOPE(TerrainRunJobs, Terrain);
     Math::mat4 cameraTransform = Math::inverse(Graphics::CameraContext::GetView(view->GetCamera()));
     terrainVirtualTileState.indirectionUploadOffsets[ctx.bufferIndex] = 0;
-
 
     if (raytracingState.callbackFrame == ctx.frameIndex)
         raytracingState.terrainSetupCallback();

--- a/syswork/shaders/vk/lib/materials.fxh
+++ b/syswork/shaders/vk/lib/materials.fxh
@@ -114,6 +114,7 @@ ptr struct TerrainMaterial
     textureHandle LowresAlbedoFallback;
     textureHandle LowresNormalFallback;
     textureHandle LowresMaterialFallback;
+    float WorldSize;
 };
 
 MATERIAL_BINDING rw_buffer MaterialBindings

--- a/syswork/shaders/vk/lib/materials.fxh
+++ b/syswork/shaders/vk/lib/materials.fxh
@@ -114,7 +114,6 @@ ptr struct TerrainMaterial
     textureHandle LowresAlbedoFallback;
     textureHandle LowresNormalFallback;
     textureHandle LowresMaterialFallback;
-    float WorldSize;
 };
 
 MATERIAL_BINDING rw_buffer MaterialBindings

--- a/syswork/shaders/vk/lib/raytracing.fxh
+++ b/syswork/shaders/vk/lib/raytracing.fxh
@@ -51,12 +51,6 @@ ptr alignment(32) struct VertexAttributeSkin
     uint indices;
 };
 
-ptr alignment(16) struct VertexTerrain
-{
-    vec3 pos;
-    int uv;
-};
-
 ptr alignment(4) struct Indexes32
 {
     uint index;
@@ -167,7 +161,7 @@ UnpackSign(int packedNormal)
 /**
 */
 void
-SampleTerrain(in Object obj, uint prim, in vec3 baryCoords, float worldSize, out uvec3 indices, out vec2 uv, out mat3 tbn)
+SampleTerrain(in Object obj, uint prim, in vec3 baryCoords, out uvec3 indices, out vec2 uv, out mat3 tbn)
 {
     // Sample the index buffer
     if (obj.Use16BitIndex == 1)
@@ -183,7 +177,7 @@ SampleTerrain(in Object obj, uint prim, in vec3 baryCoords, float worldSize, out
     vec2 uv2 = UnpackUV32((obj.PositionsPtr[indices.z]).uv);
     uv = BaryCentricVec2(uv0, uv1, uv2, baryCoords);
 
-    tbn = TangentSpace(vec3(1,0,0), vec3(0,1,0), 1);
+    tbn = PlaneTBN(vec3(0, 1, 0));
 }
 
 //------------------------------------------------------------------------------

--- a/syswork/shaders/vk/lib/raytracing.fxh
+++ b/syswork/shaders/vk/lib/raytracing.fxh
@@ -21,6 +21,7 @@ struct HitResult
     vec4 material;
     vec3 normal;
     float depth;
+    uint miss;
 };
 
 // Declare type for vertex positions and uv

--- a/syswork/shaders/vk/lib/shared.fxh
+++ b/syswork/shaders/vk/lib/shared.fxh
@@ -17,9 +17,12 @@ const int SHADOW_CASTER_COUNT = 16;
 #define FLT_MIN     -3.40282347E+38F
  
 // the texture list can be updated once per tick (frame)
+group(TICK_GROUP) binding(0) texture1D			Textures1D[MAX_TEXTURES];
+group(TICK_GROUP) binding(0) texture1DArray 	Textures1DArray[MAX_TEXTURES];
 group(TICK_GROUP) binding(0) texture2D			Textures2D[MAX_TEXTURES];
 group(TICK_GROUP) binding(0) texture2DMS		Textures2DMS[MAX_TEXTURES];
 group(TICK_GROUP) binding(0) textureCube		TexturesCube[MAX_TEXTURES];
+group(TICK_GROUP) binding(0) textureCubeArray	TexturesCubeArray[MAX_TEXTURES];
 group(TICK_GROUP) binding(0) texture3D			Textures3D[MAX_TEXTURES];
 group(TICK_GROUP) binding(0) texture2DArray	    Textures2DArray[MAX_TEXTURES];
 group(TICK_GROUP) sampler_state		Basic2DSampler {};


### PR DESCRIPTION
This PR adds terrain geometry to the raytracing setup. Terrain materials are only using their low resolution fallback textures, so don't expect any high resolution textures when sampling from it.

