### PR TITLE
fix graphics device creation not using verified extension set

### DIFF
--- a/code/render/coregraphics/vk/vkgraphicsdevice.cc
+++ b/code/render/coregraphics/vk/vkgraphicsdevice.cc
@@ -1079,10 +1079,10 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
         .taskShader = true,
         .meshShader = true,
         .multiviewMeshShader = false,
-        .primitiveFragmentShadingRateMeshShader = info.features.enableVariableRateShading,
+        .primitiveFragmentShadingRateMeshShader = CoreGraphics::VariableRateShadingSupported,
         .meshShaderQueries = false,
     };
-    if (info.features.enableMeshShaders)
+    if (CoreGraphics::MeshShadersSupported)
     {
         lastExtension = &meshShadersFeatures;
     }
@@ -1097,7 +1097,7 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
         .primitiveFragmentShadingRate = true,
         .attachmentFragmentShadingRate = true,
     };
-    if (info.features.enableVariableRateShading)
+    if (CoreGraphics::VariableRateShadingSupported)
     {
         lastExtension = &variableShadingFeatures;
     }
@@ -1126,7 +1126,7 @@ CreateGraphicsDevice(const GraphicsDeviceCreateInfo& info)
         .rayTraversalPrimitiveCulling = false
     };
 
-    if (info.features.enableRayTracing)
+    if (CoreGraphics::RayTracingSupported)
     {
         lastExtension = &raytracingFeatures;
     }


### PR DESCRIPTION
Updated the checks in the device creation to use the verified values instead of the requested ones. So it should now properly disable features if requested but not supported by the graphics card.