### PR TITLE
Use generation ids as the IdAllocator default ID.

### DIFF
--- a/code/application/game/filter.cc
+++ b/code/application/game/filter.cc
@@ -125,7 +125,7 @@ Filter
 FilterBuilder::CreateFilter(FilterCreateInfo info)
 {
     n_assert(info.numInclusive > 0);
-    uint32_t filter = filterAllocator.Alloc();
+    Ids::Id32 filter = filterAllocator.Alloc();
 
     ComponentArray inclusiveArray;
     inclusiveArray.Resize(info.numInclusive);

--- a/code/foundation/ids/id.h
+++ b/code/foundation/ids/id.h
@@ -43,16 +43,23 @@
     }; \
     static constexpr x Invalid##x = Ids::InvalidId16;
 
-#define ID_32_24_8_NAMED_TYPE(x, id32_name, id24_name, id8_name) struct x { \
+#define ID_32_24_8_NAMED_TYPE(x, id32_name, id24_name, id8_name, combined_name) struct x { \
     Ids::Id32 id32_name : 32;\
-    Ids::Id32 id24_name : 24;\
-    Ids::Id32 id8_name: 8;\
+    union\
+    {\
+        struct\
+        {\
+            Ids::Id32 id24_name : 24;\
+            Ids::Id32 id8_name: 8;\
+        };\
+        Ids::Id32 combined_name;\
+    };\
     constexpr x() : id32_name(Ids::InvalidId32), id24_name(Ids::InvalidId24), id8_name(Ids::InvalidId8) {};\
     constexpr x(const Ids::Id32 id32, const Ids::Id24 id24, const Ids::Id8 id8) : id32_name(id32), id24_name(id24), id8_name(id8){} \
-    constexpr x(const Ids::Id64 id) : id32_name(Ids::Id::GetHigh(id)), id24_name(Ids::Id::GetBig(Ids::Id::GetLow(id))), id8_name(Ids::Id::GetTiny(Ids::Id::GetLow(id))) {};\
+    constexpr x(const Ids::Id64 id) : id32_name(Ids::Id::GetHigh(id)), id24_name(Ids::Index(Ids::Id::GetLow(id))), id8_name(Ids::Generation(Ids::Id::GetLow(id))) {};\
     explicit constexpr operator Ids::Id64() const { return Ids::Id::MakeId32_24_8(id32_name, id24_name, id8_name); }\
     static constexpr x Invalid() { return Ids::Id::MakeId32_24_8(Ids::InvalidId32, Ids::InvalidId24, Ids::InvalidId8); }\
-    constexpr uint32_t HashCode() const { return (uint32_t)Ids::Id::MakeId24_8(id24_name, id8_name); }\
+    constexpr uint32_t HashCode() const { return (uint32_t)combined_name; }\
     constexpr Ids::Id64 HashCode64() const { return Ids::Id::MakeId32_24_8(id32_name, id24_name, id8_name); }\
     const bool operator==(const x& rhs) const { return id32_name == rhs.id32_name && id24_name == rhs.id24_name && id8_name == rhs.id8_name; }\
     const bool operator!=(const x& rhs) const { return id32_name != rhs.id32_name || id24_name != rhs.id24_name || id8_name != rhs.id8_name; }\
@@ -61,20 +68,34 @@
     template <typename T> constexpr T As() const { static_assert(sizeof(T) == sizeof(x), "Can only convert between ID types of equal size"); T ret; memcpy((void*)&ret, this, sizeof(T)); return ret; }; \
     }; \
     static constexpr x Invalid##x = Ids::Id::MakeId32_24_8(Ids::InvalidId32, Ids::InvalidId24, Ids::InvalidId8);
-#define ID_32_24_8_TYPE(x) ID_32_24_8_NAMED_TYPE(x, id32, id24, id8)
+#define ID_32_24_8_TYPE(x) ID_32_24_8_NAMED_TYPE(x, parent, index, generation, id)
 
-#define ID_24_8_24_8_NAMED_TYPE(x, id24_0_name, id8_0_name, id24_1_name, id8_1_name) struct x { \
-    Ids::Id32 id24_0_name : 24;\
-    Ids::Id8 id8_0_name : 8;\
-    Ids::Id32 id24_1_name : 24;\
-    Ids::Id8 id8_1_name : 8;\
-    constexpr x() : id24_0_name(Ids::InvalidId24), id8_0_name(Ids::InvalidId8), id24_1_name(Ids::InvalidId24), id8_1_name(Ids::InvalidId8) {};\
+#define ID_24_8_24_8_NAMED_TYPE(x, id24_0_name, id8_0_name, id24_1_name, id8_1_name, combined0_name, combined1_name) struct x { \
+    union\
+    {\
+        struct\
+        {\
+            Ids::Id32 id24_0_name : 24;\
+            Ids::Id8 id8_0_name : 8;\
+        };\
+        Ids::Id32 combined0_name;\
+    };\
+    union\
+    {\
+        struct\
+        {\
+            Ids::Id32 id24_1_name : 24;\
+            Ids::Id8 id8_1_name : 8;\
+        };\
+        Ids::Id32 combined1_name;\
+    };\
+    constexpr x() : combined0_name(Ids::InvalidId32), combined1_name(Ids::InvalidId32) {};\
     constexpr x(const Ids::Id24 id24_0, const Ids::Id8 id8_0, const Ids::Id24 id24_1, const Ids::Id8 id8_1) : id24_0_name(id24_0), id8_0_name(id8_0), id24_1_name(id24_1), id8_1_name(id8_1) {} \
-    constexpr x(const Ids::Id64 id) : id24_0_name(Ids::Id::GetBig(Ids::Id::GetHigh(id))), id8_0_name(Ids::Id::GetTiny(Ids::Id::GetHigh(id))), id24_1_name(Ids::Id::GetBig(Ids::Id::GetLow(id))), id8_1_name(Ids::Id::GetTiny(Ids::Id::GetLow(id))) {};\
+    constexpr x(const Ids::Id64 id) : combined0_name(Ids::Id::GetLow(id)), combined1_name(Ids::Id::GetHigh(id)) {};\
     explicit constexpr operator Ids::Id64() const { return Ids::Id::MakeId24_8_24_8(id24_0_name, id8_0_name, id24_1_name, id8_1_name); }\
-    static constexpr x Invalid() { return Ids::Id::MakeId24_8_24_8(Ids::InvalidId24, Ids::InvalidId8, Ids::InvalidId24, Ids::InvalidId8); }\
-    constexpr Ids::Id32 AllocId() const { return Ids::Id::MakeId24_8(id24_1_name, id8_1_name); }\
-    constexpr uint32_t HashCode() const { return (uint32_t)Ids::Id::MakeId24_8(id24_0_name, id8_0_name); }\
+    static constexpr x Invalid() { return Ids::InvalidId64; }\
+    constexpr Ids::Id32 AllocId() const { return combined1_name; }\
+    constexpr uint32_t HashCode() const { return (uint32_t)combined0_name; }\
     constexpr Ids::Id64 HashCode64() const { return Ids::Id::MakeId24_8_24_8(id24_0_name, id8_0_name, id24_1_name, id8_1_name); }\
     const bool operator==(const x& rhs) const { return id24_0_name == rhs.id24_0_name && id8_0_name == rhs.id8_0_name && id24_1_name == rhs.id24_1_name && id8_1_name == rhs.id8_1_name; }\
     const bool operator!=(const x& rhs) const { return id24_0_name != rhs.id24_0_name || id8_0_name != rhs.id8_0_name || id24_1_name != rhs.id24_1_name || id8_1_name != rhs.id8_1_name; }\
@@ -83,17 +104,24 @@
     template <typename T> constexpr T As() const { static_assert(sizeof(T) == sizeof(x), "Can only convert between ID types of equal size"); T ret; memcpy((void*)&ret, this, sizeof(T)); return ret; }; \
     }; \
     static constexpr x Invalid##x = Ids::Id::MakeId24_8_24_8(Ids::InvalidId24, Ids::InvalidId8, Ids::InvalidId24, Ids::InvalidId8);
-#define ID_24_8_24_8_TYPE(x) ID_24_8_24_8_NAMED_TYPE(x, id24_0, id8_0, id24_1, id8_1)
+#define ID_24_8_24_8_TYPE(x) ID_24_8_24_8_NAMED_TYPE(x, index0, generation0, index1, generation1, id0, id1)
 
-#define ID_24_8_NAMED_TYPE(x, id24_name, id8_name) struct x { \
-    Ids::Id32 id24_name : 24; \
-    Ids::Id32 id8_name : 8; \
+#define ID_24_8_NAMED_TYPE(x, id24_name, id8_name, combined_name) struct x { \
+    union \
+    {\
+        struct\
+        {\
+            Ids::Id32 id24_name : 24; \
+            Ids::Id32 id8_name : 8; \
+        };\
+        Ids::Id32 combined_name;\
+    }; \
     constexpr x() : id24_name(Ids::InvalidId24), id8_name(Ids::InvalidId8) {} \
     constexpr x(const Ids::Id24 id0, const Ids::Id8 id1) : id24_name(id0), id8_name(id1) {} \
-    constexpr x(const Ids::Id32 id) : id24_name(Ids::Id::GetBig(id)), id8_name(Ids::Id::GetTiny(id)) {};\
-    explicit constexpr operator Ids::Id32() const { return Ids::Id::MakeId24_8(id24_name, id8_name); }\
-    static constexpr x Invalid() { return Ids::Id::MakeId24_8(Ids::InvalidId24, Ids::InvalidId8); }\
-    constexpr uint32_t HashCode() const { return (uint32_t)Ids::Id::MakeId24_8(id24_name, id8_name); }\
+    constexpr x(const Ids::Id32 id) : combined_name(id) {};\
+    explicit constexpr operator Ids::Id32() const { return combined_name; }\
+    static constexpr x Invalid() { return Ids::InvalidId32; }\
+    constexpr uint32_t HashCode() const { return (uint32_t)combined_name; }\
     const bool operator==(const x& rhs) const { return id24_name == rhs.id24_name && id8_name == rhs.id8_name; }\
     const bool operator!=(const x& rhs) const { return id24_name != rhs.id24_name || id8_name != rhs.id8_name; }\
     const bool operator<(const x& rhs) const { return HashCode() < rhs.HashCode(); }\
@@ -101,7 +129,7 @@
     template <typename T> constexpr T As() const { static_assert(sizeof(T) == sizeof(x), "Can only convert between ID types of equal size"); T ret; memcpy((void*)&ret, this, sizeof(T)); return ret; }; \
     }; \
     static constexpr x Invalid##x = Ids::Id::MakeId24_8(Ids::InvalidId24, Ids::InvalidId8);
-#define ID_24_8_TYPE(x) ID_24_8_NAMED_TYPE(x, id24, id8)
+#define ID_24_8_TYPE(x) ID_24_8_NAMED_TYPE(x, index, generation, id)
 
 namespace Ids
 {

--- a/code/foundation/ids/idgenerationpool.h
+++ b/code/foundation/ids/idgenerationpool.h
@@ -53,6 +53,8 @@ public:
     void Deallocate(Id32 id);
     /// check if valid
     bool IsValid(Id32 id) const;
+    /// Get free ids
+    Util::Queue<Id32>& FreeIds();
 
 private:
     /// array containing generation value for every index
@@ -66,7 +68,7 @@ private:
 //------------------------------------------------------------------------------
 /**
 */
-static Id24 
+constexpr static Id24 
 Index(const Id32 id)
 {
     return id & ID_MASK;
@@ -75,7 +77,7 @@ Index(const Id32 id)
 //------------------------------------------------------------------------------
 /**
 */
-static generation_t
+constexpr static generation_t
 Generation(const Id32 id)
 {
     return (id >> ID_BITS) & GENERATION_MASK;
@@ -91,6 +93,15 @@ CreateId(const Id24 index, generation_t generation)
     id = (generation << ID_BITS) | index;
     n_assert2(index < (1 << ID_BITS), "index overflow");
     return id;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+inline Util::Queue<Id32>& 
+IdGenerationPool::FreeIds()
+{
+    return this->freeIds;
 }
 
 } // namespace Ids

--- a/code/foundation/util/arrayallocator.h
+++ b/code/foundation/util/arrayallocator.h
@@ -67,7 +67,7 @@ public:
 
     /// same as 32 bit get, but const
     template <int MEMBER>
-    const tuple_array_t<MEMBER, TYPES...>& Get(const uint32_t index) const;
+    const tuple_array_t<MEMBER, TYPES...>& ConstGet(const uint32_t index) const;
 
     /// set single item
     template <int MEMBER>
@@ -268,7 +268,7 @@ ArrayAllocator<TYPES...>::Get(const uint32_t index)
 template<class ...TYPES>
 template<int MEMBER>
 inline const tuple_array_t<MEMBER, TYPES...>&
-ArrayAllocator<TYPES...>::Get(const uint32_t index) const
+ArrayAllocator<TYPES...>::ConstGet(const uint32_t index) const
 {
     return std::get<MEMBER>(this->objects)[index];
 }

--- a/code/physics/physics/streamactorpool.cc
+++ b/code/physics/physics/streamactorpool.cc
@@ -63,8 +63,8 @@ StreamActorPool::Setup()
 ActorId
 StreamActorPool::CreateActorInstance(ActorResourceId id, Math::mat4 const& trans, ActorType type, uint64_t userData, IndexT scene)
 {
-    __LockName(&this->allocator, lock, id.resourceId);
-    ActorInfo& info = this->allocator.Get<0>(id.resourceId);
+    __LockName(&this->allocator, lock, id.id);
+    ActorInfo& info = this->allocator.Get<0>(id.id);
 
     Math::vec3 outScale; Math::quat outRotation; Math::vec3 outTranslation;
     Math::decompose(trans, outScale, outRotation, outTranslation);
@@ -114,8 +114,8 @@ StreamActorPool::DiscardActorInstance(ActorId id)
     Actor& actor = ActorContext::GetActor(id);
     if (actor.res != ActorResourceId::Invalid())
     {
-        __LockName(&this->allocator, lock, actor.res.resourceId);
-        ActorInfo& info = this->allocator.Get<0>(actor.res.resourceId);
+        __LockName(&this->allocator, lock, actor.res.id);
+        ActorInfo& info = this->allocator.Get<0>(actor.res.id);
         info.instanceCount--;
     }
     ActorContext::DiscardActor(id);
@@ -516,9 +516,7 @@ StreamActorPool::InitializeResource(const Ids::Id32 entry, const Util::StringAto
     Ids::Id32 id = allocator.Alloc();
     allocator.Set<Actor_Info>(id, actorInfo);
 
-    ActorResourceId ret;
-    ret.resourceId = id;
-    ret.resourceType = Physics::ActorIdType;
+    ActorResourceId ret = id;
     return ret;
 }
 
@@ -528,8 +526,8 @@ StreamActorPool::InitializeResource(const Ids::Id32 entry, const Util::StringAto
 void
 StreamActorPool::Unload(const Resources::ResourceId id)
 {
-    __LockName(&this->allocator, lock, id.resourceId);
-    ActorInfo& info = this->allocator.Get<0>(id.resourceId);
+    __LockName(&this->allocator, lock, id.resource);
+    ActorInfo& info = this->allocator.Get<0>(id.resource);
     n_assert2(info.instanceCount == 0, "Actor has active Instances");
     const Util::StringAtom tag = this->GetTag(id);
     
@@ -538,7 +536,7 @@ StreamActorPool::Unload(const Resources::ResourceId id)
         i->release();
     }
     info.shapes.Clear();
-    allocator.Dealloc(id.resourceId);
+    allocator.Dealloc(id.resource);
 }
 
 

--- a/code/render/characters/skeleton.cc
+++ b/code/render/characters/skeleton.cc
@@ -20,9 +20,7 @@ CreateSkeleton(const SkeletonCreateInfo& info)
     skeletonAllocator.Set<Skeleton_JointNameMap>(id, info.jointIndexMap);
     skeletonAllocator.Set<Skeleton_IdleSamples>(id, info.idleSamples);
 
-    SkeletonId ret;
-    ret.id24 = id;
-    ret.id8 = CoreGraphics::SkeletonIdType;
+    SkeletonId ret = id;
     return ret;
 }
 
@@ -32,7 +30,7 @@ CreateSkeleton(const SkeletonCreateInfo& info)
 void 
 DestroySkeleton(const SkeletonId id)
 {
-    skeletonAllocator.Dealloc(id.id24);
+    skeletonAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -41,7 +39,7 @@ DestroySkeleton(const SkeletonId id)
 const SizeT 
 SkeletonGetNumJoints(const SkeletonId id)
 {
-    return skeletonAllocator.Get<Skeleton_Joints>(id.id24).Size();
+    return skeletonAllocator.Get<Skeleton_Joints>(id.id).Size();
 }
 
 //------------------------------------------------------------------------------
@@ -50,7 +48,7 @@ SkeletonGetNumJoints(const SkeletonId id)
 const Util::FixedArray<CharacterJoint>& 
 SkeletonGetJoints(const SkeletonId id)
 {
-    return skeletonAllocator.Get<Skeleton_Joints>(id.id24);
+    return skeletonAllocator.Get<Skeleton_Joints>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -59,7 +57,7 @@ SkeletonGetJoints(const SkeletonId id)
 const Util::FixedArray<Math::mat4>&
 SkeletonGetBindPose(const SkeletonId id)
 {
-    return skeletonAllocator.Get<Skeleton_BindPose>(id.id24);
+    return skeletonAllocator.Get<Skeleton_BindPose>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -68,7 +66,7 @@ SkeletonGetBindPose(const SkeletonId id)
 const IndexT 
 SkeletonGetJointIndex(const SkeletonId id, const Util::StringAtom& name)
 {
-    return skeletonAllocator.Get<Skeleton_JointNameMap>(id.id24)[name];
+    return skeletonAllocator.Get<Skeleton_JointNameMap>(id.id)[name];
 }
 
 //------------------------------------------------------------------------------
@@ -77,7 +75,7 @@ SkeletonGetJointIndex(const SkeletonId id, const Util::StringAtom& name)
 const Util::FixedArray<Math::vec4>&
 SkeletonGetIdleSamples(const SkeletonId id)
 {
-    return skeletonAllocator.Get<Skeleton_IdleSamples>(id.id24);
+    return skeletonAllocator.Get<Skeleton_IdleSamples>(id.id);
 }
 
 } // namespace Characters

--- a/code/render/characters/skeletonloader.cc
+++ b/code/render/characters/skeletonloader.cc
@@ -92,9 +92,7 @@ SkeletonLoader::InitializeResource(const Ids::Id32 entry, const Util::StringAtom
 
     auto id = skeletonResourceAllocator.Alloc();
     skeletonResourceAllocator.Set<0>(id, skeletons);
-    SkeletonResourceId ret;
-    ret.resourceId = id;
-    ret.resourceType = CoreGraphics::SkeletonResourceIdType;
+    SkeletonResourceId ret = id;
     return ret;
 }
 

--- a/code/render/characters/skeletonresource.cc
+++ b/code/render/characters/skeletonresource.cc
@@ -16,7 +16,7 @@ SkeletonResourceAllocator skeletonResourceAllocator;
 const SkeletonId
 SkeletonResourceGetSkeleton(const SkeletonResourceId id, IndexT index)
 {
-    return skeletonResourceAllocator.Get<0>(id.resourceId)[index];
+    return skeletonResourceAllocator.Get<0>(id.id)[index];
 }
 
 //------------------------------------------------------------------------------
@@ -26,12 +26,12 @@ SkeletonResourceGetSkeleton(const SkeletonResourceId id, IndexT index)
 void
 DestroySkeletonResource(const SkeletonResourceId id)
 {
-    auto skeletons = skeletonResourceAllocator.Get<0>(id.resourceId);
+    auto skeletons = skeletonResourceAllocator.Get<0>(id.id);
     for (IndexT i = 0; i < skeletons.Size(); i++)
     {
         DestroySkeleton(skeletons[i]);
     }
-    skeletonResourceAllocator.Dealloc(id.resourceId);
+    skeletonResourceAllocator.Dealloc(id.id);
 }
 
 } // namespace Characters

--- a/code/render/coreanimation/animation.cc
+++ b/code/render/coreanimation/animation.cc
@@ -23,9 +23,7 @@ CreateAnimation(const AnimationCreateInfo& info)
     animAllocator.Set<Anim_ClipIndices>(id, info.indices);
     animAllocator.Set<Anim_KeyBuffer>(id, info.keyBuffer);
 
-    AnimationId ret;
-    ret.id24 = id;
-    ret.id8 = CoreGraphics::AnimResourceIdType;
+    AnimationId ret = id;
     return ret;
 }
 
@@ -34,13 +32,13 @@ CreateAnimation(const AnimationCreateInfo& info)
 */
 void DestroyAnimation(const AnimationId id)
 {
-    animAllocator.Get<Anim_Clips>(id.id24).Clear();
-    animAllocator.Get<Anim_Curves>(id.id24).Clear();
-    animAllocator.Get<Anim_Events>(id.id24).Clear();
-    animAllocator.Get<Anim_ClipIndices>(id.id24).Clear();
-    animAllocator.Get<Anim_KeyBuffer>(id.id24)->Discard();
-    animAllocator.Set<Anim_KeyBuffer>(id.id24, nullptr);
-    animAllocator.Dealloc(id.id24);
+    animAllocator.Get<Anim_Clips>(id.id).Clear();
+    animAllocator.Get<Anim_Curves>(id.id).Clear();
+    animAllocator.Get<Anim_Events>(id.id).Clear();
+    animAllocator.Get<Anim_ClipIndices>(id.id).Clear();
+    animAllocator.Get<Anim_KeyBuffer>(id.id)->Discard();
+    animAllocator.Set<Anim_KeyBuffer>(id.id, nullptr);
+    animAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -49,7 +47,7 @@ void DestroyAnimation(const AnimationId id)
 const Util::FixedArray<AnimClip>&
 AnimGetClips(const AnimationId& id)
 {
-    return animAllocator.Get<Anim_Clips>(id.id24);
+    return animAllocator.Get<Anim_Clips>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -58,7 +56,7 @@ AnimGetClips(const AnimationId& id)
 const AnimClip& 
 AnimGetClip(const AnimationId& id, const IndexT index)
 {
-    return animAllocator.Get<Anim_Clips>(id.id24)[index];
+    return animAllocator.Get<Anim_Clips>(id.id)[index];
 }
 
 //------------------------------------------------------------------------------
@@ -67,7 +65,7 @@ AnimGetClip(const AnimationId& id, const IndexT index)
 const Ptr<AnimKeyBuffer>&
 AnimGetBuffer(const AnimationId& id)
 {
-    return animAllocator.Get<Anim_KeyBuffer>(id.id24);
+    return animAllocator.Get<Anim_KeyBuffer>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -76,7 +74,7 @@ AnimGetBuffer(const AnimationId& id)
 const Util::FixedArray<AnimCurve>&
 AnimGetCurves(const AnimationId& id)
 {
-    return animAllocator.Get<Anim_Curves>(id.id24);
+    return animAllocator.Get<Anim_Curves>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -85,7 +83,7 @@ AnimGetCurves(const AnimationId& id)
 const IndexT
 AnimGetIndex(const AnimationId& id, const Util::StringAtom& name)
 {
-    return animAllocator.Get<Anim_ClipIndices>(id.id24)[name];
+    return animAllocator.Get<Anim_ClipIndices>(id.id)[name];
 }
 
 } // namespace CoreAnimation

--- a/code/render/coreanimation/animationloader.cc
+++ b/code/render/coreanimation/animationloader.cc
@@ -134,9 +134,7 @@ AnimationLoader::InitializeResource(const Ids::Id32 entry, const Util::StringAto
 
     auto id = animationResourceAllocator.Alloc();
     animationResourceAllocator.Set<0>(id, animations);
-    AnimationResourceId ret;
-    ret.resourceId = id;
-    ret.resourceType = CoreGraphics::AnimResourceIdType;
+    AnimationResourceId ret = id;
     return ret;
 }
 

--- a/code/render/coreanimation/animationresource.cc
+++ b/code/render/coreanimation/animationresource.cc
@@ -14,7 +14,7 @@ AnimationResourceAllocator animationResourceAllocator;
 const AnimationId
 AnimationResourceGetAnimation(const AnimationResourceId id, IndexT index)
 {
-    return animationResourceAllocator.Get<0>(id.resourceId)[index];
+    return animationResourceAllocator.Get<0>(id.id)[index];
 }
 
 //------------------------------------------------------------------------------
@@ -23,12 +23,12 @@ AnimationResourceGetAnimation(const AnimationResourceId id, IndexT index)
 void
 DestroyAnimationResource(const AnimationResourceId id)
 {
-    auto animations = animationResourceAllocator.Get<0>(id.resourceId);
+    auto animations = animationResourceAllocator.Get<0>(id.id);
     for (IndexT i = 0; i < animations.Size(); i++)
     {
         DestroyAnimation(animations[i]);
     }
-    animationResourceAllocator.Dealloc(id.resourceId);
+    animationResourceAllocator.Dealloc(id.id);
 }
 
 } // namespace CoreAnimation

--- a/code/render/coregraphics/base/shaderserverbase.h
+++ b/code/render/coregraphics/base/shaderserverbase.h
@@ -148,9 +148,7 @@ ShaderServerBase::GetShader(Resources::ResourceName resId) const
 {
     n_assert_fmt(this->shaders.Contains(resId), "%s not found!\n This might be a problem with your export. Check the exports folder!\n", resId.Value());
     Resources::ResourceId shader = this->shaders[resId];
-    CoreGraphics::ShaderId ret;
-    ret.resourceId = shader.resourceId;
-    ret.resourceType = shader.resourceType;
+    CoreGraphics::ShaderId ret = shader.resource;
     return ret;
 }
 

--- a/code/render/coregraphics/config.h
+++ b/code/render/coregraphics/config.h
@@ -34,45 +34,6 @@ union InputAssemblyKey
     bool operator<(const InputAssemblyKey& rhs) const { return this->key < rhs.key; }
 };
 
-enum IdType
-{
-    BufferIdType,
-    TextureIdType,
-    TextureViewIdType,
-    VertexLayoutIdType,
-    ShaderIdType,
-    ShaderProgramIdType,
-    ShaderStateIdType,
-    ShaderInstanceIdType,
-    ShaderConstantIdType,
-    CommandBufferIdType,
-    CommandBufferPoolIdType,
-    MeshIdType,
-    MeshResourceIdType,
-    ModelIdType,
-    EventIdType,
-    BarrierIdType,
-    SemaphoreIdType,
-    FenceIdType,
-    WindowIdType,
-    SkeletonIdType,
-    SkeletonResourceIdType,
-    PassIdType,
-    AnimResourceIdType,
-    AnimIdType,
-    ResourceTableIdType,
-    ResourceTableLayoutIdType,
-    ResourcePipelineIdType,
-    SamplerIdType,
-    MaterialIdType,
-    SubmissionContextIdType,
-    PipelineIdType,
-    ImageIdType,
-    BlasIdType,
-    BlasInstanceIdType,
-    TlasIdType
-};
-
 enum QueueType
 {
     GraphicsQueueType,

--- a/code/render/coregraphics/debug/meshpagehandler.cc
+++ b/code/render/coregraphics/debug/meshpagehandler.cc
@@ -130,12 +130,6 @@ MeshPageHandler::HandleMeshInfoRequest(const Util::String& resId, const Ptr<Stre
         return HttpStatus::NotFound;
     }
 
-    if (id.resourceType != MeshResourceIdType)
-    {
-        // resource exists but is not a mesh
-        return HttpStatus::NotFound;
-    }
-
     Ptr<HtmlPageWriter> htmlWriter = HtmlPageWriter::Create();
     htmlWriter->SetStream(responseContentStream);
     htmlWriter->SetTitle("Nebula Mesh Info");
@@ -297,13 +291,6 @@ MeshPageHandler::HandleVertexDumpRequest(const Util::String& resId, IndexT minVe
     {
         return HttpStatus::NotFound;
     }
-    if (id.resourceType != MeshIdType)
-    {
-        // resource exists but is not a mesh
-        return HttpStatus::NotFound;
-    }
-
-
 
     Ptr<HtmlPageWriter> htmlWriter = HtmlPageWriter::Create();
     htmlWriter->SetStream(responseContentStream);

--- a/code/render/coregraphics/debug/shaderpagehandler.cc
+++ b/code/render/coregraphics/debug/shaderpagehandler.cc
@@ -116,12 +116,6 @@ ShaderPageHandler::HandleShaderInfoRequest(const Util::String& resId, const Ptr<
         return HttpStatus::NotFound;
     }
 
-    if (id.resourceType != ShaderIdType)
-    {
-        // id is not a shader type!
-        return HttpStatus::NotFound;
-    }
-
     Ptr<HtmlPageWriter> htmlWriter = HtmlPageWriter::Create();
     htmlWriter->SetStream(responseContentStream);
     htmlWriter->SetTitle("Nebula Shader Info");

--- a/code/render/coregraphics/debug/texturepagehandler.cc
+++ b/code/render/coregraphics/debug/texturepagehandler.cc
@@ -193,12 +193,6 @@ TexturePageHandler::HandleImageRequest(const Dictionary<String,String>& query, c
         return HttpStatus::NotFound;
     }
 
-    if (id.resourceType != TextureIdType)
-    {
-        // resource exists but is not a texture
-        return HttpStatus::NotFound;
-    }
-
     // attach a StreamTextureSaver to the texture
     // NOTE: the StreamSaver is expected to set the media type on the stream!
     HttpStatus::Code httpStatus = HttpStatus::InternalServerError;
@@ -223,12 +217,6 @@ TexturePageHandler::HandleTextureInfoRequest(const Util::String& resId, const Pt
 
     if (!resManager->HasResource(id))
     {
-        return HttpStatus::NotFound;
-    }
-
-    if (id.resourceType != TextureIdType)
-    {
-        // resource exists but is not a texture
         return HttpStatus::NotFound;
     }
 

--- a/code/render/coregraphics/image.cc
+++ b/code/render/coregraphics/image.cc
@@ -423,9 +423,7 @@ ImageId CreateImage(const ImageCreateInfoFile& info)
         stream->Unmap();
         stream->Close();
 
-        ImageId ret;
-        ret.id24 = id;
-        ret.id8 = ImageIdType;
+        ImageId ret = id;
         return ret;
     }
 #endif
@@ -445,7 +443,7 @@ ImageId CreateImage(const ImageCreateInfoData& info)
 */
 void DestroyImage(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     Memory::Free(Memory::ResourceHeap, loadInfo.buffer);
 }
 
@@ -454,7 +452,7 @@ void DestroyImage(const ImageId id)
 */
 ImageDimensions ImageGetDimensions(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return ImageDimensions{ loadInfo.width, loadInfo.height, loadInfo.depth };
 }
 
@@ -464,7 +462,7 @@ ImageDimensions ImageGetDimensions(const ImageId id)
 const byte* 
 ImageGetBuffer(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return loadInfo.buffer;
 }
 
@@ -474,7 +472,7 @@ ImageGetBuffer(const ImageId id)
 const byte* 
 ImageGetRedPtr(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return &loadInfo.buffer[loadInfo.redOffset];
 }
 
@@ -484,7 +482,7 @@ ImageGetRedPtr(const ImageId id)
 const byte* 
 ImageGetGreenPtr(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return &loadInfo.buffer[loadInfo.greenOffset];
 }
 
@@ -494,7 +492,7 @@ ImageGetGreenPtr(const ImageId id)
 const byte* 
 ImageGetBluePtr(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return &loadInfo.buffer[loadInfo.blueOffset];
 }
 
@@ -504,7 +502,7 @@ ImageGetBluePtr(const ImageId id)
 const byte* 
 ImageGetAlphaPtr(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return &loadInfo.buffer[loadInfo.alphaOffset];
 }
 
@@ -514,7 +512,7 @@ ImageGetAlphaPtr(const ImageId id)
 const SizeT 
 ImageGetPixelStride(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return CoreGraphics::PixelFormat::ToSize(loadInfo.format);
 }
 
@@ -524,7 +522,7 @@ ImageGetPixelStride(const ImageId id)
 ImageChannelPrimitive
 ImageGetChannelPrimitive(const ImageId id)
 {
-    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id24);
+    ImageLoadInfo& loadInfo = imageAllocator.Get<0>(id.id);
     return loadInfo.primitive;
 }
 

--- a/code/render/coregraphics/mesh.cc
+++ b/code/render/coregraphics/mesh.cc
@@ -40,9 +40,7 @@ CreateMesh(const MeshCreateInfo& info)
     meshAllocator.Set<Mesh_Internals>(id, internals);
     meshAllocator.Release(id);
 
-    MeshId ret;
-    ret.id24 = id;
-    ret.id8 = MeshIdType;
+    MeshId ret = id;
     return ret;
 }
 
@@ -52,12 +50,12 @@ CreateMesh(const MeshCreateInfo& info)
 void
 DestroyMesh(const MeshId id)
 {
-    const CoreGraphics::VertexAlloc& vertices = meshAllocator.ConstGet<Mesh_Internals>(id.id24).vertexAllocation;
-    const CoreGraphics::VertexAlloc& indices = meshAllocator.ConstGet<Mesh_Internals>(id.id24).indexAllocation;
+    const CoreGraphics::VertexAlloc& vertices = meshAllocator.ConstGet<Mesh_Internals>(id.id).vertexAllocation;
+    const CoreGraphics::VertexAlloc& indices = meshAllocator.ConstGet<Mesh_Internals>(id.id).indexAllocation;
 
     CoreGraphics::DeallocateVertices(vertices);
     CoreGraphics::DeallocateIndices(indices);
-    meshAllocator.Dealloc(id.id24);
+    meshAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -66,7 +64,7 @@ DestroyMesh(const MeshId id)
 const Util::Array<CoreGraphics::PrimitiveGroup>&
 MeshGetPrimitiveGroups(const MeshId id)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).primitiveGroups;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).primitiveGroups;
 }
 
 //------------------------------------------------------------------------------
@@ -75,7 +73,7 @@ MeshGetPrimitiveGroups(const MeshId id)
 const CoreGraphics::PrimitiveGroup
 MeshGetPrimitiveGroup(const MeshId id, const IndexT group)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).primitiveGroups[group];
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).primitiveGroups[group];
 }
 
 //------------------------------------------------------------------------------
@@ -84,7 +82,7 @@ MeshGetPrimitiveGroup(const MeshId id, const IndexT group)
 const BufferId
 MeshGetVertexBuffer(const MeshId id, const IndexT stream)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).streams[stream].vertexBuffer;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).streams[stream].vertexBuffer;
 }
 
 //------------------------------------------------------------------------------
@@ -93,7 +91,7 @@ MeshGetVertexBuffer(const MeshId id, const IndexT stream)
 const void
 MeshSetVertexBuffer(const MeshId id, const BufferId buffer, const IndexT stream)
 {
-    meshAllocator.ConstGet<Mesh_Internals>(id.id24).streams[stream].vertexBuffer = buffer;
+    meshAllocator.ConstGet<Mesh_Internals>(id.id).streams[stream].vertexBuffer = buffer;
 }
 
 //------------------------------------------------------------------------------
@@ -102,7 +100,7 @@ MeshSetVertexBuffer(const MeshId id, const BufferId buffer, const IndexT stream)
 const uint
 MeshGetVertexOffset(const MeshId id, const IndexT stream)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).streams[stream].offset;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).streams[stream].offset;
 }
 
 //------------------------------------------------------------------------------
@@ -111,7 +109,7 @@ MeshGetVertexOffset(const MeshId id, const IndexT stream)
 const BufferId
 MeshGetIndexBuffer(const MeshId id)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).indexBuffer;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).indexBuffer;
 }
 
 //------------------------------------------------------------------------------
@@ -120,7 +118,7 @@ MeshGetIndexBuffer(const MeshId id)
 const uint
 MeshGetIndexOffset(const MeshId id)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).indexBufferOffset;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).indexBufferOffset;
 }
 
 //------------------------------------------------------------------------------
@@ -129,7 +127,7 @@ MeshGetIndexOffset(const MeshId id)
 const IndexType::Code
 MeshGetIndexType(const MeshId id)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).indexType;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).indexType;
 }
 
 //------------------------------------------------------------------------------
@@ -138,7 +136,7 @@ MeshGetIndexType(const MeshId id)
 const CoreGraphics::PrimitiveTopology::Code
 MeshGetTopology(const MeshId id)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).primitiveTopology;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).primitiveTopology;
 }
 
 //------------------------------------------------------------------------------
@@ -147,7 +145,7 @@ MeshGetTopology(const MeshId id)
 const CoreGraphics::VertexLayoutId
 MeshGetVertexLayout(const MeshId id)
 {
-    return meshAllocator.ConstGet<Mesh_Internals>(id.id24).vertexLayout;
+    return meshAllocator.ConstGet<Mesh_Internals>(id.id).vertexLayout;
 }
 
 //------------------------------------------------------------------------------
@@ -156,7 +154,7 @@ MeshGetVertexLayout(const MeshId id)
 const void
 MeshBind(const MeshId id, const CoreGraphics::CmdBufferId cmd)
 {
-    const auto& internals = meshAllocator.ConstGet<Mesh_Internals>(id.id24);
+    const auto& internals = meshAllocator.ConstGet<Mesh_Internals>(id.id);
 
     CoreGraphics::CmdSetPrimitiveTopology(cmd, internals.primitiveTopology);
     CoreGraphics::CmdSetVertexLayout(cmd, internals.vertexLayout);

--- a/code/render/coregraphics/meshloader.cc
+++ b/code/render/coregraphics/meshloader.cc
@@ -94,7 +94,7 @@ MeshLoader::InitializeResource(Ids::Id32 entry, const Util::StringAtom& tag, con
     n_assert(stream.isvalid());
     String resIdExt = this->names[entry].AsString().GetFileExtension();
 
-    MeshResourceId ret = { meshResourceAllocator.Alloc(), MeshIdType };
+    MeshResourceId ret = meshResourceAllocator.Alloc();
 
     if (resIdExt == "nvx")
     {
@@ -304,7 +304,7 @@ MeshLoader::SetupMeshFromNvx(const Ptr<IO::Stream>& stream, const Ids::Id32 entr
     }
 
     // Update mesh allocator
-    meshResourceAllocator.Set<0>(meshResource.resourceId, meshes);
+    meshResourceAllocator.Set<0>(meshResource.id, meshes);
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/meshresource.cc
+++ b/code/render/coregraphics/meshresource.cc
@@ -14,7 +14,7 @@ MeshResourceAllocator meshResourceAllocator;
 const MeshId
 MeshResourceGetMesh(const MeshResourceId id, const IndexT index)
 {
-    return meshResourceAllocator.Get<0>(id.resourceId)[index];
+    return meshResourceAllocator.Get<0>(id.id)[index];
 }
 
 //------------------------------------------------------------------------------
@@ -23,7 +23,7 @@ MeshResourceGetMesh(const MeshResourceId id, const IndexT index)
 const SizeT
 MeshResourceGetNumMeshes(const MeshResourceId id)
 {
-    return meshResourceAllocator.Get<0>(id.resourceId).Size();
+    return meshResourceAllocator.Get<0>(id.id).Size();
 }
 
 //------------------------------------------------------------------------------
@@ -31,12 +31,12 @@ MeshResourceGetNumMeshes(const MeshResourceId id)
 */
 void DestroyMeshResource(const MeshResourceId id)
 {
-    auto meshes = meshResourceAllocator.Get<0>(id.resourceId);
+    auto meshes = meshResourceAllocator.Get<0>(id.id);
     for (IndexT i = 0; i < meshes.Size(); i++)
     {
         DestroyMesh(meshes[i]);
     }
-    meshResourceAllocator.Dealloc(id.resourceId);
+    meshResourceAllocator.Dealloc(id.id);
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/shader.h
+++ b/code/render/coregraphics/shader.h
@@ -49,7 +49,7 @@ struct ResourcePipelineId;
 struct ResourceTableSet;
 
 RESOURCE_ID_TYPE(ShaderId);             
-ID_24_8_24_8_NAMED_TYPE(ShaderProgramId, programId, programType, shaderId, shaderType);     // 32 bits shader, 24 bits program, 8 bits type
+ID_24_8_24_8_NAMED_TYPE(ShaderProgramId, programId, programGeneration, shaderId, shaderGeneration, program, shader);     // 32 bits shader, 24 bits program, 8 bits type
 
 ID_32_TYPE(DerivativeStateId);          // 32 bits derivative state (already created from an ordinary state)
 

--- a/code/render/coregraphics/shaderloader.cc
+++ b/code/render/coregraphics/shaderloader.cc
@@ -77,9 +77,7 @@ ShaderLoader::ReloadFromStream(const Resources::ResourceId id, const Ptr<IO::Str
         return Resources::Resource::Failed;
     }
 
-    ShaderId shader;
-    shader.resourceId = id.resourceId;
-    shader.resourceType = id.resourceType;
+    ShaderId shader = id.resource;
     ReloadShader(shader, effect);
     return Resources::Resource::Loaded;
 }
@@ -90,9 +88,7 @@ ShaderLoader::ReloadFromStream(const Resources::ResourceId id, const Ptr<IO::Str
 void
 ShaderLoader::Unload(const Resources::ResourceId res)
 {
-    ShaderId id;
-    id.resourceId = res.resourceId;
-    id.resourceType = res.resourceType;
+    ShaderId id = res.resource;
     CoreGraphics::DestroyShader(id);
 }
 

--- a/code/render/coregraphics/textureloader.cc
+++ b/code/render/coregraphics/textureloader.cc
@@ -289,9 +289,7 @@ TextureLoader::StreamResource(const Resources::ResourceId entry, IndexT frameInd
     uint bitsToLoad = requestedBits;
 
     // Setup texture id
-    TextureId texture;
-    texture.resourceId = entry.resourceId;
-    texture.resourceType = entry.resourceType;
+    TextureId texture = entry.resource;
     TextureIdAcquire(texture);
 
     // First, poll all submissions to find what's finished loading
@@ -342,9 +340,7 @@ TextureLoader::Unload(const Resources::ResourceId id)
     // Free streamer alloc
     this->streams[id.loaderInstanceId].stream->MemoryUnmap();
     Memory::Free(Memory::ScratchHeap, this->streams[id.loaderInstanceId].data);
-    TextureId tex;
-    tex.resourceId = id.resourceId;
-    tex.resourceType = id.resourceType;
+    TextureId tex = id.resource;
     CoreGraphics::DestroyTexture(tex);
 }
 

--- a/code/render/coregraphics/vk/vkaccelerationstructure.cc
+++ b/code/render/coregraphics/vk/vkaccelerationstructure.cc
@@ -24,7 +24,7 @@ VkTlasAllocator tlasAllocator;
 const VkDevice
 BlasGetVkDevice(const CoreGraphics::BlasId id)
 {
-    return blasAllocator.ConstGet<Blas_Device>(id.id24);
+    return blasAllocator.ConstGet<Blas_Device>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -33,7 +33,7 @@ BlasGetVkDevice(const CoreGraphics::BlasId id)
 const VkBuffer
 BlasGetVkBuffer(const CoreGraphics::BlasId id)
 {
-    return BufferGetVk(blasAllocator.ConstGet<Blas_Buffer>(id.id24));
+    return BufferGetVk(blasAllocator.ConstGet<Blas_Buffer>(id.id));
 }
 
 //------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ BlasGetVkBuffer(const CoreGraphics::BlasId id)
 const VkAccelerationStructureKHR
 BlasGetVk(const CoreGraphics::BlasId id)
 {
-    return blasAllocator.ConstGet<Blas_Handle>(id.id24);
+    return blasAllocator.ConstGet<Blas_Handle>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -51,7 +51,7 @@ BlasGetVk(const CoreGraphics::BlasId id)
 const VkAccelerationStructureBuildGeometryInfoKHR&
 BlasGetVkBuild(const CoreGraphics::BlasId id)
 {
-    return blasAllocator.ConstGet<Blas_Geometry>(id.id24).buildGeometryInfo;
+    return blasAllocator.ConstGet<Blas_Geometry>(id.id).buildGeometryInfo;
 }
 
 //------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ BlasGetVkBuild(const CoreGraphics::BlasId id)
 const Util::Array<VkAccelerationStructureBuildRangeInfoKHR>&
 BlasGetVkRanges(const CoreGraphics::BlasId id)
 {
-    return blasAllocator.ConstGet<Blas_Geometry>(id.id24).rangeInfos;
+    return blasAllocator.ConstGet<Blas_Geometry>(id.id).rangeInfos;
 }
 
 //------------------------------------------------------------------------------
@@ -69,7 +69,7 @@ BlasGetVkRanges(const CoreGraphics::BlasId id)
 const VkDevice
 TlasGetVkDevice(const CoreGraphics::TlasId id)
 {
-    return tlasAllocator.ConstGet<Tlas_Device>(id.id24);
+    return tlasAllocator.ConstGet<Tlas_Device>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ TlasGetVkDevice(const CoreGraphics::TlasId id)
 const VkBuffer
 TlasGetVkBuffer(const CoreGraphics::TlasId id)
 {
-    return BufferGetVk(tlasAllocator.ConstGet<Tlas_Buffer>(id.id24));
+    return BufferGetVk(tlasAllocator.ConstGet<Tlas_Buffer>(id.id));
 }
 
 //------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ TlasGetVkBuffer(const CoreGraphics::TlasId id)
 const VkAccelerationStructureKHR
 TlasGetVk(const CoreGraphics::TlasId id)
 {
-    return tlasAllocator.ConstGet<Tlas_Handle>(id.id24);
+    return tlasAllocator.ConstGet<Tlas_Handle>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -96,7 +96,7 @@ TlasGetVk(const CoreGraphics::TlasId id)
 const VkAccelerationStructureBuildGeometryInfoKHR&
 TlasGetVkBuild(const CoreGraphics::TlasId id)
 {
-    return tlasAllocator.ConstGet<Tlas_Scene>(id.id24).geometryInfo;
+    return tlasAllocator.ConstGet<Tlas_Scene>(id.id).geometryInfo;
 }
 
 //------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ TlasGetVkBuild(const CoreGraphics::TlasId id)
 const Util::Array<VkAccelerationStructureBuildRangeInfoKHR>&
 TlasGetVkRanges(const CoreGraphics::TlasId id)
 {
-    return tlasAllocator.ConstGet<Tlas_Scene>(id.id24).rangeInfos;
+    return tlasAllocator.ConstGet<Tlas_Scene>(id.id).rangeInfos;
 }
 
 } // namespace Vulkan
@@ -260,9 +260,7 @@ CreateBlas(const BlasCreateInfo& info)
     blasAllocator.Set<Blas_Handle>(id, as);
     setup.buildGeometryInfo.dstAccelerationStructure = as;
 
-    BlasId ret;
-    ret.id24 = id;
-    ret.id8 = BlasIdType;
+    BlasId ret = id;
     return ret;
 }
 
@@ -272,10 +270,10 @@ CreateBlas(const BlasCreateInfo& info)
 void
 DestroyBlas(const BlasId blas)
 {
-    blasAllocator.Dealloc(blas.id24);
     CoreGraphics::DelayedDeleteBlas(blas);
-    CoreGraphics::DestroyBuffer(blasAllocator.Get<Blas_Buffer>(blas.id24));
-    CoreGraphics::DestroyBuffer(blasAllocator.Get<Blas_Scratch>(blas.id24));
+    CoreGraphics::DestroyBuffer(blasAllocator.Get<Blas_Buffer>(blas.id));
+    CoreGraphics::DestroyBuffer(blasAllocator.Get<Blas_Scratch>(blas.id));
+    blasAllocator.Dealloc(blas.id);
 }
 
 //------------------------------------------------------------------------------
@@ -319,10 +317,7 @@ CreateBlasInstance(const BlasInstanceCreateInfo& info)
 
     blasInstanceAllocator.Set<BlasInstance_Transform>(id, info.transform);
 
-    BlasInstanceId ret;
-    ret.id24 = id;
-    ret.id8 = BlasInstanceIdType;
-
+    BlasInstanceId ret = id;
     BlasInstanceIdRelease(ret);
     return ret;
 }
@@ -333,9 +328,9 @@ CreateBlasInstance(const BlasInstanceCreateInfo& info)
 void
 DestroyBlasInstance(const BlasInstanceId id)
 {
-    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id);
     setup.mask = 0x0; // Disable instance such that TLAS building will ignore it
-    blasInstanceAllocator.Dealloc(id.id24);
+    blasInstanceAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -344,7 +339,7 @@ DestroyBlasInstance(const BlasInstanceId id)
 void
 BlasInstanceUpdate(const BlasInstanceId id, const Math::mat4& transform, CoreGraphics::BufferId buf, uint offset)
 {
-    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id);
     Math::mat4 trans = Math::transpose(transform);
     trans.store3(&setup.transform.matrix[0][0]);
 
@@ -358,7 +353,7 @@ BlasInstanceUpdate(const BlasInstanceId id, const Math::mat4& transform, CoreGra
 void
 BlasInstanceUpdate(const BlasInstanceId id, CoreGraphics::BufferId buf, uint offset)
 {
-    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id);
     char* ptr = (char*)CoreGraphics::BufferMap(buf) + offset;
     memcpy(ptr, &setup, sizeof(setup));
 }
@@ -369,7 +364,7 @@ BlasInstanceUpdate(const BlasInstanceId id, CoreGraphics::BufferId buf, uint off
 void
 BlasInstanceSetMask(const BlasInstanceId id, uint mask)
 {
-    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id24);
+    VkAccelerationStructureInstanceKHR& setup = blasInstanceAllocator.Get<BlasInstance_Instance>(id.id);
     setup.mask = mask;
 }
 
@@ -526,9 +521,7 @@ CreateTlas(const TlasCreateInfo& info)
     tlasAllocator.Set<Tlas_Handle>(id, as);
     scene.geometryInfo.dstAccelerationStructure = as;
 
-    TlasId ret;
-    ret.id24 = id;
-    ret.id8 = TlasIdType;
+    TlasId ret = id;
     return ret;
 }
 
@@ -539,10 +532,10 @@ void
 DestroyTlas(const TlasId tlas)
 {
     CoreGraphics::DelayedDeleteTlas(tlas);
-    CoreGraphics::DestroyBuffer(tlasAllocator.Get<Tlas_Buffer>(tlas.id24));
-    CoreGraphics::DestroyBuffer(tlasAllocator.Get<Tlas_BuildScratch>(tlas.id24));
-    CoreGraphics::DestroyBuffer(tlasAllocator.Get<Tlas_UpdateScratch>(tlas.id24));
-    tlasAllocator.Dealloc(tlas.id24);
+    CoreGraphics::DestroyBuffer(tlasAllocator.Get<Tlas_Buffer>(tlas.id));
+    CoreGraphics::DestroyBuffer(tlasAllocator.Get<Tlas_BuildScratch>(tlas.id));
+    CoreGraphics::DestroyBuffer(tlasAllocator.Get<Tlas_UpdateScratch>(tlas.id));
+    tlasAllocator.Dealloc(tlas.id);
 }
 
 //------------------------------------------------------------------------------
@@ -551,9 +544,9 @@ DestroyTlas(const TlasId tlas)
 void
 TlasInitBuild(const TlasId tlas)
 {
-    SceneSetup& scene = tlasAllocator.Get<Tlas_Scene>(tlas.id24);
+    SceneSetup& scene = tlasAllocator.Get<Tlas_Scene>(tlas.id);
     scene.geometryInfo.mode = VkBuildAccelerationStructureModeKHR::VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
-    scene.geometryInfo.scratchData = VkDeviceOrHostAddressKHR{ .deviceAddress = tlasAllocator.Get<Tlas_BuildScratchAddr>(tlas.id24) };
+    scene.geometryInfo.scratchData = VkDeviceOrHostAddressKHR{ .deviceAddress = tlasAllocator.Get<Tlas_BuildScratchAddr>(tlas.id) };
 }
 
 //------------------------------------------------------------------------------
@@ -562,9 +555,9 @@ TlasInitBuild(const TlasId tlas)
 void
 TlasInitUpdate(const TlasId tlas)
 {
-    SceneSetup& scene = tlasAllocator.Get<Tlas_Scene>(tlas.id24);
+    SceneSetup& scene = tlasAllocator.Get<Tlas_Scene>(tlas.id);
     scene.geometryInfo.mode = VkBuildAccelerationStructureModeKHR::VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
-    scene.geometryInfo.scratchData = VkDeviceOrHostAddressKHR{ .deviceAddress = tlasAllocator.Get<Tlas_UpdateScratchAddr>(tlas.id24) };
+    scene.geometryInfo.scratchData = VkDeviceOrHostAddressKHR{ .deviceAddress = tlasAllocator.Get<Tlas_UpdateScratchAddr>(tlas.id) };
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkbarrier.cc
+++ b/code/render/coregraphics/vk/vkbarrier.cc
@@ -24,7 +24,7 @@ VkBarrierAllocator barrierAllocator(0x00FFFFFF);
 const VkBarrierInfo&
 BarrierGetVk(const CoreGraphics::BarrierId id)
 {
-    return barrierAllocator.Get<Barrier_Info>(id.id24);
+    return barrierAllocator.Get<Barrier_Info>(id.id);
 }
 }
 
@@ -126,9 +126,7 @@ CreateBarrier(const BarrierCreateInfo& info)
         vkInfo.numMemoryBarriers = 1;
     }
 
-    BarrierId eventId;
-    eventId.id24 = id;
-    eventId.id8 = BarrierIdType;
+    BarrierId eventId = id;
     return eventId;
 }
 
@@ -138,7 +136,7 @@ CreateBarrier(const BarrierCreateInfo& info)
 void
 DestroyBarrier(const BarrierId id)
 {
-    barrierAllocator.Dealloc(id.id24);
+    barrierAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -147,8 +145,8 @@ DestroyBarrier(const BarrierId id)
 void
 BarrierReset(const BarrierId id)
 {
-    VkBarrierInfo& vkInfo = barrierAllocator.Get<Barrier_Info>(id.id24);
-    Util::Array<CoreGraphics::TextureId>& rts = barrierAllocator.Get<Barrier_Textures>(id.id24);
+    VkBarrierInfo& vkInfo = barrierAllocator.Get<Barrier_Info>(id.id);
+    Util::Array<CoreGraphics::TextureId>& rts = barrierAllocator.Get<Barrier_Textures>(id.id);
 
     IndexT i;
     for (i = 0; i < rts.Size(); i++)

--- a/code/render/coregraphics/vk/vkevent.cc
+++ b/code/render/coregraphics/vk/vkevent.cc
@@ -27,7 +27,7 @@ VkEventAllocator eventAllocator(0x00FFFFFF);
 const VkEventInfo&
 EventGetVk(const CoreGraphics::EventId id)
 {
-    return eventAllocator.Get<Event_Info>(id.id24);
+    return eventAllocator.Get<Event_Info>(id.id);
 }
 }
 
@@ -123,9 +123,7 @@ CreateEvent(const EventCreateInfo& info)
         vkInfo.numMemoryBarriers = 1;
     }
 
-    EventId eventId;
-    eventId.id24 = id;
-    eventId.id8 = EventIdType;
+    EventId eventId = id;
     return eventId;
 }
 
@@ -135,10 +133,10 @@ CreateEvent(const EventCreateInfo& info)
 void
 DestroyEvent(const EventId id)
 {
-    VkEventInfo& vkInfo = eventAllocator.Get<Event_Info>(id.id24);
-    const VkDevice& dev = eventAllocator.Get<Event_Device>(id.id24);
+    VkEventInfo& vkInfo = eventAllocator.Get<Event_Info>(id.id);
+    const VkDevice& dev = eventAllocator.Get<Event_Device>(id.id);
     vkDestroyEvent(dev, vkInfo.event, nullptr);
-    eventAllocator.Dealloc(id.id24);
+    eventAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -147,7 +145,7 @@ DestroyEvent(const EventId id)
 void
 EventSignal(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGraphics::PipelineStage stage)
 {
-    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
+    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
     vkCmdSetEvent(CmdBufferGetVk(buf), info.event, VkTypes::AsVkPipelineStage(stage));
 }
 
@@ -157,7 +155,7 @@ EventSignal(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGra
 void
 EventWait(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGraphics::PipelineStage waitStage, const CoreGraphics::PipelineStage signalStage)
 {
-    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
+    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
     vkCmdWaitEvents(CmdBufferGetVk(buf), 1, &info.event,
         VkTypes::AsVkPipelineStage(waitStage),
         VkTypes::AsVkPipelineStage(signalStage),
@@ -175,7 +173,7 @@ EventWait(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGraph
 void
 EventReset(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGraphics::PipelineStage stage)
 {
-    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
+    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
     vkCmdResetEvent(CmdBufferGetVk(buf), info.event, VkTypes::AsVkPipelineStage(stage));
 }
 
@@ -185,7 +183,7 @@ EventReset(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGrap
 void
 EventWaitAndReset(const EventId id, const CoreGraphics::CmdBufferId buf, const CoreGraphics::PipelineStage waitStage, const CoreGraphics::PipelineStage signalStage)
 {
-    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
+    VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
     vkCmdWaitEvents(CmdBufferGetVk(buf), 1, &info.event,
         VkTypes::AsVkPipelineStage(waitStage),
         VkTypes::AsVkPipelineStage(signalStage),
@@ -204,8 +202,8 @@ EventWaitAndReset(const EventId id, const CoreGraphics::CmdBufferId buf, const C
 bool 
 EventPoll(const EventId id)
 {
-    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
-    VkDevice dev = eventAllocator.Get<Event_Device>(id.id24);
+    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
+    VkDevice dev = eventAllocator.Get<Event_Device>(id.id);
     VkResult res = vkGetEventStatus(dev, info.event);
     return res == VK_EVENT_SET;
 }
@@ -216,8 +214,8 @@ EventPoll(const EventId id)
 void 
 EventHostReset(const EventId id)
 {
-    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
-    VkDevice dev = eventAllocator.Get<Event_Device>(id.id24);
+    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
+    VkDevice dev = eventAllocator.Get<Event_Device>(id.id);
     vkResetEvent(dev, info.event);
 }
 
@@ -227,8 +225,8 @@ EventHostReset(const EventId id)
 void 
 EventHostSignal(const EventId id)
 {
-    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
-    VkDevice dev = eventAllocator.Get<Event_Device>(id.id24);
+    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
+    VkDevice dev = eventAllocator.Get<Event_Device>(id.id);
     vkSetEvent(dev, info.event);
 }
 
@@ -238,8 +236,8 @@ EventHostSignal(const EventId id)
 void
 EventHostWait(const EventId id)
 {
-    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id24);
-    VkDevice dev = eventAllocator.Get<Event_Device>(id.id24);
+    const VkEventInfo& info = eventAllocator.Get<Event_Info>(id.id);
+    VkDevice dev = eventAllocator.Get<Event_Device>(id.id);
     VkResult res;
     while (true)
     {

--- a/code/render/coregraphics/vk/vkfence.cc
+++ b/code/render/coregraphics/vk/vkfence.cc
@@ -19,7 +19,7 @@ VkFence
 FenceGetVk(const CoreGraphics::FenceId id)
 {
     if (id == CoreGraphics::FenceId::Invalid()) return VK_NULL_HANDLE;
-    else                                        return fenceAllocator.Get<1>(id.id24).fence;
+    else                                        return fenceAllocator.Get<1>(id.id).fence;
 }
 
 }
@@ -51,9 +51,7 @@ CreateFence(const FenceCreateInfo& info)
     fenceAllocator.Get<0>(id) = dev;
     fenceAllocator.Get<1>(id).fence = fence;
     
-    FenceId ret;
-    ret.id24 = id;
-    ret.id8 = FenceIdType;
+    FenceId ret = id;
     return ret;
 }
 
@@ -63,10 +61,10 @@ CreateFence(const FenceCreateInfo& info)
 void
 DestroyFence(const FenceId id)
 {
-    VkFenceInfo& vkInfo = fenceAllocator.Get<1>(id.id24);
-    const VkDevice& dev = fenceAllocator.Get<0>(id.id24);
+    VkFenceInfo& vkInfo = fenceAllocator.Get<1>(id.id);
+    const VkDevice& dev = fenceAllocator.Get<0>(id.id);
     vkDestroyFence(dev, vkInfo.fence, nullptr);
-    fenceAllocator.Dealloc(id.id24);
+    fenceAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -75,7 +73,7 @@ DestroyFence(const FenceId id)
 bool 
 FencePeek(const FenceId id)
 {
-    return vkGetFenceStatus(fenceAllocator.Get<0>(id.id24), fenceAllocator.Get<1>(id.id24).fence) == VK_SUCCESS;
+    return vkGetFenceStatus(fenceAllocator.Get<0>(id.id), fenceAllocator.Get<1>(id.id).fence) == VK_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
@@ -84,7 +82,7 @@ FencePeek(const FenceId id)
 bool 
 FenceReset(const FenceId id)
 {
-    return vkResetFences(fenceAllocator.Get<0>(id.id24), 1, &fenceAllocator.Get<1>(id.id24).fence) == VK_SUCCESS;
+    return vkResetFences(fenceAllocator.Get<0>(id.id), 1, &fenceAllocator.Get<1>(id.id).fence) == VK_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
@@ -93,8 +91,8 @@ FenceReset(const FenceId id)
 bool 
 FenceWait(const FenceId id, const uint64 time)
 {
-    VkFence fence = fenceAllocator.Get<1>(id.id24).fence;
-    VkDevice dev = fenceAllocator.Get<0>(id.id24);
+    VkFence fence = fenceAllocator.Get<1>(id.id).fence;
+    VkDevice dev = fenceAllocator.Get<0>(id.id);
     VkResult res = vkWaitForFences(dev, 1, &fence, false, time);
     return res == VK_SUCCESS || res == VK_TIMEOUT;
 }
@@ -105,8 +103,8 @@ FenceWait(const FenceId id, const uint64 time)
 bool 
 FenceWaitAndReset(const FenceId id, const uint64 time)
 {
-    VkFence fence = fenceAllocator.Get<1>(id.id24).fence;
-    VkDevice dev = fenceAllocator.Get<0>(id.id24);
+    VkFence fence = fenceAllocator.Get<1>(id.id).fence;
+    VkDevice dev = fenceAllocator.Get<0>(id.id);
     VkResult res = vkWaitForFences(dev, 1, &fence, false, time);
     if (res == VK_SUCCESS)
     {

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -2567,7 +2567,7 @@ ObjectSetName(const SemaphoreId id, const char* name)
         VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
         nullptr,
         VK_OBJECT_TYPE_SEMAPHORE,
-        (uint64_t)SemaphoreGetVk(id.id24),
+        (uint64_t)SemaphoreGetVk(id.id),
         name
     };
     VkDevice dev = GetCurrentDevice();

--- a/code/render/coregraphics/vk/vkpass.cc
+++ b/code/render/coregraphics/vk/vkpass.cc
@@ -23,7 +23,7 @@ VkPassAllocator passAllocator(0x00FFFFFF);
 const VkRenderPassBeginInfo&
 PassGetVkRenderPassBeginInfo(const CoreGraphics::PassId& id)
 {
-    return passAllocator.Get<Pass_VkRenderPassBeginInfo>(id.id24);
+    return passAllocator.Get<Pass_VkRenderPassBeginInfo>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -32,7 +32,7 @@ PassGetVkRenderPassBeginInfo(const CoreGraphics::PassId& id)
 const VkGraphicsPipelineCreateInfo&
 PassGetVkFramebufferInfo(const CoreGraphics::PassId& id)
 {
-    return passAllocator.Get<Pass_VkRuntimeInfo>(id.id24).framebufferPipelineInfo;
+    return passAllocator.Get<Pass_VkRuntimeInfo>(id.id).framebufferPipelineInfo;
 }
 
 //------------------------------------------------------------------------------
@@ -41,7 +41,7 @@ PassGetVkFramebufferInfo(const CoreGraphics::PassId& id)
 const SizeT 
 PassGetVkNumAttachments(const CoreGraphics::PassId& id)
 {
-    return passAllocator.Get<Pass_VkLoadInfo>(id.id24).attachments.Size();
+    return passAllocator.Get<Pass_VkLoadInfo>(id.id).attachments.Size();
 }
 
 //------------------------------------------------------------------------------
@@ -50,7 +50,7 @@ PassGetVkNumAttachments(const CoreGraphics::PassId& id)
 const VkDevice
 PassGetVkDevice(const CoreGraphics::PassId& id)
 {
-    return passAllocator.Get<Pass_VkLoadInfo>(id.id24).dev;
+    return passAllocator.Get<Pass_VkLoadInfo>(id.id).dev;
 }
 
 //------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ PassGetVkDevice(const CoreGraphics::PassId& id)
 const VkFramebuffer
 PassGetVkFramebuffer(const CoreGraphics::PassId& id)
 {
-    return passAllocator.Get<Pass_VkLoadInfo>(id.id24).framebuffer;
+    return passAllocator.Get<Pass_VkLoadInfo>(id.id).framebuffer;
 }
 
 //------------------------------------------------------------------------------
@@ -68,7 +68,7 @@ PassGetVkFramebuffer(const CoreGraphics::PassId& id)
 const VkRenderPass
 PassGetVkRenderPass(const CoreGraphics::PassId& id)
 {
-    return passAllocator.Get<Pass_VkLoadInfo>(id.id24).pass;
+    return passAllocator.Get<Pass_VkLoadInfo>(id.id).pass;
 }
 
 } // namespace Vulkan
@@ -473,7 +473,7 @@ GetSubpassInfo(
 void
 SetupPass(const PassId pid)
 {
-    Ids::Id32 id = pid.id24;
+    Ids::Id32 id = pid.id;
     VkPassLoadInfo& loadInfo = passAllocator.Get<Pass_VkLoadInfo>(id);
     VkPassRuntimeInfo& runtimeInfo = passAllocator.Get<Pass_VkRuntimeInfo>(id);
     VkRenderPassBeginInfo& beginInfo = passAllocator.Get<Pass_VkRenderPassBeginInfo>(id);
@@ -705,10 +705,7 @@ CreatePass(const PassCreateInfo& info)
         }
     }
 
-    PassId ret;
-    ret.id24 = id;
-    ret.id8 = PassIdType;
-
+    PassId ret = id;
     SetupPass(ret);
 
     return ret;
@@ -720,8 +717,8 @@ CreatePass(const PassCreateInfo& info)
 void
 DestroyPass(const PassId id)
 {
-    VkPassLoadInfo& loadInfo = passAllocator.Get<Pass_VkLoadInfo>(id.id24);
-    VkPassRuntimeInfo& runtimeInfo = passAllocator.Get<Pass_VkRuntimeInfo>(id.id24);
+    VkPassLoadInfo& loadInfo = passAllocator.Get<Pass_VkLoadInfo>(id.id);
+    VkPassRuntimeInfo& runtimeInfo = passAllocator.Get<Pass_VkRuntimeInfo>(id.id);
 
     for (IndexT i = 0; i < loadInfo.attachments.Size(); i++)
         CoreGraphics::DestroyTextureView(loadInfo.attachments[i]);
@@ -741,7 +738,7 @@ DestroyPass(const PassId id)
 void
 PassWindowResizeCallback(const PassId id)
 {
-    VkPassLoadInfo& loadInfo = passAllocator.Get<Pass_VkLoadInfo>(id.id24);
+    VkPassLoadInfo& loadInfo = passAllocator.Get<Pass_VkLoadInfo>(id.id);
 
     // destroy pass and our descriptor set
     vkDestroyRenderPass(loadInfo.dev, loadInfo.pass, nullptr);
@@ -761,7 +758,7 @@ PassWindowResizeCallback(const PassId id)
 const Util::Array<CoreGraphics::TextureViewId>&
 PassGetAttachments(const CoreGraphics::PassId id)
 {
-    return passAllocator.Get<Pass_VkLoadInfo>(id.id24).attachments;
+    return passAllocator.Get<Pass_VkLoadInfo>(id.id).attachments;
 }
 
 //------------------------------------------------------------------------------
@@ -770,7 +767,7 @@ PassGetAttachments(const CoreGraphics::PassId id)
 const uint32_t
 PassGetNumSubpassAttachments(const CoreGraphics::PassId id, const IndexT subpass)
 {
-    return passAllocator.Get<Pass_SubpassAttachments>(id.id24)[subpass];
+    return passAllocator.Get<Pass_SubpassAttachments>(id.id)[subpass];
 }
 
 //------------------------------------------------------------------------------
@@ -779,7 +776,7 @@ PassGetNumSubpassAttachments(const CoreGraphics::PassId id, const IndexT subpass
 const CoreGraphics::ResourceTableId
 PassGetResourceTable(const CoreGraphics::PassId id)
 {
-    VkPassRuntimeInfo& runtimeInfo = passAllocator.Get<Pass_VkRuntimeInfo>(id.id24);
+    VkPassRuntimeInfo& runtimeInfo = passAllocator.Get<Pass_VkRuntimeInfo>(id.id);
     return runtimeInfo.passDescriptorSet;
 }
 
@@ -789,7 +786,7 @@ PassGetResourceTable(const CoreGraphics::PassId id)
 const Util::StringAtom 
 PassGetName(const CoreGraphics::PassId id)
 {
-    return passAllocator.Get<Pass_VkLoadInfo>(id.id24).name;
+    return passAllocator.Get<Pass_VkLoadInfo>(id.id).name;
 }
 
 //------------------------------------------------------------------------------
@@ -798,7 +795,7 @@ PassGetName(const CoreGraphics::PassId id)
 const Util::FixedArray<Math::rectangle<int>>&
 PassGetRects(const CoreGraphics::PassId& id)
 {
-    const VkPassRuntimeInfo& info = passAllocator.Get<Pass_VkRuntimeInfo>(id.id24);
+    const VkPassRuntimeInfo& info = passAllocator.Get<Pass_VkRuntimeInfo>(id.id);
     return info.subpassRects[info.currentSubpassIndex];
 }
 
@@ -808,7 +805,7 @@ PassGetRects(const CoreGraphics::PassId& id)
 const Util::FixedArray<Math::rectangle<int>>&
 PassGetViewports(const CoreGraphics::PassId& id)
 {
-    const VkPassRuntimeInfo& info = passAllocator.Get<Pass_VkRuntimeInfo>(id.id24);
+    const VkPassRuntimeInfo& info = passAllocator.Get<Pass_VkRuntimeInfo>(id.id);
     return info.subpassViewports[info.currentSubpassIndex];
 }
 

--- a/code/render/coregraphics/vk/vkpipeline.cc
+++ b/code/render/coregraphics/vk/vkpipeline.cc
@@ -72,7 +72,7 @@ CreateGraphicsPipeline(const PipelineCreateInfo& info)
     obj.pipeline = pipeline;
     obj.layout = programInfo.layout;
     obj.pass = info.pass;
-    return PipelineId{ ret, PipelineIdType };
+    return PipelineId{ ret };
 }
 
 //------------------------------------------------------------------------------
@@ -81,9 +81,9 @@ CreateGraphicsPipeline(const PipelineCreateInfo& info)
 void
 DestroyGraphicsPipeline(const PipelineId pipeline)
 {
-    Pipeline& obj = pipelineAllocator.Get<0>(pipeline.id24);
+    Pipeline& obj = pipelineAllocator.Get<0>(pipeline.id);
     vkDestroyPipeline(Vulkan::GetCurrentDevice(), obj.pipeline, nullptr);
-    pipelineAllocator.Dealloc(pipeline.id24);
+    pipelineAllocator.Dealloc(pipeline.id);
 }
 
 //------------------------------------------------------------------------------
@@ -388,9 +388,7 @@ CreateRaytracingPipeline(const Util::Array<CoreGraphics::ShaderProgramId> progra
     Ids::Id32 id = pipelineAllocator.Alloc();
     pipelineAllocator.Set<Pipeline_Object>(id, { .pipeline = pipeline, .layout = createInfo.layout, .pass = InvalidPassId });
 
-    PipelineId pipeId;
-    pipeId.id24 = id;
-    pipeId.id8 = PipelineIdType;
+    PipelineId pipeId = id;
     ret.pipeline = pipeId;
 
     return ret;
@@ -406,9 +404,9 @@ DestroyRaytracingPipeline(const PipelineRayTracingTable& table)
     CoreGraphics::DestroyBuffer(table.missBindingBuffer);
     CoreGraphics::DestroyBuffer(table.hitBindingBuffer);
     CoreGraphics::DestroyBuffer(table.callableBindingBuffer);
-    Pipeline& obj = pipelineAllocator.Get<0>(table.pipeline.id24);
+    Pipeline& obj = pipelineAllocator.Get<0>(table.pipeline.id);
     vkDestroyPipeline(Vulkan::GetCurrentDevice(), obj.pipeline, nullptr);
-    pipelineAllocator.Dealloc(table.pipeline.id24);
+    pipelineAllocator.Dealloc(table.pipeline.id);
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vkresourcetable.cc
+++ b/code/render/coregraphics/vk/vkresourcetable.cc
@@ -29,7 +29,7 @@ VkDescriptorSetLayout EmptySetLayout;
 const VkDescriptorSet&
 ResourceTableGetVkDescriptorSet(CoreGraphics::ResourceTableId id)
 {
-    return resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    return resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ ResourceTableGetVkDescriptorSet(CoreGraphics::ResourceTableId id)
 const IndexT
 ResourceTableGetVkPoolIndex(CoreGraphics::ResourceTableId id)
 {
-    return resourceTableAllocator.Get<ResourceTable_DescriptorPoolIndex>(id.id24);
+    return resourceTableAllocator.Get<ResourceTable_DescriptorPoolIndex>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ ResourceTableGetVkPoolIndex(CoreGraphics::ResourceTableId id)
 const VkDevice&
 ResourceTableGetVkDevice(CoreGraphics::ResourceTableId id)
 {
-    return resourceTableAllocator.Get<ResourceTable_Device>(id.id24);
+    return resourceTableAllocator.Get<ResourceTable_Device>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ SetupEmptyDescriptorSetLayout()
 const VkDescriptorSetLayout&
 ResourceTableLayoutGetVk(const CoreGraphics::ResourceTableLayoutId& id)
 {
-    return resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(id.id24);
+    return resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -97,14 +97,14 @@ ResourceTableLayoutGetVk(const CoreGraphics::ResourceTableLayoutId& id)
 void
 ResourceTableLayoutAllocTable(const CoreGraphics::ResourceTableLayoutId& id, const VkDevice dev, uint overallocationSize, IndexT& outIndex, VkDescriptorSet& outSet)
 {
-    Util::Array<uint32_t>& freeItems = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPoolFreeItems>(id.id24);
+    Util::Array<uint32_t>& freeItems = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPoolFreeItems>(id.id);
     VkDescriptorPool pool = VK_NULL_HANDLE;
     for (IndexT i = 0; i < freeItems.Size(); i++)
     {
         // if free, return
         if (freeItems[i] > 0)
         {
-            pool = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id24)[i];
+            pool = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id)[i];
             outIndex = i;
             break;
         }
@@ -113,7 +113,7 @@ ResourceTableLayoutAllocTable(const CoreGraphics::ResourceTableLayoutId& id, con
     // no pool found, allocate new pool
     if (pool == VK_NULL_HANDLE)
     {
-        Util::Array<VkDescriptorPoolSize> poolSizes = resourceTableLayoutAllocator.Get<ResourceTableLayout_PoolSizes>(id.id24);
+        Util::Array<VkDescriptorPoolSize> poolSizes = resourceTableLayoutAllocator.Get<ResourceTableLayout_PoolSizes>(id.id);
         for (IndexT i = 0; i < poolSizes.Size(); i++)
         {
             poolSizes[i].descriptorCount *= overallocationSize;
@@ -134,9 +134,9 @@ ResourceTableLayoutAllocTable(const CoreGraphics::ResourceTableLayoutId& id, con
         n_assert(res == VK_SUCCESS);
 
         // add to list of pools, and set new pointer to the new pool
-        resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id24).Append(pool);
+        resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id).Append(pool);
         freeItems.Append(overallocationSize);
-        outIndex = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id24).Size() - 1;
+        outIndex = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id).Size() - 1;
     }
 
     VkDescriptorSetAllocateInfo dsetAlloc =
@@ -161,10 +161,10 @@ ResourceTableLayoutAllocTable(const CoreGraphics::ResourceTableLayoutId& id, con
 void
 ResourceTableLayoutDeallocTable(const CoreGraphics::ResourceTableLayoutId& id, const VkDevice dev, const VkDescriptorSet& set, const IndexT index)
 {
-    VkDescriptorPool& pool = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id24)[index];
+    VkDescriptorPool& pool = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id)[index];
     VkResult res = vkFreeDescriptorSets(dev, pool, 1, &set);
     n_assert(res == VK_SUCCESS);
-    resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPoolFreeItems>(id.id24)[index]++;
+    resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPoolFreeItems>(id.id)[index]++;
 }
 
 //------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ ResourceTableLayoutDeallocTable(const CoreGraphics::ResourceTableLayoutId& id, c
 const VkDescriptorPool&
 ResourceTableLayoutGetVkDescriptorPool(const CoreGraphics::ResourceTableLayoutId& id, const IndexT index)
 {
-    return resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id24)[index];
+    return resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id)[index];
 }
 
 //------------------------------------------------------------------------------
@@ -182,7 +182,7 @@ ResourceTableLayoutGetVkDescriptorPool(const CoreGraphics::ResourceTableLayoutId
 uint*
 ResourceTableLayoutGetFreeItemsCounter(const CoreGraphics::ResourceTableLayoutId& id, const IndexT index)
 {
-    Util::Array<uint>& freeItems = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPoolFreeItems>(id.id24);
+    Util::Array<uint>& freeItems = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPoolFreeItems>(id.id);
     return &freeItems[index];
 }
 
@@ -192,7 +192,7 @@ ResourceTableLayoutGetFreeItemsCounter(const CoreGraphics::ResourceTableLayoutId
 const VkPipelineLayout&
 ResourcePipelineGetVk(const CoreGraphics::ResourcePipelineId& id)
 {
-    return resourcePipelineAllocator.Get<1>(id.id24);
+    return resourcePipelineAllocator.Get<1>(id.id);
 }
 
 } // namespace Vulkan
@@ -223,9 +223,7 @@ CreateResourceTable(const ResourceTableCreateInfo& info)
     layout = info.layout;
     ResourceTableLayoutAllocTable(layout, dev, info.overallocationSize, poolIndex, set);
 
-    ResourceTableId ret;
-    ret.id24 = id;
-    ret.id8 = ResourceTableIdType;
+    ResourceTableId ret = id;
     return ret;
 }
 
@@ -238,7 +236,7 @@ DestroyResourceTable(const ResourceTableId id)
     n_assert(id != InvalidResourceTableId);
     CoreGraphics::DelayedDeleteDescriptorSet(id);
 
-    resourceTableAllocator.Dealloc(id.id24);
+    resourceTableAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -247,7 +245,7 @@ DestroyResourceTable(const ResourceTableId id)
 const ResourceTableLayoutId&
 ResourceTableGetLayout(ResourceTableId id)
 {
-    return resourceTableAllocator.Get<ResourceTable_Layout>(id.id24);
+    return resourceTableAllocator.Get<ResourceTable_Layout>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -256,12 +254,12 @@ ResourceTableGetLayout(ResourceTableId id)
 void
 ResourceTableCopy(const ResourceTableId from, IndexT fromSlot, IndexT fromIndex, const ResourceTableId to, IndexT toSlot, IndexT toIndex, const SizeT numResources)
 {
-    VkDescriptorSet& fromSet = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(from.id24);
-    VkDescriptorSet& toSet = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(to.id24);
+    VkDescriptorSet& fromSet = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(from.id);
+    VkDescriptorSet& toSet = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(to.id);
 
-    Threading::SpinlockScope scope1(&resourceTableAllocator.Get<ResourceTable_Lock>(from.id24));
-    Threading::SpinlockScope scope2(&resourceTableAllocator.Get<ResourceTable_Lock>(to.id24));
-    Util::Array<VkCopyDescriptorSet>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(to.id24);
+    Threading::SpinlockScope scope1(&resourceTableAllocator.Get<ResourceTable_Lock>(from.id));
+    Threading::SpinlockScope scope2(&resourceTableAllocator.Get<ResourceTable_Lock>(to.id));
+    Util::Array<VkCopyDescriptorSet>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(to.id);
 
     VkCopyDescriptorSet copy =
     {
@@ -284,10 +282,10 @@ ResourceTableCopy(const ResourceTableId from, IndexT fromSlot, IndexT fromIndex,
 void
 ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTexture& tex)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -295,8 +293,8 @@ ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTexture& te
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     write.pNext = nullptr;
 
-    const CoreGraphics::ResourceTableLayoutId& layout = resourceTableAllocator.Get<ResourceTable_Layout>(id.id24);
-    const Util::HashTable<uint32_t, bool>& immutable = resourceTableLayoutAllocator.Get<ResourceTableLayout_ImmutableSamplerFlags>(layout.id24);
+    const CoreGraphics::ResourceTableLayoutId& layout = resourceTableAllocator.Get<ResourceTable_Layout>(id.id);
+    const Util::HashTable<uint32_t, bool>& immutable = resourceTableLayoutAllocator.Get<ResourceTableLayout_ImmutableSamplerFlags>(layout.id);
 
     VkDescriptorImageInfo img;
     if (immutable[tex.slot])
@@ -341,10 +339,10 @@ ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTexture& te
 void 
 ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTextureView& tex)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -352,8 +350,8 @@ ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTextureView
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     write.pNext = nullptr;
 
-    const CoreGraphics::ResourceTableLayoutId& layout = resourceTableAllocator.Get<ResourceTable_Layout>(id.id24);
-    const Util::HashTable<uint32_t, bool>& immutable = resourceTableLayoutAllocator.Get<ResourceTableLayout_ImmutableSamplerFlags>(layout.id24);
+    const CoreGraphics::ResourceTableLayoutId& layout = resourceTableAllocator.Get<ResourceTable_Layout>(id.id);
+    const Util::HashTable<uint32_t, bool>& immutable = resourceTableLayoutAllocator.Get<ResourceTableLayout_ImmutableSamplerFlags>(layout.id);
 
     VkDescriptorImageInfo img;
     if (immutable[tex.slot])
@@ -396,10 +394,10 @@ ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTextureView
 void
 ResourceTableSetInputAttachment(const ResourceTableId id, const ResourceTableInputAttachment& tex)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -436,10 +434,10 @@ ResourceTableSetInputAttachment(const ResourceTableId id, const ResourceTableInp
 void
 ResourceTableSetRWTexture(const ResourceTableId id, const ResourceTableTexture& tex)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -476,10 +474,10 @@ ResourceTableSetRWTexture(const ResourceTableId id, const ResourceTableTexture& 
 void 
 ResourceTableSetRWTexture(const ResourceTableId id, const ResourceTableTextureView& tex)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -517,10 +515,10 @@ void
 ResourceTableSetConstantBuffer(const ResourceTableId id, const ResourceTableBuffer& buf)
 {
     n_assert(!buf.texelBuffer);
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(buf.slot != InvalidIndex);
 
@@ -564,10 +562,10 @@ ResourceTableSetConstantBuffer(const ResourceTableId id, const ResourceTableBuff
 void 
 ResourceTableSetRWBuffer(const ResourceTableId id, const ResourceTableBuffer& buf)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(buf.slot != InvalidIndex);
 
@@ -610,10 +608,10 @@ ResourceTableSetRWBuffer(const ResourceTableId id, const ResourceTableBuffer& bu
 void
 ResourceTableSetSampler(const ResourceTableId id, const ResourceTableSampler& samp)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(samp.slot != InvalidIndex);
 
@@ -650,10 +648,10 @@ ResourceTableSetSampler(const ResourceTableId id, const ResourceTableSampler& sa
 void
 ResourceTableSetAccelerationStructure(const ResourceTableId id, const ResourceTableTlas& tlas)
 {
-    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id24);
+    VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tlas.slot != InvalidIndex);
 
@@ -694,10 +692,10 @@ ResourceTableCommitChanges(const ResourceTableId id)
     n_assert(!ResourceTableBlocked);
 
     // resource tables are blocked, add to pending write queue
-    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id24));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id24);
-    Util::Array<VkCopyDescriptorSet>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(id.id24);
-    VkDevice& dev = resourceTableAllocator.Get<ResourceTable_Device>(id.id24);
+    Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
+    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<VkCopyDescriptorSet>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(id.id);
+    VkDevice& dev = resourceTableAllocator.Get<ResourceTable_Device>(id.id);
 
     // because we store the write-infos in the other list, and the VkWriteDescriptorSet wants a pointer to the structure
     // we need to re-assign the pointers, but thankfully they have values from before
@@ -1075,10 +1073,7 @@ CreateResourceTableLayout(const ResourceTableLayoutCreateInfo& info)
         n_assert(res == VK_SUCCESS);
     }
 
-    ResourceTableLayoutId ret;
-    ret.id24 = id;
-    ret.id8 = ResourceTableLayoutIdType;
-
+    ResourceTableLayoutId ret = id;
     return ret;
 }
 
@@ -1088,18 +1083,18 @@ CreateResourceTableLayout(const ResourceTableLayoutCreateInfo& info)
 void
 DestroyResourceTableLayout(const ResourceTableLayoutId& id)
 {
-    VkDevice& dev = resourceTableLayoutAllocator.Get<ResourceTableLayout_Device>(id.id24);
-    VkDescriptorSetLayout& layout = resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(id.id24);
+    VkDevice& dev = resourceTableLayoutAllocator.Get<ResourceTableLayout_Device>(id.id);
+    VkDescriptorSetLayout& layout = resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(id.id);
     vkDestroyDescriptorSetLayout(dev, layout, nullptr);
 
     // destroy all pools
-    Util::Array<VkDescriptorPool>& pools = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id24);
+    Util::Array<VkDescriptorPool>& pools = resourceTableLayoutAllocator.Get<ResourceTableLayout_DescriptorPools>(id.id);
     for (IndexT i = 0; i < pools.Size(); i++)
         vkDestroyDescriptorPool(dev, pools[i], nullptr);
 
     pools.Clear();
 
-    resourceTableLayoutAllocator.Dealloc(id.id24);
+    resourceTableLayoutAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -1123,7 +1118,7 @@ CreateResourcePipeline(const ResourcePipelineCreateInfo& info)
         {
             layouts.Append(EmptySetLayout);
         }
-        layouts.Append(resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(info.tables[i].id24));
+        layouts.Append(resourceTableLayoutAllocator.Get<ResourceTableLayout_SetLayout>(info.tables[i].id));
     }
 
     VkPushConstantRange push;
@@ -1144,9 +1139,7 @@ CreateResourcePipeline(const ResourcePipelineCreateInfo& info)
     VkResult res = vkCreatePipelineLayout(dev, &crInfo, nullptr, &layout);
     n_assert(res == VK_SUCCESS);
 
-    ResourcePipelineId ret;
-    ret.id24 = id;
-    ret.id8 = ResourcePipelineIdType;
+    ResourcePipelineId ret = id;
     return ret;
 }
 
@@ -1156,11 +1149,11 @@ CreateResourcePipeline(const ResourcePipelineCreateInfo& info)
 void
 DestroyResourcePipeline(const ResourcePipelineId& id)
 {
-    VkDevice& dev = resourcePipelineAllocator.Get<0>(id.id24);
-    VkPipelineLayout& layout = resourcePipelineAllocator.Get<1>(id.id24);
+    VkDevice& dev = resourcePipelineAllocator.Get<0>(id.id);
+    VkPipelineLayout& layout = resourcePipelineAllocator.Get<1>(id.id);
     vkDestroyPipelineLayout(dev, layout, nullptr);
 
-    resourcePipelineAllocator.Dealloc(id.id24);
+    resourcePipelineAllocator.Dealloc(id.id);
 }
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/vk/vksampler.cc
+++ b/code/render/coregraphics/vk/vksampler.cc
@@ -17,7 +17,7 @@ VkSamplerAllocator samplerAllocator;
 const VkSampler&
 SamplerGetVk(const CoreGraphics::SamplerId& id)
 {
-    return samplerAllocator.Get<1>(id.id24);
+    return samplerAllocator.Get<1>(id.id);
 }
 
 } // namespace Vulkan
@@ -262,16 +262,12 @@ CreateSampler(const SamplerCreateInfo& info)
 
         UniqueSamplerHashes.Add(hash, id);
 
-        SamplerId ret;
-        ret.id24 = id;
-        ret.id8 = SamplerIdType;
+        SamplerId ret = id;
         return ret;
     }
     else
     {
-        SamplerId ret;
-        ret.id24 = UniqueSamplerHashes.ValueAtIndex(i);
-        ret.id8 = SamplerIdType;
+        SamplerId ret = UniqueSamplerHashes.ValueAtIndex(i);
         return ret;
     }
 }
@@ -282,12 +278,12 @@ CreateSampler(const SamplerCreateInfo& info)
 void
 DestroySampler(const SamplerId& id)
 {
-    UniqueSamplerHashes.Erase(samplerAllocator.Get<2>(id.id24));
-    VkDevice& dev = samplerAllocator.Get<0>(id.id24);
-    VkSampler& sampler = samplerAllocator.Get<1>(id.id24);
+    UniqueSamplerHashes.Erase(samplerAllocator.Get<2>(id.id));
+    VkDevice& dev = samplerAllocator.Get<0>(id.id);
+    VkSampler& sampler = samplerAllocator.Get<1>(id.id);
     vkDestroySampler(dev, sampler, nullptr);
 
-    samplerAllocator.Dealloc(id.id24);
+    samplerAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------

--- a/code/render/coregraphics/vk/vksemaphore.cc
+++ b/code/render/coregraphics/vk/vksemaphore.cc
@@ -22,7 +22,7 @@ VkSemaphore
 SemaphoreGetVk(const CoreGraphics::SemaphoreId& id)
 {
     if (id == CoreGraphics::SemaphoreId::Invalid()) return VK_NULL_HANDLE;
-    else                                            return semaphoreAllocator.Get<Semaphore_VkHandle>(id.id24);
+    else                                            return semaphoreAllocator.Get<Semaphore_VkHandle>(id.id);
 }
 }
 
@@ -58,9 +58,7 @@ CreateSemaphore(const SemaphoreCreateInfo& info)
     VkResult res = vkCreateSemaphore(dev, &cinfo, nullptr, &semaphoreAllocator.Get<Semaphore_VkHandle>(id));
     n_assert(res == VK_SUCCESS);
 
-    SemaphoreId ret;
-    ret.id24 = id;
-    ret.id8 = SemaphoreIdType;
+    SemaphoreId ret = id;
     return ret;
 }
 
@@ -70,8 +68,8 @@ CreateSemaphore(const SemaphoreCreateInfo& info)
 void
 DestroySemaphore(const SemaphoreId& semaphore)
 {
-    vkDestroySemaphore(semaphoreAllocator.Get<Semaphore_Device>(semaphore.id24), semaphoreAllocator.Get<Semaphore_VkHandle>(semaphore.id24), nullptr);
-    semaphoreAllocator.Dealloc(semaphore.id24);
+    vkDestroySemaphore(semaphoreAllocator.Get<Semaphore_Device>(semaphore.id), semaphoreAllocator.Get<Semaphore_VkHandle>(semaphore.id), nullptr);
+    semaphoreAllocator.Dealloc(semaphore.id);
 }
 
 //------------------------------------------------------------------------------
@@ -80,7 +78,7 @@ DestroySemaphore(const SemaphoreId& semaphore)
 uint64 
 SemaphoreGetValue(const SemaphoreId& semaphore)
 {
-    return semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id24);
+    return semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id);
 }
 
 //------------------------------------------------------------------------------
@@ -89,13 +87,13 @@ SemaphoreGetValue(const SemaphoreId& semaphore)
 void 
 SemaphoreSignal(const SemaphoreId& semaphore)
 {
-    switch (semaphoreAllocator.Get<Semaphore_Type>(semaphore.id24))
+    switch (semaphoreAllocator.Get<Semaphore_Type>(semaphore.id))
     {
     case SemaphoreType::Binary:
-        semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id24) = 1;
+        semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id) = 1;
         break;
     case SemaphoreType::Timeline:
-        semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id24)++;
+        semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id)++;
         break;
     }
 }
@@ -106,10 +104,10 @@ SemaphoreSignal(const SemaphoreId& semaphore)
 void 
 SemaphoreReset(const SemaphoreId& semaphore)
 {
-    switch (semaphoreAllocator.Get<Semaphore_Type>(semaphore.id24))
+    switch (semaphoreAllocator.Get<Semaphore_Type>(semaphore.id))
     {
     case SemaphoreType::Binary:
-        semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id24) = 0;
+        semaphoreAllocator.Get<Semaphore_LastIndex>(semaphore.id) = 0;
         break;
     default: n_error("unhandled enum"); break;
     }

--- a/code/render/coregraphics/vk/vkshaderserver.cc
+++ b/code/render/coregraphics/vk/vkshaderserver.cc
@@ -98,7 +98,7 @@ VkShaderServer::UpdateResources()
         const _PendingView& pend = pendingViewsThisFrame[i];
 
         TextureIdLock _0(pend.tex);
-        VkTextureRuntimeInfo& info = textureAllocator.Get<Texture_RuntimeInfo>(pend.tex.resourceId);
+        VkTextureRuntimeInfo& info = textureAllocator.Get<Texture_RuntimeInfo>(pend.tex.id);
         VkImageView oldView = info.view;
         VkResult res = vkCreateImageView(GetCurrentDevice(), &pend.createInfo, nullptr, &info.view);
         n_assert(res == VK_SUCCESS);

--- a/code/render/coregraphics/vk/vktextureview.cc
+++ b/code/render/coregraphics/vk/vktextureview.cc
@@ -22,7 +22,7 @@ VkTextureViewAllocator textureViewAllocator(0x00FFFFFF);
 const VkImageView 
 TextureViewGetVk(const TextureViewId id)
 {
-    return textureViewAllocator.Get<TextureView_RuntimeInfo>(id.id24).view;
+    return textureViewAllocator.Get<TextureView_RuntimeInfo>(id.id).view;
 }
 
 //------------------------------------------------------------------------------
@@ -31,7 +31,7 @@ TextureViewGetVk(const TextureViewId id)
 const VkDevice
 TextureViewGetVkDevice(const CoreGraphics::TextureViewId id)
 {
-    return textureViewAllocator.Get<TextureView_LoadInfo>(id.id24).dev;
+    return textureViewAllocator.Get<TextureView_LoadInfo>(id.id).dev;
 }
 
 } // namespace Vulkan
@@ -92,9 +92,7 @@ CreateTextureView(const TextureViewCreateInfo& info)
     VkResult stat = vkCreateImageView(loadInfo.dev, &viewCreate, nullptr, &runtimeInfo.view);
     n_assert(stat == VK_SUCCESS);
 
-    TextureViewId ret;
-    ret.id24 = id;
-    ret.id8 = TextureViewIdType;
+    TextureViewId ret = id;
 
 #if NEBULA_GRAPHICS_DEBUG
     ObjectSetName(ret, info.name.Value());
@@ -109,10 +107,10 @@ CreateTextureView(const TextureViewCreateInfo& info)
 void 
 DestroyTextureView(const TextureViewId id)
 {
-    //VkTextureViewLoadInfo& loadInfo = textureViewAllocator.Get<TextureView_LoadInfo>(id.id24);
-    //VkTextureViewRuntimeInfo& runtimeInfo = textureViewAllocator.Get<TextureView_RuntimeInfo>(id.id24);
+    //VkTextureViewLoadInfo& loadInfo = textureViewAllocator.Get<TextureView_LoadInfo>(id.id);
+    //VkTextureViewRuntimeInfo& runtimeInfo = textureViewAllocator.Get<TextureView_RuntimeInfo>(id.id);
     CoreGraphics::DelayedDeleteTextureView(id);
-    textureViewAllocator.Dealloc(id.id24);
+    textureViewAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -121,8 +119,8 @@ DestroyTextureView(const TextureViewId id)
 void
 TextureViewReload(const TextureViewId id)
 {
-    VkTextureViewRuntimeInfo& runtimeInfo = textureViewAllocator.Get<TextureView_RuntimeInfo>(id.id24);
-    VkTextureViewLoadInfo& loadInfo = textureViewAllocator.Get<TextureView_LoadInfo>(id.id24);
+    VkTextureViewRuntimeInfo& runtimeInfo = textureViewAllocator.Get<TextureView_RuntimeInfo>(id.id);
+    VkTextureViewLoadInfo& loadInfo = textureViewAllocator.Get<TextureView_LoadInfo>(id.id);
 
     // First destroy the old view
     CoreGraphics::DelayedDeleteTextureView(id);
@@ -166,7 +164,7 @@ TextureViewReload(const TextureViewId id)
 TextureId
 TextureViewGetTexture(const TextureViewId id)
 {
-    VkTextureViewLoadInfo& loadInfo = textureViewAllocator.Get<TextureView_LoadInfo>(id.id24);
+    VkTextureViewLoadInfo& loadInfo = textureViewAllocator.Get<TextureView_LoadInfo>(id.id);
     return loadInfo.tex;
 }
 

--- a/code/render/coregraphics/vk/vkvertexlayout.cc
+++ b/code/render/coregraphics/vk/vkvertexlayout.cc
@@ -20,7 +20,7 @@ VkPipelineVertexInputStateCreateInfo*
 VertexLayoutGetDerivative(const CoreGraphics::VertexLayoutId layout, const CoreGraphics::ShaderProgramId shader)
 {
     Threading::CriticalScope scope(&vertexSignatureMutex);
-    Util::HashTable<uint64_t, DerivativeLayout>& hashTable = vertexLayoutAllocator.Get<VertexSignature_ProgramLayoutMapping>(layout.resourceId);
+    Util::HashTable<uint64_t, DerivativeLayout>& hashTable = vertexLayoutAllocator.Get<VertexSignature_ProgramLayoutMapping>(layout.id);
     const Ids::Id64 shaderHash = shader.HashCode64();
 
     IndexT i = hashTable.FindIndex(shaderHash);
@@ -31,8 +31,8 @@ VertexLayoutGetDerivative(const CoreGraphics::VertexLayoutId layout, const CoreG
     else
     {
         const VkProgramReflectionInfo& program = ShaderGetProgramReflection(shader);
-        const BindInfo& bindInfo = vertexLayoutAllocator.Get<VertexSignature_BindInfo>(layout.resourceId);
-        const VkPipelineVertexInputStateCreateInfo& baseInfo = vertexLayoutAllocator.Get<VertexSignature_VkPipelineInfo>(layout.resourceId);
+        const BindInfo& bindInfo = vertexLayoutAllocator.Get<VertexSignature_BindInfo>(layout.id);
+        const VkPipelineVertexInputStateCreateInfo& baseInfo = vertexLayoutAllocator.Get<VertexSignature_VkPipelineInfo>(layout.id);
 
         IndexT index = hashTable.Add(shaderHash, {});
         DerivativeLayout& layout = hashTable.ValueAtIndex(shaderHash, index);
@@ -70,7 +70,7 @@ const VertexLayoutVkBindInfo&
 VertexLayoutGetVkBindInfo(const CoreGraphics::VertexLayoutId layout)
 {
     Threading::CriticalScope scope(&vertexSignatureMutex);
-    return vertexLayoutAllocator.Get<VertexSignature_DynamicBindInfo>(layout.resourceId);
+    return vertexLayoutAllocator.Get<VertexSignature_DynamicBindInfo>(layout.id);
 }
 
 } // namespace Vulkan
@@ -193,9 +193,7 @@ CreateVertexLayout(const VertexLayoutCreateInfo& info)
         .pVertexAttributeDescriptions = bindInfo.attrs.Begin()
     };
 
-    VertexLayoutId ret;
-    ret.resourceId = id;
-    ret.resourceType = VertexLayoutIdType;
+    VertexLayoutId ret = id;
     return ret;
 }
 
@@ -205,7 +203,7 @@ CreateVertexLayout(const VertexLayoutCreateInfo& info)
 void
 DestroyVertexLayout(const VertexLayoutId id)
 {
-    vertexLayoutAllocator.Dealloc(id.resourceId);
+    vertexLayoutAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -214,7 +212,7 @@ DestroyVertexLayout(const VertexLayoutId id)
 const SizeT
 VertexLayoutGetSize(const VertexLayoutId id)
 {
-    return vertexLayoutAllocator.Get<VertexSignature_LayoutInfo>(id.resourceId).vertexByteSize;
+    return vertexLayoutAllocator.Get<VertexSignature_LayoutInfo>(id.id).vertexByteSize;
 }
 
 //------------------------------------------------------------------------------
@@ -223,7 +221,7 @@ VertexLayoutGetSize(const VertexLayoutId id)
 const SizeT
 VertexLayoutGetStreamSize(const VertexLayoutId id, IndexT stream)
 {
-    return vertexLayoutAllocator.Get<VertexSignature_StreamSize>(id.resourceId)[stream];
+    return vertexLayoutAllocator.Get<VertexSignature_StreamSize>(id.id)[stream];
 }
 
 //------------------------------------------------------------------------------
@@ -232,7 +230,7 @@ VertexLayoutGetStreamSize(const VertexLayoutId id, IndexT stream)
 const Util::Array<VertexComponent>&
 VertexLayoutGetComponents(const VertexLayoutId id)
 {
-    return vertexLayoutAllocator.Get<VertexSignature_LayoutInfo>(id.resourceId).comps;
+    return vertexLayoutAllocator.Get<VertexSignature_LayoutInfo>(id.id).comps;
 }
 
 } // namespace Vulkan

--- a/code/render/frame/framescript.cc
+++ b/code/render/frame/framescript.cc
@@ -274,7 +274,7 @@ FrameScript::Build()
         {
             CoreGraphics::BarrierCreateInfo inf =
             {
-                Util::String::Sprintf("End of Frame Texture Reset Transition %d", tex.resourceId),
+                Util::String::Sprintf("End of Frame Texture Reset Transition %d", tex.id),
                 CoreGraphics::BarrierDomain::Global,
                 fromStage,
                 toStage,

--- a/code/render/graphics/graphicscontext.h
+++ b/code/render/graphics/graphicscontext.h
@@ -186,16 +186,15 @@ inline void
 GraphicsContext::InternalDefragment(ID_ALLOCATOR& allocator, Graphics::GraphicsContextState&& state)
 {
     auto& freeIds = allocator.FreeIds();
-    uint32_t index;
-    uint32_t oldIndex;
+    Ids::Id32 index;
+    Ids::Id32 oldIndex;
     Graphics::GraphicsEntityId lastId;
     IndexT mapIndex;
     uint32_t dataSize;
     SizeT size = freeIds.Size();
     for (SizeT i = size - 1; i >= 0; --i)
     {
-        index = freeIds.Back();
-        freeIds.EraseBack();
+        index = freeIds.Dequeue();
         dataSize = (uint32_t)allocator.Size();
         if (index >= dataSize)
         {
@@ -214,7 +213,7 @@ GraphicsContext::InternalDefragment(ID_ALLOCATOR& allocator, Graphics::GraphicsC
         }
         else
         {
-            freeIds.Append(index);
+            freeIds.Enqueue(index);
             i++;
         }
     }

--- a/code/render/graphics/graphicsserver.cc
+++ b/code/render/graphics/graphicsserver.cc
@@ -287,7 +287,7 @@ GraphicsServer::OnWindowResized(CoreGraphics::WindowId wndId)
     {
         if (this->contexts[i]->OnWindowResized != nullptr)
         {
-            this->contexts[i]->OnWindowResized(wndId.id24, mode.GetWidth(), mode.GetHeight());
+            this->contexts[i]->OnWindowResized(wndId.id, mode.GetWidth(), mode.GetHeight());
         }
     }
 }

--- a/code/render/materials/material.h
+++ b/code/render/materials/material.h
@@ -31,7 +31,7 @@ struct ShaderConfigBatchConstant;
 struct ShaderConfigBatchTexture;
 
 RESOURCE_ID_TYPE(MaterialId);
-ID_32_24_8_NAMED_TYPE(MaterialInstanceId, instance, materialId, materialType); // 32 bits instance, 24 bits material, 8 bits type
+ID_32_24_8_NAMED_TYPE(MaterialInstanceId, instance, materialId, materialGeneration, material); // 32 bits instance, 24 bits material, 8 bits type
 
 typedef IndexT BatchIndex;
 

--- a/code/render/materials/materialloader.cc
+++ b/code/render/materials/materialloader.cc
@@ -649,9 +649,7 @@ MaterialLoader::RegisterTerrainMaterial(const MaterialInterface::TerrainMaterial
 void
 MaterialLoader::Unload(const Resources::ResourceId id)
 {
-    MaterialId material;
-    material.resourceId = id.resourceId;
-    material.resourceType = id.resourceType;
+    MaterialId material = id.resource;
     DestroyMaterial(material);
 }
 

--- a/code/render/models/model.cc
+++ b/code/render/models/model.cc
@@ -20,9 +20,7 @@ CreateModel(const ModelCreateInfo& info)
     modelAllocator.Set<Model_BoundingBox>(id, info.boundingBox);
     modelAllocator.Set<Model_Nodes>(id, info.nodes);
 
-    ModelId ret;
-    ret.resourceId = id;
-    ret.resourceType = CoreGraphics::ModelIdType;
+    ModelId ret = id;
     return ret;
 }
 
@@ -32,8 +30,8 @@ CreateModel(const ModelCreateInfo& info)
 void
 DestroyModel(const ModelId id)
 {
-    modelAllocator.Get<Model_Nodes>(id.resourceId).Clear();
-    modelAllocator.Dealloc(id.resourceId);
+    modelAllocator.Get<Model_Nodes>(id.id).Clear();
+    modelAllocator.Dealloc(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -42,7 +40,7 @@ DestroyModel(const ModelId id)
 const Util::Array<Models::ModelNode*>&
 ModelGetNodes(const ModelId id)
 {
-    return modelAllocator.Get<Model_Nodes>(id.resourceId);
+    return modelAllocator.Get<Model_Nodes>(id.id);
 }
 
 //------------------------------------------------------------------------------
@@ -51,7 +49,7 @@ ModelGetNodes(const ModelId id)
 const Math::bbox&
 ModelGetBoundingBox(const ModelId id)
 {
-    return modelAllocator.Get<Model_BoundingBox>(id.resourceId);
+    return modelAllocator.Get<Model_BoundingBox>(id.id);
 }
 
 } // namespace Models

--- a/code/render/models/modelloader.cc
+++ b/code/render/models/modelloader.cc
@@ -178,9 +178,7 @@ ModelLoader::InitializeResource(Ids::Id32 entry, const Util::StringAtom& tag, co
 void
 ModelLoader::Unload(const Resources::ResourceId id)
 {
-    ModelId model;
-    model.resourceId = id.resourceId;
-    model.resourceType = id.resourceType;
+    ModelId model = id.resource;
     const Util::Array<Models::ModelNode*>& nodes = ModelGetNodes(model);
 
     // unload nodes

--- a/code/resource/resources/resourceid.h
+++ b/code/resource/resources/resourceid.h
@@ -27,20 +27,22 @@
 #include "util/stringatom.h"
 #include "ids/id.h"
 #include "core/debug.h"
+#include "ids/idgenerationpool.h"
 namespace Resources
 {
 typedef Util::StringAtom ResourceName;
-ID_24_8_24_8_NAMED_TYPE(ResourceId, loaderInstanceId, loaderIndex, resourceId, resourceType);               // 24 bits: loader resource id, 8 bits: loader index, 24 bits: unique resource id, 8 bits: resource type
+ID_24_8_24_8_NAMED_TYPE(ResourceId, loaderInstanceId, loaderIndex, resourceId, generation, loader, resource);               // 24 bits: loader resource id, 8 bits: loader index, 24 bits: unique resource id, 8 bits: generation
 
 // define a generic typed ResourceId, this is so we can have specialized allocators, but have a common pool implementation...
-ID_24_8_NAMED_TYPE(ResourceUnknownId, resourceId, resourceType);
+ID_24_8_NAMED_TYPE(ResourceUnknownId, resourceId, generation, id);
 
 } // namespace Resource
 
 #define RESOURCE_ID_TYPE(type) struct type : public Resources::ResourceUnknownId { \
         constexpr type() {};\
         constexpr type(const Resources::ResourceUnknownId& res) : Resources::ResourceUnknownId(res) {};\
-        constexpr type(const Resources::ResourceId& res) : Resources::ResourceUnknownId(res.resourceId, res.resourceType) {};\
-        constexpr type(const Ids::Id24 id, const Ids::Id8 type) : Resources::ResourceUnknownId(id, type) {};\
+        constexpr type(const Resources::ResourceId& res) : Resources::ResourceUnknownId(res.resourceId, res.generation) {};\
+        constexpr type(const Ids::Id24 id, const Ids::Id8 generation) : Resources::ResourceUnknownId(id, generation) {};\
+        constexpr type(const Ids::Id32 id) : Resources::ResourceUnknownId(Ids::Index(id), Ids::Generation(id)) {};\
     }; \
     static constexpr type Invalid##type = Resources::InvalidResourceUnknownId;

--- a/code/resource/resources/resourceloader.cc
+++ b/code/resource/resources/resourceloader.cc
@@ -216,16 +216,16 @@ ResourceLoader::SetupIdFromEntry(const Ids::Id32 entry, ResourceId& cacheEntry)
     {
         case Resource::State::Loaded:
             cacheEntry.resourceId = this->resources[entry].resourceId;
-            cacheEntry.resourceType = this->resources[entry].resourceType;
+            cacheEntry.generation = this->resources[entry].generation;
             break;
         case Resource::State::Failed:
             cacheEntry.resourceId = this->failResourceId.resourceId;
-            cacheEntry.resourceType = this->failResourceId.resourceType;
+            cacheEntry.generation = this->failResourceId.generation;
             break;
         case Resource::State::Pending:
         case Resource::State::Unloaded:
             cacheEntry.resourceId = this->placeholderResourceId.resourceId;
-            cacheEntry.resourceType = this->placeholderResourceId.resourceType;
+            cacheEntry.generation = this->placeholderResourceId.generation;
             break;
     }
 }
@@ -291,7 +291,7 @@ _LoadInternal(ResourceLoader* loader, const ResourceLoader::_PendingResourceLoad
             // If new resource, initialize it
             ResourceUnknownId internalResource = loader->InitializeResource(res.entry, res.tag, stream, res.immediate);
             resource.resourceId = internalResource.resourceId;
-            resource.resourceType = internalResource.resourceType;
+            resource.generation = internalResource.generation;
             requestedBits = loader->LodMask(res.entry, res.lod, !res.immediate);
 
             if (res.immediate)
@@ -314,7 +314,7 @@ _LoadInternal(ResourceLoader* loader, const ResourceLoader::_PendingResourceLoad
                 // If the initialize failed, it means the file is invalid or can't be found
                 state = Resource::Failed;
                 resource.resourceId = loader->failResourceId.resourceId;
-                resource.resourceType = loader->failResourceId.resourceType;
+                resource.generation = loader->failResourceId.generation;
                 n_printf("[RESOURCE LOADER] Failed to load resource %s\n", loader->names[res.entry].Value());
                 goto skip_stream;
             }
@@ -322,7 +322,7 @@ _LoadInternal(ResourceLoader* loader, const ResourceLoader::_PendingResourceLoad
         else
         {
             resource.resourceId = loader->failResourceId.resourceId;
-            resource.resourceType = loader->failResourceId.resourceType;
+            resource.generation = loader->failResourceId.generation;
             n_printf("[RESOURCE LOADER] Failed to open resource %s\n", loader->names[res.entry].Value());
             state = Resource::Failed;
             goto skip_stream;


### PR DESCRIPTION
Remove the silly IDs where we store the 'type' in the last 8 bits. We already have structs for the types, so we could use those bit for generations to provide better validation. 