### PR TITLE
Added a resource browser to the editor

### DIFF
--- a/code/render/coregraphics/pixelformat.cc
+++ b/code/render/coregraphics/pixelformat.cc
@@ -91,9 +91,12 @@ PixelFormat::ToString(PixelFormat::Code code)
         case DXT5:          return "DXT5";
         case DXT5sRGB:      return "DXT5 sRGB";
         case BC4:           return "BC4";
+        case BC5:           return "BC5";
         case BC7:           return "BC7";
         case BC7sRGB:       return "BC7 sRGB";
         case R8:            return "R8";
+        case R16F:          return "R16F";
+        case R16:           return "R16";
         case R16G16F:       return "R16G16F";
         case R16G16:        return "R16G16";
         case R16G16B16A16F: return "R16G16B16A16F";
@@ -147,6 +150,7 @@ PixelFormat::ToSize(Code code)
     case R32:
     case R10G10B10X2:
     case R10G10B10A2:
+    case R11G11B10F:
     case D24X8:
     case D24S8:
         return 4;

--- a/code/render/coregraphics/texture.cc
+++ b/code/render/coregraphics/texture.cc
@@ -23,6 +23,9 @@ TextureId Red2D;
 TextureId Green2D;
 TextureId Blue2D;
 
+#ifdef WITH_NEBULA_EDITOR
+Util::Array<CoreGraphics::TextureId> TrackedTextures;
+#endif
 //------------------------------------------------------------------------------
 /**
 */
@@ -196,5 +199,16 @@ TextureGetAdjustedInfo(const TextureCreateInfo& info)
     }
     return rt;
 }
+
+
+//------------------------------------------------------------------------------
+/**
+*/
+const Util::Array<CoreGraphics::TextureId>&
+TextureGetCreated()
+{
+    return TrackedTextures;
+}
+
 
 } // namespace CoreGraphics

--- a/code/render/coregraphics/texture.h
+++ b/code/render/coregraphics/texture.h
@@ -183,6 +183,8 @@ const TextureId CreateTexture(const TextureCreateInfo& info);
 /// destroy vertex buffer
 void DestroyTexture(const TextureId id);
 
+/// Get name of texture
+Util::StringAtom TextureGetName(const TextureId id);
 /// get texture dimensions
 TextureDimensions TextureGetDimensions(const TextureId id);
 /// get texture relative dimensions
@@ -251,6 +253,11 @@ TextureCreateInfoAdjusted TextureGetAdjustedInfo(const TextureCreateInfo& info);
 /// Set highest LOD on texture
 void TextureSetHighestLod(const CoreGraphics::TextureId id, uint lod);
 
+#ifdef WITH_NEBULA_EDITOR
+/// Get all created textures
+const Util::Array<CoreGraphics::TextureId>& TextureGetCreated();
+extern Util::Array<CoreGraphics::TextureId> TrackedTextures;
+#endif
 
 //------------------------------------------------------------------------------
 /**

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -571,6 +571,10 @@ CreateTexture(const TextureCreateInfo& info)
 
     TextureId ret = id;
 
+#ifdef WITH_NEBULA_EDITOR
+    TrackedTextures.Append(ret);
+#endif
+
     Vulkan::VkTextureRuntimeInfo& runtimeInfo = textureAllocator.Get<Vulkan::Texture_RuntimeInfo>(id);
     Vulkan::VkTextureLoadInfo& loadInfo = textureAllocator.Get<Vulkan::Texture_LoadInfo>(id);
 
@@ -706,6 +710,20 @@ DestroyTexture(const TextureId id)
 {
     DeleteTexture(id);
     textureAllocator.Dealloc(id.id);
+
+#ifdef WITH_NEBULA_EDITOR
+    TrackedTextures.EraseIndex(TrackedTextures.FindIndex(id));
+#endif
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+Util::StringAtom
+TextureGetName(const TextureId id)
+{
+    const Vulkan::VkTextureLoadInfo& loadInfo = textureAllocator.Get<Vulkan::Texture_LoadInfo>(id.resourceId);
+    return loadInfo.name;
 }
 
 //------------------------------------------------------------------------------

--- a/code/resource/resources/resourceloader.cc
+++ b/code/resource/resources/resourceloader.cc
@@ -375,8 +375,8 @@ Resource::State
 ResourceLoader::LoadImmediate(_PendingResourceLoad& res)
 {
     // If already loaded, just return
-    if (this->states[res.entry] == Resource::Loaded)
-        return Resource::Loaded;
+    //if (this->states[res.entry] == Resource::Loaded)
+    //    return Resource::Loaded;
 
     return _LoadInternal(this, res);
 }
@@ -414,7 +414,7 @@ Resources::ResourceLoader::CreateResource(const ResourceName& res, const void* l
 
     // Store the file path as ID for the file
     IO::URI path(res.Value());
-    IndexT i = this->ids.FindIndex(path.AsString());
+    IndexT i = this->ids.FindIndex(path.GetHostAndLocalPath());
 
     // Setup return value as placeholder by default
     ResourceId ret = this->placeholderResourceId;
@@ -441,7 +441,7 @@ Resources::ResourceLoader::CreateResource(const ResourceName& res, const void* l
         }
 
         // add the resource name to the resource id
-        this->names[instanceId] = path.AsString();
+        this->names[instanceId] = path.GetHostAndLocalPath();
         this->usage[instanceId] = 1;
         this->tags[instanceId] = tag;
         this->states[instanceId] = Resource::Pending;
@@ -478,7 +478,7 @@ Resources::ResourceLoader::CreateResource(const ResourceName& res, const void* l
         this->loads[instanceId] = pending;
 
         // add mapping between resource name and resource being loaded
-        this->ids.Add(path.AsString(), instanceId);
+        this->ids.Add(path.GetHostAndLocalPath(), instanceId);
 
         if (immediate)
         {
@@ -746,7 +746,11 @@ ResourceLoader::SetMinLod(const Resources::ResourceId& id, const float lod, bool
 {
     if (immediate)
     {
-        this->StreamMaxLOD(id, lod, immediate);
+        _PendingResourceLoad& load = this->loads[id.loaderInstanceId];
+        load.lod = lod;
+        load.mode |= _PendingResourceLoad::Update;
+        load.immediate = immediate;
+        this->LoadImmediate(load);
     }
     else
     {

--- a/toolkit/editor/CMakeLists.txt
+++ b/toolkit/editor/CMakeLists.txt
@@ -89,6 +89,8 @@ fips_dir(editor)
                 history.h
                 outline.cc
                 outline.h
+                resourcebrowser.cc
+                resourcebrowser.h
                 styleeditor.cc
                 styleeditor.h
                 toolbar.cc

--- a/toolkit/editor/editor/ui/uimanager.cc
+++ b/toolkit/editor/editor/ui/uimanager.cc
@@ -15,6 +15,7 @@
 #include "windows/inspector.h"
 #include "windows/assetbrowser.h"
 #include "windows/asseteditor/asseteditor.h"
+#include "windows/resourcebrowser.h"
 #include "coregraphics/texture.h"
 #include "resources/resourceserver.h"
 #include "editor/commandmanager.h"
@@ -62,6 +63,7 @@ OnActivate()
     windowServer->RegisterWindow("Presentation::Inspector", "Inspector");
     windowServer->RegisterWindow("Presentation::AssetBrowser", "Asset Browser");
     windowServer->RegisterWindow("Presentation::AssetEditor", "Asset Editor", "Editor");
+    windowServer->RegisterWindow("Presentation::ResourceBrowser", "Resource Browser", "Resources");
     
     Icons::play          = NLoadIcon("systex:icon_play.dds");
     Icons::pause         = NLoadIcon("systex:icon_pause.dds");

--- a/toolkit/editor/editor/ui/windows/asseteditor/asseteditor.cc
+++ b/toolkit/editor/editor/ui/windows/asseteditor/asseteditor.cc
@@ -135,7 +135,7 @@ AssetEditor::Run(SaveMode save)
                     {
                         item.grabFocus = false;
                         auto& saveFunc = SavingFunctions[(uint)item.assetType];
-                        if (saveFunc)
+                        if (saveFunc && save == SaveMode::SaveActive)
                             saveFunc(this, &item);
 
                         auto& renderFunc = RenderFunctions[(uint)item.assetType];

--- a/toolkit/editor/editor/ui/windows/resourcebrowser.cc
+++ b/toolkit/editor/editor/ui/windows/resourcebrowser.cc
@@ -1,0 +1,136 @@
+//------------------------------------------------------------------------------
+//  @file resourcebrowser.cc
+//  @copyright (C) 2024 Individual contributors, see AUTHORS file
+//------------------------------------------------------------------------------
+#include "foundation/stdneb.h"
+#include "resourcebrowser.h"
+#include "dynui/imguicontext.h"
+
+#include "coregraphics/texture.h"
+namespace Presentation
+{
+__ImplementClass(Presentation::ResourceBrowser, 'RsBw', Presentation::BaseWindow);
+
+//------------------------------------------------------------------------------
+/**
+*/
+ResourceBrowser::ResourceBrowser()
+{
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+ResourceBrowser::~ResourceBrowser()
+{
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
+ResourceBrowser::Update()
+{
+    
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+void 
+ResourceBrowser::Run(SaveMode save)
+{
+    static Dynui::ImguiTextureId selectedTex;
+    ImVec2 size = ImGui::GetContentRegionAvail();
+    if (ImGui::BeginChild("List", ImVec2{ size.x / 2, size.y }, false, ImGuiWindowFlags_NoScrollbar))
+    {
+        static int current = -1;
+        ImGui::PushFont(Dynui::ImguiContext::state.boldFont);
+        ImGui::Text("Textures");
+        ImGui::PopFont();
+        if (ImGui::BeginTable("Textures###Table", 4, ImGuiTableFlags_Resizable | ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY))
+        {
+            ImGui::TableSetupColumn("Name");
+            ImGui::TableSetupColumn("Dimensions");
+            ImGui::TableSetupColumn("Format");
+            ImGui::TableSetupColumn("Size");
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableHeadersRow();
+
+            int counter = 0;
+            for (auto tex : CoreGraphics::TrackedTextures)
+            {
+                ImGui::TableNextColumn();
+                CoreGraphics::TextureIdLock _0(tex);
+                CoreGraphics::TextureDimensions dims = CoreGraphics::TextureGetDimensions(tex);
+                CoreGraphics::PixelFormat::Code format = CoreGraphics::TextureGetPixelFormat(tex);
+
+                bool selected = false;
+                if (ImGui::Selectable(CoreGraphics::TextureGetName(tex).Value(), counter == current, ImGuiSelectableFlags_SpanAllColumns))
+                    current = counter;
+
+                uint byteSize = dims.width * dims.height * dims.depth * CoreGraphics::PixelFormat::ToSize(format);
+                ImGui::TableNextColumn();
+                ImGui::Text(Util::Format("%dx%dx%d", dims.width, dims.height, dims.depth).AsCharPtr());
+                ImGui::TableNextColumn();
+                ImGui::Text(Util::Format("%s", CoreGraphics::PixelFormat::ToString(format).AsCharPtr()).AsCharPtr());
+                ImGui::TableNextColumn();
+                if (byteSize > 1_GB)
+                    ImGui::Text(Util::Format("%.2f GB", byteSize / float(1_GB)).AsCharPtr());
+                else if (byteSize > 1_MB)
+                    ImGui::Text(Util::Format("%.2f MB", byteSize / float(1_MB)).AsCharPtr());
+                else if (byteSize > 1_KB)
+                    ImGui::Text(Util::Format("%.2f KB", byteSize / float(1_KB)).AsCharPtr());
+                else
+                    ImGui::Text(Util::Format("%.2f B", float(byteSize)).AsCharPtr());
+                counter++;
+            }
+            ImGui::EndTable();
+        }
+        ImGui::EndChild();
+
+        ImGui::SameLine();
+
+        if (current != -1)
+        {
+            CoreGraphics::TextureIdLock _0(CoreGraphics::TrackedTextures[current]);
+            selectedTex.nebulaHandle = CoreGraphics::TrackedTextures[current];
+            CoreGraphics::TextureDimensions dims = CoreGraphics::TextureGetDimensions(CoreGraphics::TrackedTextures[current]);
+            float ratio = dims.width / dims.height;
+            ImVec2 remainder = ImGui::GetContentRegionAvail();
+            static int mip = 0, layer = 0;
+            if (ImGui::BeginChild("Preview", ImVec2{ size.x / 2, size.y }))
+            {
+                ImGui::Image(&selectedTex, ImVec2{ (float)remainder.x / 2, (float)remainder.x / 2 * ratio });
+                ImGui::InputInt("Mip", &mip);
+                ImGui::InputInt("Layer", &layer);
+                mip = Math::min(Math::max(0, mip), CoreGraphics::TextureGetNumMips(CoreGraphics::TrackedTextures[current]) - 1);
+                layer = Math::min(Math::max(0, layer), CoreGraphics::TextureGetNumLayers(CoreGraphics::TrackedTextures[current]) - 1);
+                ImGui::EndChild();
+            }
+
+            selectedTex.layer = layer;
+            selectedTex.mip = mip;
+        }
+        else
+        {
+            ImGuiStyle& style = ImGui::GetStyle();
+
+            static const char* EmptyString = "Nothing selected";
+            float sizeX = ImGui::CalcTextSize(EmptyString).x + style.FramePadding.x * 2.0f;
+            float availX = ImGui::GetContentRegionAvail().x;
+            float sizeY = ImGui::CalcTextSize(EmptyString).y + style.FramePadding.y * 2.0f;
+            float availY = ImGui::GetContentRegionAvail().y;
+
+            float off = (availX - sizeX) * 0.5f;
+            if (off > 0.0f)
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off);
+            off = (availY - sizeY) * 0.5f;
+            if (off > 0.0f)
+                ImGui::SetCursorPosY(ImGui::GetCursorPosY() + off);
+            ImGui::Text(EmptyString);
+        }
+    }
+}
+
+} // namespace Presentation

--- a/toolkit/editor/editor/ui/windows/resourcebrowser.h
+++ b/toolkit/editor/editor/ui/windows/resourcebrowser.h
@@ -1,0 +1,29 @@
+#pragma once
+//------------------------------------------------------------------------------
+/**
+    Browser for resources
+
+    @copyright
+    (C) 2024 Individual contributors, see AUTHORS file
+*/
+//------------------------------------------------------------------------------
+#include "editor/ui/window.h"
+
+namespace Presentation
+{
+
+class ResourceBrowser : public BaseWindow
+{
+    __DeclareClass(ResourceBrowser)
+public:
+    ResourceBrowser();
+    ~ResourceBrowser();
+
+    void Update();
+    void Run(SaveMode save) override;
+private:
+};
+
+__RegisterClass(ResourceBrowser)
+
+} // namespace Presentation


### PR DESCRIPTION
- Extends textures (and in the future other resources) to keep track of allocated objects so we can recall them later. 
- Fixes a few misses in PixelFormat.
- Fixes an issue with LoadImmediate not working for streaming LODs.
- Fixes issue with Asset Editor not correctly showing changes.