### PR TITLE
Remove tons of heap allocs during the frame

### DIFF
--- a/code/foundation/jobs2/jobs2.cc
+++ b/code/foundation/jobs2/jobs2.cc
@@ -292,7 +292,7 @@ Threading::ThreadId sequenceThread;
 */
 void
 JobBeginSequence(
-    const Util::FixedArray<const Threading::AtomicCounter*>& waitCounters
+    const Util::FixedArray<const Threading::AtomicCounter*, true>& waitCounters
     , Threading::AtomicCounter* doneCounter
     , Threading::Event* signalEvent)
 {

--- a/code/foundation/jobs2/jobs2.h
+++ b/code/foundation/jobs2/jobs2.h
@@ -185,7 +185,7 @@ extern const Threading::AtomicCounter* prevDoneCounter;
 extern Threading::ThreadId sequenceThread;
 
 /// Begin a sequence of jobs
-void JobBeginSequence(const Util::FixedArray<const Threading::AtomicCounter*>& waitCounters = nullptr
+void JobBeginSequence(const Util::FixedArray<const Threading::AtomicCounter*, true>& waitCounters = nullptr
     , Threading::AtomicCounter* doneCounter = nullptr
     , Threading::Event* signalEvent = nullptr);
 
@@ -224,7 +224,7 @@ JobDispatch(
     LAMBDA&& func
     , const SizeT numInvocations
     , const SizeT groupSize
-    , const Util::FixedArray<const Threading::AtomicCounter*>& waitCounters = nullptr
+    , const Util::FixedArray<const Threading::AtomicCounter*, true>& waitCounters = nullptr
     , Threading::AtomicCounter* doneCounter = nullptr
     , Threading::Event* signalEvent = nullptr
 )
@@ -288,7 +288,7 @@ template <typename LAMBDA> void
 JobDispatch(
     LAMBDA&& func
     , const SizeT numInvocations
-    , const Util::FixedArray<const Threading::AtomicCounter*>& waitCounters = nullptr
+    , const Util::FixedArray<const Threading::AtomicCounter*, true>& waitCounters = nullptr
     , Threading::AtomicCounter* doneCounter = nullptr
     , Threading::Event* signalEvent = nullptr
 )
@@ -305,7 +305,7 @@ JobDispatch(
     , const SizeT numInvocations
     , const SizeT groupSize
     , const CTX& context
-    , const Util::FixedArray<const Threading::AtomicCounter*>& waitCounters = nullptr
+    , const Util::FixedArray<const Threading::AtomicCounter*, true>& waitCounters = nullptr
     , Threading::AtomicCounter* doneCounter = nullptr
     , Threading::Event* signalEvent = nullptr
 )
@@ -376,7 +376,7 @@ JobDispatch(
     const JobFunc& func
     , const SizeT numInvocations
     , const CTX& context
-    , const Util::FixedArray<const Threading::AtomicCounter*>& waitCounters = nullptr
+    , const Util::FixedArray<const Threading::AtomicCounter*, true>& waitCounters = nullptr
     , Threading::AtomicCounter* doneCounter = nullptr
     , Threading::Event* signalEvent = nullptr
 )

--- a/code/foundation/memory/memory.h
+++ b/code/foundation/memory/memory.h
@@ -41,6 +41,24 @@ ArrayAlloc(size_t size)
 /**
 */
 template<typename TYPE>
+TYPE*
+ArrayAllocStack(size_t size)
+{
+    TYPE* buffer = (TYPE*)StackAlloc(size * sizeof(TYPE));
+    if constexpr (!std::is_trivially_constructible<TYPE>::value)
+    {
+        for (size_t i = 0; i < size; ++i)
+        {
+            ::new(&buffer[i]) TYPE;
+        }
+    }
+    return buffer;
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<typename TYPE>
 void 
 ArrayFree(size_t size, TYPE* buffer)
 {
@@ -52,4 +70,21 @@ ArrayFree(size_t size, TYPE* buffer)
         }
     }
     Memory::Free(Memory::ObjectArrayHeap, (void*)buffer);
+}
+
+//------------------------------------------------------------------------------
+/**
+*/
+template<typename TYPE>
+void
+ArrayFreeStack(size_t size, TYPE* buffer)
+{
+    if constexpr (!std::is_trivially_destructible<TYPE>::value)
+    {
+        for (size_t i = 0; i < size; ++i)
+        {
+            buffer[i].~TYPE();
+        }
+    }
+    StackFree((void*)buffer);
 }

--- a/code/foundation/util/array.h
+++ b/code/foundation/util/array.h
@@ -222,6 +222,8 @@ public:
     /// grow array with grow value
     void Grow();
 protected:
+    template<class T, bool S>
+    friend class FixedArray;
 
     /// destroy an element (call destructor without freeing memory)
     void Destroy(TYPE* elm);

--- a/code/render/characters/charactercontext.cc
+++ b/code/render/characters/charactercontext.cc
@@ -743,7 +743,7 @@ CharacterContext::UpdateAnimations(const Graphics::FrameContext& ctx)
                 n_assert(renderables.nodeTypes[node] == Models::NodeType::CharacterSkinNodeType);
                 Models::CharacterSkinNode* sparent = reinterpret_cast<Models::CharacterSkinNode*>(renderables.nodes[node]);
                 const Util::Array<IndexT>& usedIndices = sparent->skinFragments[0].jointPalette;
-                Util::FixedArray<Math::mat4> usedMatrices(usedIndices.Size());
+                Util::FixedArray<Math::mat4, true> usedMatrices(usedIndices.Size());
 
                 // update joints, which is stored in character context
                 if (!jointPalette.IsEmpty())

--- a/code/render/coregraphics/barrier.h
+++ b/code/render/coregraphics/barrier.h
@@ -206,9 +206,9 @@ struct BarrierScope
     void Flush()
     {
         if (!this->textures.IsEmpty())
-            CoreGraphics::CmdBarrier(this->cmdBuf, this->fromStage, this->toStage, CoreGraphics::BarrierDomain::Global, this->textures, InvalidIndex, InvalidIndex, this->name);
+            CoreGraphics::CmdBarrier(this->cmdBuf, this->fromStage, this->toStage, CoreGraphics::BarrierDomain::Global, std::move(this->textures), InvalidIndex, InvalidIndex, this->name);
         if (!this->buffers.IsEmpty())
-            CoreGraphics::CmdBarrier(this->cmdBuf, this->fromStage, this->toStage, CoreGraphics::BarrierDomain::Global, this->buffers, InvalidIndex, InvalidIndex, this->name);
+            CoreGraphics::CmdBarrier(this->cmdBuf, this->fromStage, this->toStage, CoreGraphics::BarrierDomain::Global, std::move(this->buffers), InvalidIndex, InvalidIndex, this->name);
         this->buffers.Clear();
         this->textures.Clear();
     }
@@ -249,22 +249,22 @@ void BarrierPush(
     CoreGraphics::PipelineStage fromStage,
     CoreGraphics::PipelineStage toStage,
     CoreGraphics::BarrierDomain domain,
-    const Util::FixedArray<TextureBarrierInfo>& textures,
-    const Util::FixedArray<BufferBarrierInfo>& buffers);
+    const Util::FixedArray<TextureBarrierInfo, true>& textures,
+    const Util::FixedArray<BufferBarrierInfo, true>& buffers);
 /// Push barrier to stack
 void BarrierPush(
     const CoreGraphics::CmdBufferId buf,
     CoreGraphics::PipelineStage fromStage,
     CoreGraphics::PipelineStage toStage,
     CoreGraphics::BarrierDomain domain,
-    const Util::FixedArray<TextureBarrierInfo>& textures);
+    const Util::FixedArray<TextureBarrierInfo, true>& textures);
 /// Push barrier to stack
 void BarrierPush(
     const CoreGraphics::CmdBufferId buf,
     CoreGraphics::PipelineStage fromStage,
     CoreGraphics::PipelineStage toStage,
     CoreGraphics::BarrierDomain domain,
-    const Util::FixedArray<BufferBarrierInfo>& buffers);
+    const Util::FixedArray<BufferBarrierInfo, true>& buffers);
 /// pop barrier, reverses the from-to stages and any access flags in the buffers and texture barriers
 void BarrierPop(const CoreGraphics::CmdBufferId buf);
 /// repeat barrier in queue

--- a/code/render/coregraphics/commandbuffer.cc
+++ b/code/render/coregraphics/commandbuffer.cc
@@ -15,7 +15,7 @@ CmdBarrier(const CmdBufferId id
                          , CoreGraphics::PipelineStage fromStage
                          , CoreGraphics::PipelineStage toStage
                          , CoreGraphics::BarrierDomain domain
-                         , const Util::FixedArray<TextureBarrierInfo>& textures
+                         , const Util::FixedArray<TextureBarrierInfo, true>& textures
                          , const IndexT fromQueue
                          , const IndexT toQueue
                          , const char* name)
@@ -31,7 +31,7 @@ CmdBarrier(const CmdBufferId id
                          , CoreGraphics::PipelineStage fromStage
                          , CoreGraphics::PipelineStage toStage
                          , CoreGraphics::BarrierDomain domain
-                         , const Util::FixedArray<BufferBarrierInfo>& buffers
+                         , const Util::FixedArray<BufferBarrierInfo, true>& buffers
                          , const IndexT fromQueue
                          , const IndexT toQueue
                          , const char* name)
@@ -47,7 +47,7 @@ CmdBarrier(const CmdBufferId id
                          , CoreGraphics::PipelineStage fromStage
                          , CoreGraphics::PipelineStage toStage
                          , CoreGraphics::BarrierDomain domain
-                         , const Util::FixedArray<AccelerationStructureBarrierInfo>& accelerationStructures
+                         , const Util::FixedArray<AccelerationStructureBarrierInfo, true>& accelerationStructures
                          , const IndexT fromQueue
                          , const IndexT toQueue
                          , const char* name)

--- a/code/render/coregraphics/commandbuffer.h
+++ b/code/render/coregraphics/commandbuffer.h
@@ -210,7 +210,7 @@ void CmdBarrier(
             CoreGraphics::PipelineStage fromStage,
             CoreGraphics::PipelineStage toStage,
             CoreGraphics::BarrierDomain domain,
-            const Util::FixedArray<TextureBarrierInfo>& textures,
+            const Util::FixedArray<TextureBarrierInfo, true>& textures,
             const IndexT fromQueue = InvalidIndex,
             const IndexT toQueue = InvalidIndex,
             const char* name = nullptr
@@ -221,7 +221,7 @@ void CmdBarrier(
             CoreGraphics::PipelineStage fromStage,
             CoreGraphics::PipelineStage toStage,
             CoreGraphics::BarrierDomain domain,
-            const Util::FixedArray<BufferBarrierInfo>& buffers,
+            const Util::FixedArray<BufferBarrierInfo, true>& buffers,
             const IndexT fromQueue = InvalidIndex,
             const IndexT toQueue = InvalidIndex,
             const char* name = nullptr
@@ -232,7 +232,7 @@ void CmdBarrier(
             CoreGraphics::PipelineStage fromStage,
             CoreGraphics::PipelineStage toStage,
             CoreGraphics::BarrierDomain domain,
-            const Util::FixedArray<AccelerationStructureBarrierInfo>& accelerationStructures,
+            const Util::FixedArray<AccelerationStructureBarrierInfo, true>& accelerationStructures,
             const IndexT fromQueue = InvalidIndex,
             const IndexT toQueue = InvalidIndex,
             const char* name = nullptr
@@ -243,9 +243,9 @@ void CmdBarrier(
             CoreGraphics::PipelineStage fromStage,
             CoreGraphics::PipelineStage toStage,
             CoreGraphics::BarrierDomain domain,
-            const Util::FixedArray<TextureBarrierInfo>& textures,
-            const Util::FixedArray<BufferBarrierInfo>& buffers,
-            const Util::FixedArray<AccelerationStructureBarrierInfo>& accelerationStructures,
+            const Util::FixedArray<TextureBarrierInfo, true>& textures,
+            const Util::FixedArray<BufferBarrierInfo, true>& buffers,
+            const Util::FixedArray<AccelerationStructureBarrierInfo, true>& accelerationStructures,
             const IndexT fromQueue = InvalidIndex,
             const IndexT toQueue = InvalidIndex,
             const char* name = nullptr
@@ -257,8 +257,8 @@ void CmdHandover(
             const CmdBufferId to,
             CoreGraphics::PipelineStage fromStage,
             CoreGraphics::PipelineStage toStage,
-            const Util::FixedArray<TextureBarrierInfo>& textures,
-            const Util::FixedArray<BufferBarrierInfo>& buffers,
+            const Util::FixedArray<TextureBarrierInfo, true>& textures,
+            const Util::FixedArray<BufferBarrierInfo, true>& buffers,
             const IndexT fromQueue = InvalidIndex,
             const IndexT toQueue = InvalidIndex,
             const char* name = nullptr
@@ -324,34 +324,34 @@ void CmdDrawMeshlets(const CmdBufferId id, int dimX, int dimY, int dimZ);
 void CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::TextureId fromTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& from
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& from
     , const CoreGraphics::TextureId toTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& to
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& to
 );
 /// Copy from texture to buffer
 void CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::TextureId fromTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& from
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& from
     , const CoreGraphics::BufferId toBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& to
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& to
 );
 /// Copy between buffers
 void CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::BufferId fromBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& from
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& from
     , const CoreGraphics::BufferId toBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& to
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& to
     , const SizeT size
 );
 /// Copy from buffer to texture
 void CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::BufferId fromBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& from
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& from
     , const CoreGraphics::TextureId toTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& to
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& to
 );
 /// Blit textures
 void CmdBlit(
@@ -363,9 +363,9 @@ void CmdBlit(
 );
 
 /// Set viewport array
-void CmdSetViewports(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> viewports);
+void CmdSetViewports(const CmdBufferId id, const Util::FixedArray<Math::rectangle<int>>& viewports);
 /// Set scissor array
-void CmdSetScissors(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> rects);
+void CmdSetScissors(const CmdBufferId id, const Util::FixedArray<Math::rectangle<int>>& rects);
 /// Sets a viewport for a certain index
 void CmdSetViewport(const CmdBufferId id, const Math::rectangle<int>& rect, int index);
 /// Sets a scissor rect for a certain index

--- a/code/render/coregraphics/graphicsdevice.h
+++ b/code/render/coregraphics/graphicsdevice.h
@@ -214,9 +214,9 @@ bool PollSubmissionIndex(const CoreGraphics::QueueType queue, uint64 index);
 
 /// Submit a command buffer, but doesn't necessarily execute it immediately
 SubmissionWaitEvent SubmitCommandBuffers(
-    const Util::Array<CoreGraphics::CmdBufferId>& cmds
+    const Util::Array<CoreGraphics::CmdBufferId, 8>& cmds
     , CoreGraphics::QueueType type
-    , Util::Array<CoreGraphics::SubmissionWaitEvent> waitEvents = nullptr
+    , Util::Array<CoreGraphics::SubmissionWaitEvent, 8> waitEvents = nullptr
 #if NEBULA_GRAPHICS_DEBUG
     , const char* name = nullptr
 #endif

--- a/code/render/coregraphics/meshloader.cc
+++ b/code/render/coregraphics/meshloader.cc
@@ -291,7 +291,7 @@ MeshLoader::LodMask(const _StreamData& stream, float lod, bool async) const
 void
 MeshLoader::UpdateLoaderSyncState()
 {
-    Util::Array<MeshesToSubmit> meshesToSubmit(128, 8);
+    Util::Array<MeshesToSubmit, 128> meshesToSubmit;
     this->meshesToSubmit.DequeueAll(meshesToSubmit);
 
     // Enqueue cleanups

--- a/code/render/coregraphics/textureloader.cc
+++ b/code/render/coregraphics/textureloader.cc
@@ -428,7 +428,7 @@ TextureLoader::Unload(const Resources::ResourceId id)
 void
 TextureLoader::UpdateLoaderSyncState()
 {
-    Util::Array<MipLoadMainThread> mipLoads(128, 8);
+    Util::Array<MipLoadMainThread, 128> mipLoads;
     this->mipLoadsToSubmit.DequeueAll(mipLoads);
     for (const auto& mipLoad : mipLoads)
     {

--- a/code/render/coregraphics/vk/vkbarrier.cc
+++ b/code/render/coregraphics/vk/vkbarrier.cc
@@ -180,8 +180,8 @@ BarrierPush(const CoreGraphics::CmdBufferId buf
     , CoreGraphics::PipelineStage fromStage
     , CoreGraphics::PipelineStage toStage
     , CoreGraphics::BarrierDomain domain
-    , const Util::FixedArray<TextureBarrierInfo>& textures
-    , const Util::FixedArray<BufferBarrierInfo>& buffers)
+    , const Util::FixedArray<TextureBarrierInfo, true>& textures
+    , const Util::FixedArray<BufferBarrierInfo, true>& buffers)
 {
     // first insert the barrier as is
     CmdBarrier(buf, fromStage, toStage, domain, textures, buffers, nullptr);
@@ -206,7 +206,7 @@ BarrierPush(const CoreGraphics::CmdBufferId buf
     , CoreGraphics::PipelineStage fromStage
     , CoreGraphics::PipelineStage toStage
     , CoreGraphics::BarrierDomain domain
-    , const Util::FixedArray<TextureBarrierInfo>& textures)
+    , const Util::FixedArray<TextureBarrierInfo, true>& textures)
 {
     // first insert the barrier as is
     CmdBarrier(buf, fromStage, toStage, domain, textures, nullptr, nullptr);
@@ -231,7 +231,7 @@ BarrierPush(const CoreGraphics::CmdBufferId buf
     , CoreGraphics::PipelineStage fromStage
     , CoreGraphics::PipelineStage toStage
     , CoreGraphics::BarrierDomain domain
-    , const Util::FixedArray<BufferBarrierInfo>& buffers)
+    , const Util::FixedArray<BufferBarrierInfo, true>& buffers)
 {
     // first insert the barrier as is
     CmdBarrier(buf, fromStage, toStage, domain, nullptr, buffers, nullptr);

--- a/code/render/coregraphics/vk/vkcommandbuffer.cc
+++ b/code/render/coregraphics/vk/vkcommandbuffer.cc
@@ -692,9 +692,9 @@ CmdBarrier(
         CoreGraphics::PipelineStage fromStage,
         CoreGraphics::PipelineStage toStage,
         CoreGraphics::BarrierDomain domain,
-        const Util::FixedArray<TextureBarrierInfo>& textures,
-        const Util::FixedArray<BufferBarrierInfo>& buffers,
-        const Util::FixedArray<AccelerationStructureBarrierInfo>& accelerationStructures,
+        const Util::FixedArray<TextureBarrierInfo, true>& textures,
+        const Util::FixedArray<BufferBarrierInfo, true>& buffers,
+        const Util::FixedArray<AccelerationStructureBarrierInfo, true>& accelerationStructures,
         const IndexT fromQueue,
         const IndexT toQueue,
         const char* name
@@ -812,8 +812,8 @@ CmdHandover(
     , const CmdBufferId to
     , CoreGraphics::PipelineStage fromStage
     , CoreGraphics::PipelineStage toStage
-    , const Util::FixedArray<TextureBarrierInfo>& textures
-    , const Util::FixedArray<BufferBarrierInfo>& buffers
+    , const Util::FixedArray<TextureBarrierInfo, true>& textures
+    , const Util::FixedArray<BufferBarrierInfo, true>& buffers
     , const IndexT fromQueue
     , const IndexT toQueue
     , const char* name
@@ -1224,15 +1224,15 @@ void
 CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::TextureId fromTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& from
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& from
     , const CoreGraphics::TextureId toTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& to
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& to
 )
 {
     n_assert(from.Size() > 0);
     n_assert(from.Size() == to.Size());
 
-    Util::FixedArray<VkImageCopy> copies(from.Size());
+    Util::FixedArray<VkImageCopy, true> copies(from.Size());
     for (IndexT i = 0; i < copies.Size(); i++)
     {
         n_assert(from[i].bits != ImageBits::Auto && to[i].bits != ImageBits::Auto);
@@ -1255,9 +1255,9 @@ void
 CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::TextureId fromTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& from
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& from
     , const CoreGraphics::BufferId toBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& to
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& to
 )
 {
     n_assert(from.Size() > 0);
@@ -1292,16 +1292,16 @@ void
 CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::BufferId fromBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& from
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& from
     , const CoreGraphics::BufferId toBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& to
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& to
     , const SizeT size
 )
 {
     n_assert(from.Size() > 0);
     n_assert(from.Size() == to.Size());
 
-    Util::FixedArray<VkBufferCopy> copies(from.Size());
+    Util::FixedArray<VkBufferCopy, true> copies(from.Size());
     for (IndexT i = 0; i < copies.Size(); i++)
     {
         VkBufferCopy& copy = copies[i];
@@ -1321,9 +1321,9 @@ void
 CmdCopy(
     const CmdBufferId id
     , const CoreGraphics::BufferId fromBuffer
-    , const Util::Array<CoreGraphics::BufferCopy>& from
+    , const Util::Array<CoreGraphics::BufferCopy, 4>& from
     , const CoreGraphics::TextureId toTexture
-    , const Util::Array<CoreGraphics::TextureCopy>& to
+    , const Util::Array<CoreGraphics::TextureCopy, 4>& to
 )
 {
     n_assert(from.Size() > 0);
@@ -1390,7 +1390,7 @@ CmdBlit(
 /**
 */
 void
-CmdSetViewports(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> viewports)
+CmdSetViewports(const CmdBufferId id, const Util::FixedArray<Math::rectangle<int>>& viewports)
 {
     ViewportBundle& pending = commandBuffers.Get<CmdBuffer_PendingViewports>(id.id);
     pending.numPending = 0;
@@ -1411,7 +1411,7 @@ CmdSetViewports(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> vie
 /**
 */
 void
-CmdSetScissors(const CmdBufferId id, Util::FixedArray<Math::rectangle<int>> rects)
+CmdSetScissors(const CmdBufferId id, const Util::FixedArray<Math::rectangle<int>>& rects)
 {
     ScissorBundle& pending = commandBuffers.Get<CmdBuffer_PendingScissors>(id.id);
     pending.numPending = 0;
@@ -1700,8 +1700,8 @@ CmdFinishQueries(const CmdBufferId id)
         const Util::Array<QueryBundle::QueryChunk>& chunks = queryBundle.chunks[i];
         if (!chunks.IsEmpty())
         {
-            Util::FixedArray<IndexT> offsets(chunks.Size());
-            Util::FixedArray<SizeT> counts(chunks.Size());
+            Util::FixedArray<IndexT, true> offsets(chunks.Size());
+            Util::FixedArray<SizeT, true> counts(chunks.Size());
             for (IndexT j = 0; j < chunks.Size(); j++)
             {
                 offsets[j] = chunks[j].offset;

--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -997,15 +997,13 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
     }
 
     // create device
-    Util::FixedArray<Util::FixedArray<float>> prios;
     Util::Array<VkDeviceQueueCreateInfo> queueInfos;
-    prios.Resize(uniqueQueues.Size());
-
     for (i = 0; i < uniqueQueues.Size(); i++)
     {
         auto& [family, count] = uniqueQueues.KeyValuePairAtIndex(i);
-        prios[i].Resize(count);
-        prios[i].Fill(1.0f);
+        Util::FixedArray<float, true> prios;
+        prios.Resize(count);
+        prios.Fill(1.0f);
         queueInfos.Append(
             {
                 VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
@@ -1013,7 +1011,7 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
                 0,
                 family,
                 count,
-                &prios[i][0]
+                prios.Begin()
             });
     }
 
@@ -1666,9 +1664,9 @@ AddSubmissionEvent(const CoreGraphics::SubmissionWaitEvent& event)
 */
 CoreGraphics::SubmissionWaitEvent
 SubmitCommandBuffers(
-    const Util::Array<CoreGraphics::CmdBufferId>& cmds
+    const Util::Array<CoreGraphics::CmdBufferId, 8>& cmds
     , CoreGraphics::QueueType type
-    , Util::Array<CoreGraphics::SubmissionWaitEvent> waitEvents
+    , Util::Array<CoreGraphics::SubmissionWaitEvent, 8> waitEvents
 #if NEBULA_GRAPHICS_DEBUG
     , const char* name
 #endif
@@ -1676,7 +1674,7 @@ SubmitCommandBuffers(
 {
     // Append submission
     Threading::CriticalScope _0(&submitLock);
-    Util::Array<VkCommandBuffer> vkBufs;
+    Util::Array<VkCommandBuffer, 16> vkBufs;
     vkBufs.Reserve(cmds.Size());
     for (auto cmd : cmds)
         vkBufs.Append(CmdBufferGetVk(cmd));
@@ -1725,7 +1723,7 @@ SubmitImmediateCommandBuffers()
     transferLock.Enter();
     if (!state.setupTransferCommandBuffers.IsEmpty())
     {
-        Util::Array<VkCommandBuffer> vkBufs;
+        Util::Array<VkCommandBuffer, 16> vkBufs;
         vkBufs.Reserve(state.setupTransferCommandBuffers.Size());
         for (auto cmdBuf : state.setupTransferCommandBuffers)
             vkBufs.Append(CmdBufferGetVk(cmdBuf));
@@ -1745,7 +1743,7 @@ SubmitImmediateCommandBuffers()
 
     if (!state.handoverTransferCommandBuffers.IsEmpty())
     {
-        Util::Array<VkCommandBuffer> vkBufs;
+        Util::Array<VkCommandBuffer, 16> vkBufs;
         vkBufs.Reserve(state.handoverTransferCommandBuffers.Size());
         for (auto cmdBuf : state.handoverTransferCommandBuffers)
             vkBufs.Append(CmdBufferGetVk(cmdBuf));
@@ -1767,7 +1765,7 @@ SubmitImmediateCommandBuffers()
     setupLock.Enter();
     if (!state.setupGraphicsCommandBuffers.IsEmpty())
     {
-        Util::Array<VkCommandBuffer> vkBufs;
+        Util::Array<VkCommandBuffer, 16> vkBufs;
         vkBufs.Reserve(state.setupGraphicsCommandBuffers.Size());
         for (auto cmdBuf : state.setupGraphicsCommandBuffers)
             vkBufs.Append(CmdBufferGetVk(cmdBuf));

--- a/code/render/coregraphics/vk/vkresourcetable.cc
+++ b/code/render/coregraphics/vk/vkresourcetable.cc
@@ -257,7 +257,7 @@ ResourceTableCopy(const ResourceTableId from, IndexT fromSlot, IndexT fromIndex,
 
     Threading::SpinlockScope scope1(&resourceTableAllocator.Get<ResourceTable_Lock>(from.id));
     Threading::SpinlockScope scope2(&resourceTableAllocator.Get<ResourceTable_Lock>(to.id));
-    Util::Array<VkCopyDescriptorSet>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(to.id);
+    Util::Array<VkCopyDescriptorSet, 4>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(to.id);
 
     VkCopyDescriptorSet copy =
     {
@@ -283,7 +283,7 @@ ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTexture& te
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -340,7 +340,7 @@ ResourceTableSetTexture(const ResourceTableId id, const ResourceTableTextureView
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -395,7 +395,7 @@ ResourceTableSetInputAttachment(const ResourceTableId id, const ResourceTableInp
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -435,7 +435,7 @@ ResourceTableSetRWTexture(const ResourceTableId id, const ResourceTableTexture& 
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -475,7 +475,7 @@ ResourceTableSetRWTexture(const ResourceTableId id, const ResourceTableTextureVi
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tex.slot != InvalidIndex);
 
@@ -516,7 +516,7 @@ ResourceTableSetConstantBuffer(const ResourceTableId id, const ResourceTableBuff
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(buf.slot != InvalidIndex);
 
@@ -563,7 +563,7 @@ ResourceTableSetRWBuffer(const ResourceTableId id, const ResourceTableBuffer& bu
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(buf.slot != InvalidIndex);
 
@@ -609,7 +609,7 @@ ResourceTableSetSampler(const ResourceTableId id, const ResourceTableSampler& sa
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(samp.slot != InvalidIndex);
 
@@ -649,7 +649,7 @@ ResourceTableSetAccelerationStructure(const ResourceTableId id, const ResourceTa
     VkDescriptorSet& set = resourceTableAllocator.Get<ResourceTable_DescriptorSet>(id.id);
 
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
 
     n_assert(tlas.slot != InvalidIndex);
 
@@ -691,8 +691,8 @@ ResourceTableCommitChanges(const ResourceTableId id)
 
     // resource tables are blocked, add to pending write queue
     Threading::SpinlockScope scope(&resourceTableAllocator.Get<ResourceTable_Lock>(id.id));
-    Util::Array<WriteInfo>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
-    Util::Array<VkCopyDescriptorSet>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(id.id);
+    Util::Array<WriteInfo, 16>& infoList = resourceTableAllocator.Get<ResourceTable_WriteInfos>(id.id);
+    Util::Array<VkCopyDescriptorSet, 4>& copies = resourceTableAllocator.Get<ResourceTable_Copies>(id.id);
     VkDevice& dev = resourceTableAllocator.Get<ResourceTable_Device>(id.id);
 
     // because we store the write-infos in the other list, and the VkWriteDescriptorSet wants a pointer to the structure

--- a/code/render/coregraphics/vk/vkresourcetable.h
+++ b/code/render/coregraphics/vk/vkresourcetable.h
@@ -59,8 +59,8 @@ typedef Ids::IdAllocator<
     IndexT,
     Threading::Spinlock,
     CoreGraphics::ResourceTableLayoutId,
-    Util::Array<WriteInfo>,
-    Util::Array<VkCopyDescriptorSet>
+    Util::Array<WriteInfo, 16>,
+    Util::Array<VkCopyDescriptorSet, 4>
 > VkResourceTableAllocator;
 extern VkResourceTableAllocator resourceTableAllocator;
 

--- a/code/render/coregraphics/vk/vkshaderserver.cc
+++ b/code/render/coregraphics/vk/vkshaderserver.cc
@@ -79,7 +79,7 @@ VkShaderServer::UpdateResources()
     VkDevice dev = GetCurrentDevice();
 
     // Setup new views for newly streamed LODs
-    Util::Array<_PendingView> pendingViewsThisFrame(32, 32);
+    Util::Array<_PendingView, 32> pendingViewsThisFrame;
     this->pendingViews.DequeueAll(pendingViewsThisFrame);
 
     // Delete views which have been discarded due to LOD streaming

--- a/code/render/coregraphics/vk/vksubcontexthandler.h
+++ b/code/render/coregraphics/vk/vksubcontexthandler.h
@@ -56,12 +56,12 @@ public:
         const char* name = nullptr;
 #endif
         CoreGraphics::QueueType queue;
-        Util::Array<uint64> signalIndices;
-        Util::Array<VkSemaphore> signalSemaphores;
-        Util::Array<VkCommandBuffer> buffers;
-        Util::Array<VkPipelineStageFlags> waitFlags;
-        Util::Array<VkSemaphore> waitSemaphores;
-        Util::Array<uint64> waitIndices;
+        Util::Array<uint64, 16> signalIndices;
+        Util::Array<VkSemaphore, 16> signalSemaphores;
+        Util::Array<VkCommandBuffer, 16> buffers;
+        Util::Array<VkPipelineStageFlags, 16> waitFlags;
+        Util::Array<VkSemaphore, 16> waitSemaphores;
+        Util::Array<uint64, 16> waitIndices;
     };
 
     struct SubmissionList
@@ -73,16 +73,16 @@ public:
     struct SparseBindSubmission
     {
         VkBindSparseInfo bindInfo;
-        Util::Array<uint64> signalIndices;
-        Util::Array<VkSemaphore> signalSemaphores;
+        Util::Array<uint64, 16> signalIndices;
+        Util::Array<VkSemaphore, 16> signalSemaphores;
         Util::FixedArray<VkSparseMemoryBind> opaqueMemoryBinds;
         Util::FixedArray<VkSparseImageMemoryBind> imageMemoryBinds;
         Util::FixedArray<VkSparseMemoryBind> bufferMemoryBinds;
-        Util::Array<VkSparseBufferMemoryBindInfo> bufferMemoryBindInfos;
-        Util::Array<VkSparseImageOpaqueMemoryBindInfo> imageOpaqueBindInfos;
-        Util::Array<VkSparseImageMemoryBindInfo> imageMemoryBindInfos;
-        Util::Array<VkSemaphore> waitSemaphores;
-        Util::Array<uint64> waitIndices;
+        Util::Array<VkSparseBufferMemoryBindInfo, 16> bufferMemoryBindInfos;
+        Util::Array<VkSparseImageOpaqueMemoryBindInfo, 16> imageOpaqueBindInfos;
+        Util::Array<VkSparseImageMemoryBindInfo, 16> imageMemoryBindInfos;
+        Util::Array<VkSemaphore, 16> waitSemaphores;
+        Util::Array<uint64, 16> waitIndices;
     };
 
     /// setup subcontext handler
@@ -96,7 +96,7 @@ public:
     uint64 AppendSubmissionTimeline(
         CoreGraphics::QueueType type
         , VkCommandBuffer cmds
-        , Util::Array<CoreGraphics::SubmissionWaitEvent> waitEvents
+        , Util::Array<CoreGraphics::SubmissionWaitEvent, 8> waitEvents
 #if NEBULA_GRAPHICS_DEBUG
         , const char* name = nullptr
 #endif
@@ -105,8 +105,8 @@ public:
     /// append submissions to context to execute later, supports waiting for a queue
     uint64 AppendSubmissionTimeline(
         CoreGraphics::QueueType type
-        , Util::Array<VkCommandBuffer> cmds
-        , Util::Array<CoreGraphics::SubmissionWaitEvent> waitEvents
+        , Util::Array<VkCommandBuffer, 16> cmds
+        , Util::Array<CoreGraphics::SubmissionWaitEvent, 8> waitEvents
 #if NEBULA_GRAPHICS_DEBUG
         , const char* name = nullptr
 #endif
@@ -149,7 +149,7 @@ private:
     Util::FixedArray<uint> currentQueue;
     Util::FixedArray<Util::Array<VkSemaphore>> semaphores;
     Util::FixedArray<Util::Array<uint64>> semaphoreSubmissionIds;
-    Util::FixedArray<Util::Array<TimelineSubmission2>> submissions;
+    Util::FixedArray<Util::Array<TimelineSubmission2, 16>> submissions;
     Util::Array<SparseBindSubmission> sparseBindSubmissions;
     Threading::CriticalSection submissionLock;
 };

--- a/code/render/materials/material.cc
+++ b/code/render/materials/material.cc
@@ -415,7 +415,7 @@ MaterialInstanceApply(const MaterialInstanceId id, const CoreGraphics::CmdBuffer
 
         // Set instance table
         CoreGraphics::ConstantBufferOffset offset = materialInstanceAllocator.Get<MaterialInstance_Offsets>(id.instance);
-        CoreGraphics::CmdSetResourceTable(buf, table, NEBULA_INSTANCE_GROUP, CoreGraphics::GraphicsPipeline, { offset });
+        CoreGraphics::CmdSetResourceTable(buf, table, NEBULA_INSTANCE_GROUP, CoreGraphics::GraphicsPipeline, 1, &offset);
     }
 }
 

--- a/code/render/terrain/terraincontext.cc
+++ b/code/render/terrain/terraincontext.cc
@@ -191,12 +191,12 @@ struct
     Util::Array<TerrainTileWrite::TileWrite>                                 tileWrites;
     Util::Array<TerrainTileWrite::TileWrite>                                 tileWritesThisFrame;
 
-    Util::Array<CoreGraphics::BufferCopy>                           indirectionBufferUpdatesThisFrame;
-    Util::Array<CoreGraphics::TextureCopy>                          indirectionTextureUpdatesThisFrame;
-    Util::Array<CoreGraphics::TextureCopy>                          indirectionTextureFromCopiesThisFrame;
-    Util::Array<CoreGraphics::TextureCopy>                          indirectionTextureToCopiesThisFrame;
-    Util::Array<CoreGraphics::BufferCopy>                           indirectionBufferClearsThisFrame;
-    Util::Array<CoreGraphics::TextureCopy>                          indirectionTextureClearsThisFrame;
+    Util::Array<CoreGraphics::BufferCopy, 4>                        indirectionBufferUpdatesThisFrame;
+    Util::Array<CoreGraphics::TextureCopy, 4>                       indirectionTextureUpdatesThisFrame;
+    Util::Array<CoreGraphics::TextureCopy, 4>                       indirectionTextureFromCopiesThisFrame;
+    Util::Array<CoreGraphics::TextureCopy, 4>                       indirectionTextureToCopiesThisFrame;
+    Util::Array<CoreGraphics::BufferCopy, 4>                        indirectionBufferClearsThisFrame;
+    Util::Array<CoreGraphics::TextureCopy, 4>                       indirectionTextureClearsThisFrame;
     uint numPixels;
 
 } terrainVirtualTileState;
@@ -1186,8 +1186,7 @@ TerrainContext::SetupTerrain(
     using namespace CoreGraphics;
     const Graphics::ContextEntityId cid = GetContextId(entity);
     TerrainRuntimeInfo& runtimeInfo = terrainAllocator.Get<Terrain_RuntimeInfo>(cid.id);
-    runtimeInfo.enableRayTracing = false;
-    //CoreGraphics::RayTracingSupported& enableRayTracing;
+    runtimeInfo.enableRayTracing = CoreGraphics::RayTracingSupported && enableRayTracing;
 
     runtimeInfo.worldWidth = terrainState.settings.worldSizeX;
     runtimeInfo.worldHeight = terrainState.settings.worldSizeZ;

--- a/code/render/visibility/systems/bruteforcesystem.cc
+++ b/code/render/visibility/systems/bruteforcesystem.cc
@@ -22,7 +22,7 @@ BruteforceSystem::Setup(const BruteforceSystemLoadInfo& info)
 /**
 */
 void
-BruteforceSystem::Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters)
+BruteforceSystem::Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*, true>& extraCounters)
 {
     IndexT i;
     for (i = 0; i < this->obs.count; i++)
@@ -33,7 +33,7 @@ BruteforceSystem::Run(const Threading::AtomicCounter* previousSystemCompletionCo
         this->obs.completionCounters[i] = 1;
 
         // Setup counters
-        Util::FixedArray<const Threading::AtomicCounter*> counters(extraCounters.Size() + (previousSystemCompletionCounters == nullptr ? 0 : 1));
+        Util::FixedArray<const Threading::AtomicCounter*, true> counters(extraCounters.Size() + (previousSystemCompletionCounters == nullptr ? 0 : 1));
         if (!extraCounters.IsEmpty())
             Memory::CopyElements(extraCounters.Begin(), counters.Begin(), extraCounters.Size());
         if (previousSystemCompletionCounters != nullptr)

--- a/code/render/visibility/systems/bruteforcesystem.h
+++ b/code/render/visibility/systems/bruteforcesystem.h
@@ -21,7 +21,7 @@ private:
     void Setup(const BruteforceSystemLoadInfo& info);
 
     /// run system
-    void Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters) override;
+    void Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*, true>& extraCounters) override;
 };
 
 } // namespace Visibility

--- a/code/render/visibility/systems/visibilitysystem.cc
+++ b/code/render/visibility/systems/visibilitysystem.cc
@@ -46,7 +46,7 @@ VisibilitySystem::PrepareEntities(const Math::bbox* boxes, const uint32* ids, co
 /**
 */
 void
-VisibilitySystem::Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters)
+VisibilitySystem::Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*, true>& extraCounters)
 {
     // do nothing
 }

--- a/code/render/visibility/systems/visibilitysystem.h
+++ b/code/render/visibility/systems/visibilitysystem.h
@@ -92,7 +92,7 @@ public:
     /// prepare system with entities to insert into the structure
     virtual void PrepareEntities(const Math::bbox* transforms, const uint32* ranges, const Graphics::GraphicsEntityId* entities, const uint32_t* entityFlags, const SizeT count);
     /// run system
-    virtual void Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*>& extraCounters);
+    virtual void Run(const Threading::AtomicCounter* previousSystemCompletionCounters, const Util::FixedArray<const Threading::AtomicCounter*, true>& extraCounters);
 
     /// Return completion counter for an observer
     const Threading::AtomicCounter GetCompletionCounter(IndexT i) const;

--- a/code/render/visibility/visibilitycontext.h
+++ b/code/render/visibility/visibilitycontext.h
@@ -125,8 +125,8 @@ public:
     {
         uint32 packetOffset;
         uint32 numDrawPackets;
-        Util::Array<VisibilityModelCommand> models;
-        Util::Array<VisibilityDrawCommand> draws;
+        Util::Array<VisibilityModelCommand, 256> models;
+        Util::Array<VisibilityDrawCommand, 1024> draws;
     };
 
     struct VisibilityDrawList

--- a/code/resource/resources/resourceloader.cc
+++ b/code/resource/resources/resourceloader.cc
@@ -185,7 +185,7 @@ ResourceLoader::Update(IndexT frameIndex)
     this->UpdateLoaderSyncState();
 
     // Iterate through async outputs and update loader state
-    Util::Array<ResourceLoadOutput> asyncOutputs(128, 8);
+    Util::Array<ResourceLoadOutput, 128> asyncOutputs;
     this->loadOutputs.DequeueAll(asyncOutputs);
     for (auto output : asyncOutputs)
     {
@@ -193,7 +193,7 @@ ResourceLoader::Update(IndexT frameIndex)
     }
 
     // Make a copy since ImmediateJob might add jobs to the dependentJobs list
-    Util::Array<ResourceLoadJob> dependencyJobs = this->dependentJobs;
+    Util::FixedArray<ResourceLoadJob, true> dependencyJobs = this->dependentJobs;
     this->dependentJobs.Clear();
     for (const auto& job : dependencyJobs)
     {
@@ -244,9 +244,9 @@ ResourceLoader::Update(IndexT frameIndex)
     this->pendingLoads.Clear();
 
     // go through pending lod streams
-    Util::Array<_PendingStreamLod> pendingStreams(128, 8);
+    Util::Array<_PendingStreamLod, 128> pendingStreams;
     this->pendingStreamQueue.DequeueAll(pendingStreams);
-    this->pendingStreamLods.AppendArray(pendingStreams);
+    this->pendingStreamLods.AppendArray(pendingStreams.Begin(), pendingStreams.Size()); 
     for (IndexT i = this->pendingStreamLods.Size() - 1; i >= 0; i--)
     {
         const _PendingStreamLod& streamLod = this->pendingStreamLods[i];

--- a/fips-files/generators/framescriptc.py
+++ b/fips-files/generators/framescriptc.py
@@ -261,8 +261,8 @@ class SubgraphDefinition:
         file.WriteLine("")
         if len(self.disabledBindings) > 0:
             file.WriteLine("bool SubgraphEnabled_{};".format(self.name))
-        file.WriteLine('Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>> SubgraphTextureDependencies_{};'.format(self.name))
-        file.WriteLine('Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>> SubgraphBufferDependencies_{};'.format(self.name))
+        file.WriteLine('Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8> SubgraphTextureDependencies_{};'.format(self.name))
+        file.WriteLine('Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>, 8> SubgraphBufferDependencies_{};'.format(self.name))
         file.WriteLine("void (*Subgraph_{})(const CoreGraphics::CmdBufferId, const Math::rectangle<int>& viewport, const IndexT, const IndexT);\n".format(self.name))
         file.WriteLine("void (*SubgraphPipelines_{})(const CoreGraphics::PassId, const uint);\n".format(self.name))
 
@@ -270,7 +270,7 @@ class SubgraphDefinition:
         file.WriteLine("/**")
         file.WriteLine("*/")
         file.WriteLine('void')
-        file.WriteLine('RegisterSubgraph_{}(void(*func)(const CoreGraphics::CmdBufferId, const Math::rectangle<int>& viewport, const IndexT, const IndexT), Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>> bufferDeps, Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>> textureDeps)'.format(self.name))
+        file.WriteLine('RegisterSubgraph_{}(void(*func)(const CoreGraphics::CmdBufferId, const Math::rectangle<int>& viewport, const IndexT, const IndexT), Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>, 8> bufferDeps, Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8> textureDeps)'.format(self.name))
         file.WriteLine("{")
         file.IncreaseIndent()
         file.WriteLine("Subgraph_{} = func;".format(self.name))
@@ -306,7 +306,7 @@ class SubgraphDefinition:
     def FormatHeader(self, file):
         if self.p is not None and self.subp is not None:
             file.WriteLine('void RegisterSubgraphPipelines_{}(void(*func)(const CoreGraphics::PassId, const uint));'.format(self.name))
-        file.WriteLine('void RegisterSubgraph_{}(void(*func)(const CoreGraphics::CmdBufferId, const Math::rectangle<int>& viewport, const IndexT, const IndexT), Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>> bufferDeps = nullptr, Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>> textureDeps = nullptr);'.format(self.name))
+        file.WriteLine('void RegisterSubgraph_{}(void(*func)(const CoreGraphics::CmdBufferId, const Math::rectangle<int>& viewport, const IndexT, const IndexT), Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>, 8> bufferDeps = nullptr, Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8> textureDeps = nullptr);'.format(self.name))
     
     def FormatSource(self, file):
         file.WriteLine("")
@@ -513,7 +513,7 @@ class BlitDefinition:
         file.WriteLine("*/")
         
         if len(self.resourceDependencies) > 0:
-            file.WriteLine("Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>> Blit_{}_TextureDependencies;".format(self.name))
+            file.WriteLine("Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8> Blit_{}_TextureDependencies;".format(self.name))
 
         file.WriteLine("void")
         file.WriteLine("Initialize_Blit_{}()".format(self.name))
@@ -816,7 +816,7 @@ class PassDefinition:
 
         
         if len(self.resourceDependencies) > 0:
-            file.WriteLine("Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>> Pass_{}_TextureDependencies;".format(self.name))
+            file.WriteLine("Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8> Pass_{}_TextureDependencies;".format(self.name))
 
         file.WriteLine("//------------------------------------------------------------------------------")
         file.WriteLine("/**")
@@ -1055,7 +1055,7 @@ class SubmissionDefinition:
             op.FormatSource(file)
 
         if len(imports) > 0:
-            file.WriteLine("static Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>> EndOfFrameSyncs;")
+            file.WriteLine("static Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8> EndOfFrameSyncs;")
             file.WriteLine("EndOfFrameSyncs.Clear();")
             for imp in imports:
                 file.WriteLine("EndOfFrameSyncs.Append({{ TextureIndex::{}, TextureOriginalStage[(uint)TextureIndex::{}] }});".format(imp.name, imp.name))
@@ -1209,7 +1209,7 @@ class FrameScriptGenerator:
         file.WriteLine("Num")
         file.DecreaseIndent()
         file.WriteLine("};")        
-        file.WriteLine("void Synchronize(const char* name, const CoreGraphics::CmdBufferId buf, const Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>>& textureDeps, const Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>>& bufferDeps);")
+        file.WriteLine("void Synchronize(const char* name, const CoreGraphics::CmdBufferId buf, const Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8>& textureDeps, const Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>, 8>& bufferDeps);")
 
     
         for importBuffer in self.importBuffers:
@@ -1310,7 +1310,7 @@ class FrameScriptGenerator:
         file.WriteLine("/**")
         file.WriteLine("*/")
         file.WriteLine("inline void")
-        file.WriteLine("Synchronize(const char* name, const CoreGraphics::CmdBufferId buf, const Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>>& textureDeps, const Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>>& bufferDeps)")
+        file.WriteLine("Synchronize(const char* name, const CoreGraphics::CmdBufferId buf, const Util::Array<Util::Pair<TextureIndex, CoreGraphics::PipelineStage>, 8>& textureDeps, const Util::Array<Util::Pair<BufferIndex, CoreGraphics::PipelineStage>, 8>& bufferDeps)")
         file.WriteLine("{")
         file.IncreaseIndent()
         file.WriteLine("static CoreGraphics::BarrierScope scope; scope.Init(name, buf);")


### PR DESCRIPTION
For FixedArray there is now a template argument for putting it on the stack. It's off by default for compatibility reasons. Arrays that were temporary have now been assigned a suitable stack size to avoid spilling over and allocating from the heap.