### PR TITLE
fix and refactor constant/storage buffer asserts and add some more setup descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,21 @@ Check out the documentation (WIP) here: https://gscept.github.io/nebula-doc/
         3. Added to PATH
         4. Installed with debugging symbols and binaries
 
+#### Other useful references and tools
+* [Vulkan SDK](https://vulkan.lunarg.com/) and [Vulkan Documentation](https://docs.vulkan.org/) for render pipeline debugging
+* [What is Fips](https://floooh.github.io/fips/)
+
 ## Quick Start
 
 The fastest way to setup and test nebula is to clone the [Nebula-demo](https://github.com/gscept/nebula-demo) instead. It contains a setup.bat which will setup dependencies and configure a 
-solution for you to run. If you add a `-editor` commandline argument it will start with the editor ui enabled. 
+solution for you to run via `fips open`. 
+Alternatively you can build and run the project manually with `fips build`, `fips run assetbatcher` and `fips run nebula-demo --`. If you add a `-editor` commandline argument it will start with the editor ui enabled. 
 Apart from that there are a few simple projects in the test folder. 
 Fips will take care of getting the relevant dependencies (including the actual engine in case you are setting up a external project)
 
 ## Normal setup
 If you want to proceed with the normal setup you can follow the instructions below. 
+Proceed to the project iteration section afterwards. 
 
 #### Setup config
 
@@ -40,36 +46,38 @@ If you want to proceed with the normal setup you can follow the instructions bel
 Run `fips nebula` verb to set work and toolkit directory registry variables:
 
   * `fips nebula set work {PATH}` (If you are building an external project, this would be the current path)
-  * `fips nebula set toolkit {PATH}` (this is the path to where the nebula checkout resides, if an external project that would be ../nebula)
+  * `fips nebula set toolkit {PATH}` (this is the path to where the nebula checkout resides, if an external project that would be `../nebula`)
 
-#### Build project
+#### Build project dependencies
 
 In your project directory:
   
   1. `fips physx build vc17 debug` (if you are running VS 2022, use `vc16` or `vc15` for vs 2019/2017 instead)
   2. `fips anyfx setup`
-  3. `fips gen` to generate the required build system files, e.g. a visual studio solution
-  4. `fips build` to directly compile the project
-     or
-     `fips open` to open the generated solution in your selected environment
 
 ## Iterating on the project
-Once the project is setup and working there are some common operations that you may have to perform.
+Once the project is set up and working there are some common operations that you may have to perform.
+Most of the steps and operations are required to be completed at least once to be able to run the project.
 
-### Adding files
+### Adding files – `fips gen`
 If you are adding new files, either source or templates or other flatbuffer things that you add to cmake or a cmake subfolder will typically picked up by running `fips gen`. This will regenerate your solution via cmake, in case you are using visual studio it will normally 
 notice and prompt reloading. Generally calling `fips gen` is a safe operation you can do if dependencies change etc.
 
-### Updating dependencies
+#### Location of build files
+Fips will place the solution and makefiles and the like in the `../fips-build/{PROJECT-NAME}/{CONFIG}/` folder. Easiest is to just use `fips open` to start your editor
+
+### Updating dependencies – `fips update`
 The project you are working in is commonly synced with e.g. git or some other version control, if you have other fips dependencies that changed, you can do a `fips update` to perform a git pull on the depencies used.
 
-### Dealing with content
+### Compiling the project – `fips build`
+(Re-)Building the project is possible either via the generated solution (`fips open` to open it quickly) or manually with `fips build`.
+
+### Dealing with content – `fips run assetbatcher --`
 Content is usually batched using the `assetbatcher` contained in the nebula repository which is built by default by projects as well. Running it will incrementally convert or cook content in your `work` folder to an export folder in the project location. It has a number of options to force or only batch specific folders, as well as 
 the option to be run in parallel. Running it with `-help` will print some of the options available.
 
-### Location of build files
-Fips will place the solution and makefiles and the like in the ../fips-build/projectname/projectconfig/ folder. Easiest is to just use `fips open` to start your editor
-
+## Running the project
+To run the debug project without editor tools, use `fips run {PROJECT-NAME}` or run a debug session in your solution opened with `fips open`. Use `fips run {PROJECT-NAME} -- -editor` to run the project with editor ui enabled. 
 
 ## Features
 Nebula is being developed continuously, which means that features keep getting added all the time. Currently, we support this:


### PR DESCRIPTION
Reasoning behind the refactoring part of the shader class was to get both constant and storage buffer calculations in a similar shape. I also noticed some consistencies in the other buffers as well, which was the baseline for the idea to add some functions for code that appears the same every time.

So I basically prepared such a change but didn't add too many functions at once now since that would require some more thought.

Also the usage of `bindingLayout.binding` and `block->binding` seemed to be somewhat arbitrary. Since they "should" point to the same value it shouldn't be an issue in the long run but I have set them all to `block->binding` to make it clear that this is indeed the same value.