### PR TITLE
Save device properties in globals

### DIFF
--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -31,6 +31,37 @@ extern bool VariableRateShadingSupported;
 extern bool MeshShadersSupported;
 extern bool NvidiaCheckpointsSupported;
 
+extern uint ReadWriteBufferAlignment;
+extern uint ConstantBufferAlignment;
+extern uint64 MaxConstantBufferSize;
+extern uint MaxPushConstantSize;
+extern uint64 SparseAddressSize;
+
+extern uint MaxPerStageConstantBuffers;
+extern uint MaxPerStageReadWriteBuffers;
+extern uint MaxPerStageSampledImages;
+extern uint MaxPerStageReadWriteImages;
+extern uint MaxPerStageSamplers;
+extern uint MaxPerStageInputAttachments;
+
+extern uint MaxResourceTableConstantBuffers;
+extern uint MaxResourceTableDynamicOffsetConstantBuffers;
+extern uint MaxResourceTableReadWriteBuffers;
+extern uint MaxResourceTableDynamicOffsetReadWriteBuffers;
+extern uint MaxResourceTableSampledImages;
+extern uint MaxResourceTableReadWriteImages;
+extern uint MaxResourceTableSamplers;
+extern uint MaxResourceTableInputAttachments;
+
+extern uint MemoryRangeGranularity; // Set to the smallest amount of bytes allowed for a non-coherent memory write
+extern uint TimestampPeriod;
+
+/// Raytracing properties
+extern uint AccelerationStructureScratchAlignment;
+extern uint ShaderGroupAlignment;
+extern uint64 ShaderGroupSize;
+extern uint MaxRecursionDepth;
+
 struct GraphicsDeviceCreateInfo
 {
     uint64 globalConstantBufferMemorySize;

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -1178,7 +1178,7 @@ void
 CmdRaysDispatch(const CmdBufferId id, const RayDispatchTable& table, int dimX, int dimY, int dimZ)
 {
     VkStridedDeviceAddressRegionKHR genRegion, hitRegion, missRegion, callableRegion;
-    uint handleSize = CoreGraphics::GetCurrentRaytracingProperties().shaderGroupHandleSize;
+    uint handleSize = CoreGraphics::ShaderGroupSize;
 
     auto RegionSetup = [handleSize](VkStridedDeviceAddressRegionKHR& region, const RayDispatchTable::Entry& entry)
     {

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -335,6 +335,36 @@ SetupAdapter(CoreGraphics::GraphicsDeviceCreateInfo::Features features)
                 {
                     n_printf("[Graphics Device] Using '%s' as primary graphics adapter", state.deviceProps[i].properties.deviceName);
                     state.currentDevice = i;
+                    CoreGraphics::ReadWriteBufferAlignment = state.deviceProps[i].properties.limits.minStorageBufferOffsetAlignment;
+                    CoreGraphics::ConstantBufferAlignment = state.deviceProps[i].properties.limits.minUniformBufferOffsetAlignment;
+                    CoreGraphics::MaxConstantBufferSize = state.deviceProps[i].properties.limits.maxUniformBufferRange;
+                    CoreGraphics::SparseAddressSize = state.deviceProps[i].properties.limits.sparseAddressSpaceSize;
+
+                    CoreGraphics::MaxPerStageConstantBuffers = state.deviceProps[i].properties.limits.maxPerStageDescriptorUniformBuffers;
+                    CoreGraphics::MaxPerStageReadWriteBuffers = state.deviceProps[i].properties.limits.maxPerStageDescriptorStorageBuffers;
+                    CoreGraphics::MaxPerStageSampledImages = state.deviceProps[i].properties.limits.maxPerStageDescriptorSampledImages;
+                    CoreGraphics::MaxPerStageReadWriteImages = state.deviceProps[i].properties.limits.maxPerStageDescriptorStorageImages;
+                    CoreGraphics::MaxPerStageSamplers = state.deviceProps[i].properties.limits.maxPerStageDescriptorSamplers;
+                    CoreGraphics::MaxPerStageInputAttachments = state.deviceProps[i].properties.limits.maxPerStageDescriptorInputAttachments;
+
+                    CoreGraphics::MaxPushConstantSize = state.deviceProps[i].properties.limits.maxPushConstantsSize;
+                    CoreGraphics::MaxResourceTableConstantBuffers = state.deviceProps[i].properties.limits.maxDescriptorSetUniformBuffers;
+                    CoreGraphics::MaxResourceTableDynamicOffsetConstantBuffers = state.deviceProps[i].properties.limits.maxDescriptorSetUniformBuffersDynamic;
+                    CoreGraphics::MaxResourceTableReadWriteBuffers = state.deviceProps[i].properties.limits.maxDescriptorSetStorageBuffers;
+                    CoreGraphics::MaxResourceTableDynamicOffsetReadWriteBuffers = state.deviceProps[i].properties.limits.maxDescriptorSetStorageBuffersDynamic;
+                    CoreGraphics::MaxResourceTableSampledImages = state.deviceProps[i].properties.limits.maxDescriptorSetSampledImages;
+                    CoreGraphics::MaxResourceTableReadWriteImages = state.deviceProps[i].properties.limits.maxDescriptorSetStorageImages;
+                    CoreGraphics::MaxResourceTableSamplers = state.deviceProps[i].properties.limits.maxDescriptorSetSamplers;
+                    CoreGraphics::MaxResourceTableInputAttachments = state.deviceProps[i].properties.limits.maxDescriptorSetInputAttachments;
+
+                    CoreGraphics::MemoryRangeGranularity = state.deviceProps[i].properties.limits.nonCoherentAtomSize;
+                    CoreGraphics::TimestampPeriod = state.deviceProps[i].properties.limits.timestampPeriod;
+
+                    CoreGraphics::AccelerationStructureScratchAlignment = state.accelerationStructureDeviceProps[i].minAccelerationStructureScratchOffsetAlignment;
+                    CoreGraphics::ShaderGroupAlignment = state.raytracingDeviceProps[i].shaderGroupBaseAlignment;
+                    CoreGraphics::ShaderGroupSize = state.raytracingDeviceProps[i].shaderGroupHandleSize;
+                    CoreGraphics::MaxRecursionDepth = state.raytracingDeviceProps[i].maxRayRecursionDepth;
+
                     break;
                 }
             }
@@ -376,37 +406,10 @@ GetCurrentPhysicalDevice()
 //------------------------------------------------------------------------------
 /**
 */
-VkPhysicalDeviceProperties
-GetCurrentProperties()
-{
-    return state.deviceProps[state.currentDevice].properties;
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-VkPhysicalDeviceAccelerationStructurePropertiesKHR
-GetCurrentAccelerationStructureProperties()
-{
-    return state.accelerationStructureDeviceProps[state.currentDevice];
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
-VkPhysicalDeviceRayTracingPipelinePropertiesKHR
-GetCurrentRaytracingProperties()
-{
-    return state.raytracingDeviceProps[state.currentDevice];
-}
-
-//------------------------------------------------------------------------------
-/**
-*/
 VkPhysicalDeviceFeatures 
 GetCurrentFeatures()
 {
-    return state.deviceFeatures[state.currentDevice];;
+    return state.deviceFeatures[state.currentDevice];
 }
 
 //------------------------------------------------------------------------------
@@ -715,8 +718,38 @@ bool RayTracingSupported = false;
 bool DynamicVertexInputSupported = false;
 bool MeshShadersSupported = false;
 bool VariableRateShadingSupported = false;
-
 bool NvidiaCheckpointsSupported = false;
+
+uint ReadWriteBufferAlignment = UINT_MAX;
+uint ConstantBufferAlignment = UINT_MAX;
+uint64 MaxConstantBufferSize = UINT_MAX;
+uint MaxPushConstantSize = UINT_MAX;
+uint64 SparseAddressSize = UINT_MAX;
+
+uint MaxPerStageConstantBuffers = UINT_MAX;
+uint MaxPerStageReadWriteBuffers = UINT_MAX;
+uint MaxPerStageSampledImages = UINT_MAX;
+uint MaxPerStageReadWriteImages = UINT_MAX;
+uint MaxPerStageSamplers = UINT_MAX;
+uint MaxPerStageInputAttachments = UINT_MAX;
+
+uint MaxResourceTableConstantBuffers = UINT_MAX;
+uint MaxResourceTableDynamicOffsetConstantBuffers = UINT_MAX;
+uint MaxResourceTableReadWriteBuffers = UINT_MAX;
+uint MaxResourceTableDynamicOffsetReadWriteBuffers = UINT_MAX;
+uint MaxResourceTableSampledImages = UINT_MAX;
+uint MaxResourceTableReadWriteImages = UINT_MAX;
+uint MaxResourceTableSamplers = UINT_MAX;
+uint MaxResourceTableInputAttachments = UINT_MAX;
+
+uint MemoryRangeGranularity = UINT_MAX;
+uint TimestampPeriod = UINT_MAX;
+
+uint AccelerationStructureScratchAlignment = UINT_MAX;
+uint ShaderGroupAlignment = UINT_MAX;
+uint64 ShaderGroupSize = UINT_MAX;
+uint MaxRecursionDepth = UINT_MAX;
+
 using namespace Vulkan;
 
 #if NEBULA_GRAPHICS_DEBUG
@@ -1327,7 +1360,7 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
 
     CoreGraphics::BufferCreateInfo uploadInfo;
     uploadInfo.name = "Global Upload Buffer";
-    uploadInfo.byteSize = Math::align(info.globalUploadMemorySize, state.deviceProps[state.currentDevice].properties.limits.nonCoherentAtomSize);
+    uploadInfo.byteSize = Math::align(info.globalUploadMemorySize, CoreGraphics::MemoryRangeGranularity);
     uploadInfo.mode = CoreGraphics::BufferAccessMode::HostLocal;
     uploadInfo.queueSupport = CoreGraphics::BufferQueueSupport::GraphicsQueueSupport | CoreGraphics::BufferQueueSupport::ComputeQueueSupport | CoreGraphics::BufferQueueSupport::TransferQueueSupport;
     uploadInfo.usageFlags = CoreGraphics::BufferUsageFlag::TransferBufferSource;
@@ -1427,7 +1460,7 @@ DestroyGraphicsDevice()
     VkDestroyDebugMessenger(state.instance, VkErrorDebugMessageHandle, nullptr);
 #endif
 
-    vkDestroyDevice(state.devices[0], nullptr);
+    vkDestroyDevice(state.devices[state.currentDevice], nullptr);
     vkDestroyInstance(state.instance, nullptr);
 }
 
@@ -2184,7 +2217,7 @@ AllocateUpload(const SizeT numBytes, const SizeT alignment)
     Threading::CriticalScope _0(&UploadLock);
 
     // Calculate aligned upper bound
-    SizeT adjustedAlignment = Math::max(alignment, (SizeT)state.deviceProps[state.currentDevice].properties.limits.nonCoherentAtomSize);
+    SizeT adjustedAlignment = Math::max(alignment, (SizeT)CoreGraphics::MemoryRangeGranularity);
     const SizeT alignedBytes = numBytes + adjustedAlignment - 1;
     N_BUDGET_COUNTER_INCR(N_UPLOAD_MEMORY, alignedBytes);
 
@@ -2233,7 +2266,7 @@ FlushUploads(const Util::Array<Memory::RangeAllocation>& allocations)
             range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
             range.pNext = nullptr;
             range.offset = allocations[i].offset; //uploadBuffer.interval.start;
-            range.size = Math::align(allocations[i].size, state.deviceProps[state.currentDevice].properties.limits.nonCoherentAtomSize);// (DeviceSize)size;
+            range.size = Math::align(allocations[i].size, CoreGraphics::MemoryRangeGranularity);// (DeviceSize)size;
             range.memory = BufferGetVkMemory(state.uploadBuffer);
         }
 

--- a/code/render/coregraphics/vk/vkgraphicsdevice.h
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.h
@@ -30,12 +30,6 @@ VkInstance GetInstance();
 VkDevice GetCurrentDevice();
 /// get the currently activated physical device
 VkPhysicalDevice GetCurrentPhysicalDevice();
-/// get the current device properties
-VkPhysicalDeviceProperties GetCurrentProperties();
-/// Get the current device acceleration structure properties
-VkPhysicalDeviceAccelerationStructurePropertiesKHR GetCurrentAccelerationStructureProperties();
-/// Get the current device raytracing properties
-VkPhysicalDeviceRayTracingPipelinePropertiesKHR GetCurrentRaytracingProperties();
 /// get the current device features
 VkPhysicalDeviceFeatures GetCurrentFeatures();
 /// get pipeline cache

--- a/code/render/coregraphics/vk/vkmemory.cc
+++ b/code/render/coregraphics/vk/vkmemory.cc
@@ -233,7 +233,6 @@ AllocateMemory(const VkDevice dev, const VkBuffer& buf, MemoryPoolType type, uin
     VkMemoryRequirements req;
     vkGetBufferMemoryRequirements(dev, buf, &req);
     req.alignment = Math::align(req.alignment, (DeviceSize)alignment);
-    VkPhysicalDeviceProperties props = Vulkan::GetCurrentProperties();
 
     VkMemoryPropertyFlags flags = 0;
 
@@ -251,8 +250,8 @@ AllocateMemory(const VkDevice dev, const VkBuffer& buf, MemoryPoolType type, uin
     case MemoryPool_DeviceAndHost:
         flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         // Memory needs to be aligned to non coherent atom size for flushing
-        req.size = Math::align(req.size, props.limits.nonCoherentAtomSize);
-        req.alignment = Math::align(req.alignment, props.limits.nonCoherentAtomSize);
+        req.size = Math::align(req.size, CoreGraphics::MemoryRangeGranularity);
+        req.alignment = Math::align(req.alignment, CoreGraphics::MemoryRangeGranularity);
         break;
     default:
         n_crash("AllocateMemory(): Only buffer pool types are allowed for buffer memory");
@@ -302,15 +301,14 @@ AllocateMemory(const VkDevice dev, VkMemoryRequirements reqs, VkDeviceSize alloc
 void 
 Flush(const VkDevice dev, const Alloc& alloc, IndexT offset, SizeT size)
 {
-    VkPhysicalDeviceProperties props = Vulkan::GetCurrentProperties();
     CoreGraphics::MemoryPool& pool = CoreGraphics::Pools[alloc.poolIndex];
     VkMappedMemoryRange range;
     range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
     range.pNext = nullptr;
-    range.offset = Math::align_down(alloc.offset + offset, props.limits.nonCoherentAtomSize);
+    range.offset = Math::align_down(alloc.offset + offset, CoreGraphics::MemoryRangeGranularity);
     uint flushSize = size == NEBULA_WHOLE_BUFFER_SIZE ? alloc.size : Math::min(size, (SizeT)alloc.size);
     range.size = Math::min(
-        (VkDeviceSize)Math::align(flushSize + (alloc.offset + offset - range.offset), props.limits.nonCoherentAtomSize),
+        (VkDeviceSize)Math::align(flushSize + (alloc.offset + offset - range.offset), CoreGraphics::MemoryRangeGranularity),
         pool.blockSize);
     range.memory = alloc.mem;
     VkResult res = vkFlushMappedMemoryRanges(dev, 1, &range);
@@ -323,15 +321,14 @@ Flush(const VkDevice dev, const Alloc& alloc, IndexT offset, SizeT size)
 void 
 Invalidate(const VkDevice dev, const CoreGraphics::Alloc& alloc, IndexT offset, SizeT size)
 {
-    VkPhysicalDeviceProperties props = Vulkan::GetCurrentProperties();
     CoreGraphics::MemoryPool& pool = CoreGraphics::Pools[alloc.poolIndex];
     VkMappedMemoryRange range;
     range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
     range.pNext = nullptr;
-    range.offset = Math::align_down(alloc.offset + offset, props.limits.nonCoherentAtomSize);
+    range.offset = Math::align_down(alloc.offset + offset, CoreGraphics::MemoryRangeGranularity);
     uint flushSize = size == NEBULA_WHOLE_BUFFER_SIZE ? alloc.size : Math::min((VkDeviceSize)size, alloc.size);
     range.size = Math::min(
-        (VkDeviceSize)Math::align(flushSize + (alloc.offset + offset - range.offset), props.limits.nonCoherentAtomSize),
+        (VkDeviceSize)Math::align(flushSize + (alloc.offset + offset - range.offset), CoreGraphics::MemoryRangeGranularity),
         pool.blockSize);
     range.memory = alloc.mem;
     VkResult res = vkInvalidateMappedMemoryRanges(dev, 1, &range);

--- a/code/render/coregraphics/vk/vkshader.h
+++ b/code/render/coregraphics/vk/vkshader.h
@@ -28,7 +28,6 @@ const VkProgramReflectionInfo& ShaderGetProgramReflection(const CoreGraphics::Sh
 void ShaderSetup(
     VkDevice dev,
     const Util::StringAtom& name,
-    const VkPhysicalDeviceProperties props,
     AnyFX::ShaderEffect* effect,
     Util::FixedArray<CoreGraphics::ResourcePipelinePushConstantRange>& constantRange,
     Util::Array<CoreGraphics::SamplerId>& immutableSamplers,

--- a/code/render/coregraphics/vk/vktexture.cc
+++ b/code/render/coregraphics/vk/vktexture.cc
@@ -70,8 +70,7 @@ SetupSparse(VkDevice dev, VkImage img, Ids::Id32 sparseExtension, const VkTextur
     VkMemoryRequirements memoryReqs;
     vkGetImageMemoryRequirements(dev, img, &memoryReqs);
 
-    VkPhysicalDeviceProperties devProps = GetCurrentProperties();
-    n_assert(memoryReqs.size < devProps.limits.sparseAddressSpaceSize);
+    n_assert(memoryReqs.size < CoreGraphics::SparseAddressSize);
 
     // get sparse memory requirements
     uint32_t sparseMemoryRequirementsCount;


### PR DESCRIPTION
Read the device properties from the Vulkan device and store them as globals. This reduced the headache of looking for them and navigatint the VkDeviceProps struct, as well as it allows us to write more backend agnostic code in the future.